### PR TITLE
refactor: standardize kernel and plan file paths by enforcing fixed workdir locations and updating tool callbacks

### DIFF
--- a/MaxKernel/auto_agent/callbacks.py
+++ b/MaxKernel/auto_agent/callbacks.py
@@ -98,6 +98,29 @@ def save_kernel_and_plan_paths(
   return None
 
 
+def save_base_kernel_and_plan_paths(
+  tool: BaseTool,
+  args: Dict[str, Any],
+  tool_context: ToolContext,
+  tool_response: Optional[Dict],
+) -> Optional[Dict]:
+  """Saves both base_kernel_path and kernel_plan_path during planning."""
+  if "read" in tool.name.lower() or "write" in tool.name.lower():
+    file_path = args.get("path", None)
+    if file_path:
+      if "plan" in file_path.lower() and file_path.endswith(".md"):
+        tool_context.state["kernel_plan_path"] = file_path
+        logging.info(
+          f"Saved plan path to kernel_plan_path: {file_path} (from tool: {tool.name})"
+        )
+      else:
+        tool_context.state["base_kernel_path"] = file_path
+        logging.info(
+          f"Saved base kernel path to base_kernel_path: {file_path} (from tool: {tool.name})"
+        )
+  return None
+
+
 def load_single_kernel_to_state(callback_context: CallbackContext):
   """
   Loads a single kernel file content into state.

--- a/MaxKernel/auto_agent/subagents/kernel_writing/agent.py
+++ b/MaxKernel/auto_agent/subagents/kernel_writing/agent.py
@@ -16,6 +16,7 @@ from auto_agent.callbacks import (
   get_tpu_version_callback,
   load_kernel_and_plan_to_state,
   load_single_kernel_to_state,
+  save_base_kernel_and_plan_paths,
   save_kernel_and_plan_paths,
 )
 from auto_agent.config import model_config, thinking_planner
@@ -282,7 +283,7 @@ plan_kernel_agent = CustomLlmAgent(
     get_tpu_version_callback,
     add_workdir_callback,
   ],
-  after_tool_callback=create_path_saver("kernel_plan_path"),
+  after_tool_callback=save_base_kernel_and_plan_paths,
 )
 
 

--- a/MaxKernel/auto_agent/subagents/kernel_writing/prompts/kernel_implementation_prompt.py
+++ b/MaxKernel/auto_agent/subagents/kernel_writing/prompts/kernel_implementation_prompt.py
@@ -19,7 +19,7 @@ Once you have the plan path, use the `filesystem_tool` to read this plan file. I
 
 ### Source Kernel
 The source kernel to be optimized is located at:
-**{active_kernel_filepath?}**
+**{base_kernel_path?}**
 
 If this is not available, check the plan file for the source kernel path, or ask the user.
 
@@ -126,13 +126,9 @@ You have three tools to help you:
 
 ### Output Requirement
 When you have implemented the optimized kernel:
-1.  You **must** use the `filesystem_tool` to write the *entire* optimized script to a file. 
-    - **CRITICAL**: Determine the output path using the following priority:
-      - **First priority**: If the user specified a file path (check `{active_kernel_filepath?}`), create the output file in the **same directory** with a modified name (e.g., append `_optimized` to the filename)
-        - Extract the directory path from the user's file and preserve it for the output
-        - Example: User file is "foo/bar/baz/kernel.py" → Write to "foo/bar/baz/kernel_optimized.py"
-      - **Second priority**: If the user's prompt includes a plan path (e.g., "use plan path/to/plan.md to implement..."), write the kernel to the **same directory** as the plan file (e.g., "path/to/kernel_optimized.py")
-      - **Third priority**: If no specific path was provided, write to the workdir root (e.g., "kernel_optimized.py")
+1.  You **must** use the `write_file` tool to write the *entire* optimized script to a file.
+    - **CRITICAL**: You must always write the output to exactly `{workdir}/optimized_kernel.py`.
+    - Example: `write_file(path="{workdir}/optimized_kernel.py", content=...)`
 2.  Summarize changes made and key optimizations applied, including the path where the optimized kernel was written.
 
 **IMPORTANT:** Once you have written the optimized kernel file, your task is COMPLETE. Provide a summary of the implementation and simply end your response.

--- a/MaxKernel/auto_agent/subagents/kernel_writing/prompts/kernel_planning_prompt.py
+++ b/MaxKernel/auto_agent/subagents/kernel_writing/prompts/kernel_planning_prompt.py
@@ -23,12 +23,11 @@ Identify whether you are creating a **NEW plan** or performing a **REVISION**.
 ### Step 2: Gather Context (Conditional)
 
 **For NEW Plans:**
-1.  **Find the source file:**
-    *   If code is pasted in the message, use `filesystem_tool` to save it to a temporary file (e.g., `temp_kernel_v1.py`). This becomes your source file.
-    *   If a filename is provided, that is your source file.
-    *   If neither, use the active file from session state: `{active_kernel_filepath?}`.
-    *   *Fallback:* If you cannot find a source filename or code from any of these methods, you must ask the user for a filename or for the code.
-2.  **Read content:** Use `filesystem_tool` to read the content of the identified source file.
+1.  **Create the base kernel file:**
+    *   **CRITICAL**: You MUST always save the reference source code into a file named `base_kernel.py` in the `{workdir}`.
+    *   If the source code is pasted in the message, use the `write_file` tool to save it as `base_kernel.py`.
+    *   If a source file name is provided, use the `read_file` tool to read its content, and then use `write_file` to save it as `base_kernel.py`.
+    *   *Fallback:* If you cannot find source code or a source filename from any of these methods, you must ask the user for a filename or for the code.
 *Note: All files are assumed to be in `{workdir}`.*
 
 **For REVISIONS:**
@@ -107,17 +106,15 @@ You have three tools to help you:
 ### Output Requirement
 
 **For NEW plans:**
-1.  You **must** use the `filesystem_tool` to write the plan as a markdown file.
-    - **CRITICAL**: Save the plan in the **same directory** as the source kernel file
-    - Extract the directory path from the source kernel filename
-    - Name the plan file based on the kernel name with `_plan.md` suffix
-    - Example: If source kernel is "foo/bar/kernel.py" → Save plan to "foo/bar/kernel_plan.md"
-    - If source is at workdir root, save plan at root too
+1.  You **must** use the `write_file` tool (provided by the filesystem toolset) to write the plan as a markdown file.
+    - **CRITICAL**: Save the plan in the `{workdir}`.
+    - Name the plan file `base_kernel_plan.md`.
+    - Example: `write_file(path="{workdir}/base_kernel_plan.md", content=...)`
 2.  After successfully writing the file, simply signal completion.
 3.  **DO NOT** wait for user response. Proceed automatically.
 
 **For REVISIONS:**
-1.  You **must** use the `filesystem_tool` to **overwrite** the existing plan file at `{kernel_plan_path?}` with your revised version.
+1.  You **must** use the `write_file` tool (provided by the filesystem toolset) to **overwrite** the existing plan file at `{kernel_plan_path?}` with your revised version.
 2.  After successfully overwriting the file, simply signal completion.
 3.  **DO NOT** wait for user response. Proceed automatically.
 


### PR DESCRIPTION
1. add save_base_kernel_and_plan_paths so that the plan_kernel_agent will save the base kernel file and keep its path as state
2. for the python code to be base_kernel.py and optimized_kernel.py