### PR TITLE
refactor: update add_workdir_callback to create session-specific directory

### DIFF
--- a/MaxKernel/hitl_agent/callbacks.py
+++ b/MaxKernel/hitl_agent/callbacks.py
@@ -268,8 +268,11 @@ def get_tpu_version_callback(callback_context: CallbackContext):
 
 def add_workdir_callback(callback_context: CallbackContext):
   """Add working directory to state."""
-  callback_context.state["workdir"] = WORKDIR
-  logging.info(f"Set working directory to: {WORKDIR}")
+  session_id = callback_context.session.id
+  session_dir = os.path.join(WORKDIR, session_id)
+  os.makedirs(session_dir, exist_ok=True)
+  callback_context.state["workdir"] = session_dir
+  logging.info(f"Set working directory to: {session_dir}")
 
 
 def extract_fix_summary(


### PR DESCRIPTION
Each session will create a subfolder under the work directory so that work directory from different sessions will not overlap. It is better for debugging as well.