### PR TITLE
Fix profiling agent crash when RAG_CORPUS is not set

### DIFF
--- a/MaxKernel/hitl_agent/subagents/profiling/agent.py
+++ b/MaxKernel/hitl_agent/subagents/profiling/agent.py
@@ -82,8 +82,8 @@ summarize_profile_agent = CustomLlmAgent(
     offline_tools.get_hlo_dump,
     offline_tools.create_chart_from_xplane,
     offline_tools.get_overview_page_metrics,
-    vertex_ai_rag_tool,
-  ],
+  ]
+  + ([vertex_ai_rag_tool] if vertex_ai_rag_tool else []),
 )
 
 # Main profiling orchestrator agent


### PR DESCRIPTION
## Summary
- `vertex_ai_rag_tool` is `None` when `RAG_CORPUS` env var is not set, causing a pydantic `ValidationError` when initializing `summarize_profile_agent`
- Conditionally include `vertex_ai_rag_tool` in the tools list, consistent with other subagents (explanation, kernel_writing, testing)

## Test plan
- [ ] Run `adk run` without `RAG_CORPUS` set and verify no crash
- [ ] Run `adk run` with `RAG_CORPUS` set and verify RAG tool is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)