### PR TITLE
Add JAXBench: TPU kernel benchmark suite

### DIFF
--- a/JAXBench/README.md
+++ b/JAXBench/README.md
@@ -1,0 +1,185 @@
+# JAXBench
+
+**JAXBench** is a benchmark suite of 50 curated JAX/TPU kernel workloads with a
+production-ready evaluation harness. It is designed for benchmarking and
+evaluating AI-generated TPU kernel optimizations.
+
+## Workloads
+
+The suite contains 50 workloads organized into two tiers:
+
+- **17 Priority Kernels** (`1p`–`17p`): Production operators from models like
+  Llama-3.1, DeepSeek-V3, Mixtral-8x7B, Mamba-2, RetNet, and AlphaFold2.
+  Includes attention variants, MoE, GEMM, normalization, and more. 8 of these
+  have hand-optimized Pallas TPU kernel variants.
+
+- **33 KernelBench Workloads** (`18k`–`50k`): Fused operator patterns from
+  [KernelBench](https://github.com/ScalingIntelligence/KernelBench) Level 2,
+  covering matmul+activation chains, convolutions with normalization, and
+  multi-op fusions.
+
+Each workload follows a consistent interface:
+
+```python
+CONFIG = {...}                              # Metadata (model, operator, dimensions)
+def create_inputs(dtype=jnp.bfloat16): ...  # Generate input tensors
+def workload(*inputs): ...                  # The computation to benchmark
+def get_flops(): ...                        # Optional: manual FLOP count
+```
+
+## Quick Start
+
+From the repository root (`accelerator-agents/`):
+
+```bash
+# List all workloads
+python -m JAXBench list
+
+# Run a single workload on TPU (baseline + optimized if present)
+python -m JAXBench run --workload 8p_GEMM --tpu v6e
+
+# Run all 50 workloads
+python -m JAXBench run --all --tpu v6e
+
+# Evaluate a candidate kernel against a workload
+python -m JAXBench evaluate --workload 1p_Flash_Attention --kernel path/to/my_kernel.py --json
+```
+
+### Requirements
+
+- Python 3.10+
+- JAX with TPU support (`jax[tpu]`)
+- A TPU VM (v5e or v6e)
+
+## Evaluation Harness
+
+The harness provides two primary interfaces:
+
+### 1. Agent Evaluation (`evaluate`)
+
+Evaluate a candidate kernel file against any workload. The kernel file only
+needs to export a `workload(*inputs)` function — inputs are generated from the
+baseline's `create_inputs()`.
+
+```bash
+python -m JAXBench evaluate \
+    --workload 1p_Flash_Attention \
+    --kernel path/to/my_kernel.py \
+    --tpu v6e \
+    --json
+```
+
+The evaluation pipeline:
+1. **Compile** — JIT-compiles the candidate kernel
+2. **Correctness** — Checks output against baseline (`np.allclose`, atol=1e-2, rtol=1e-2)
+3. **Benchmark** — Device-side profiling via `jax.profiler.trace()` (Perfetto traces)
+4. **Compare** — Reports speedup vs baseline XLA and Pallas reference (if present)
+
+Output (with `--json`):
+
+```json
+{
+  "workload": "8p_GEMM",
+  "status": "correct",
+  "correctness": {"correct": true, "max_diff": 0.0003, "reason": "ok"},
+  "baseline": {"median_ms": 5.32, "tflops": 723.1, "utilization_pct": 78.8},
+  "kernel": {"median_ms": 4.10, "tflops": 938.1, "utilization_pct": 90.2},
+  "pallas_reference": {"median_ms": 5.41, "tflops": 711.9, "utilization_pct": 77.6},
+  "speedup_vs_baseline": 1.30,
+  "speedup_vs_pallas": 1.32,
+  "tpu": "v6e"
+}
+```
+
+### 2. Benchmark Runner (`run`)
+
+Reproduce benchmark numbers for all workloads:
+
+```bash
+python -m JAXBench run --all --tpu v6e
+```
+
+This runs all 50 baselines and 8 optimized variants, producing
+`results.json` and `results.csv` with timing, TFLOPS, and MXU utilization.
+
+### Python API
+
+```python
+from JAXBench.harness import evaluate_kernel, run_workload, run_all
+
+# Evaluate a kernel
+result = evaluate_kernel("8p_GEMM", "path/to/kernel.py", tpu="v6e")
+
+# Run a single workload
+result = run_workload("8p_GEMM", variant="baseline", tpu="v6e")
+
+# Run all workloads
+results = run_all(tpu="v6e")
+```
+
+## Writing a Kernel for JAXBench
+
+To optimize a workload, create a Python file that exports a single function:
+
+```python
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+
+def workload(x, weight):
+    # Your optimized implementation here
+    # Receives the same inputs as the baseline's create_inputs()
+    return result
+```
+
+Then evaluate it:
+
+```bash
+python -m JAXBench evaluate --workload 8p_GEMM --kernel my_kernel.py --json
+```
+
+## Timing Methodology
+
+All benchmarks use **device-side timing** via `jax.profiler.trace()`:
+
+- Captures Perfetto JSON traces during benchmark iterations
+- Extracts `jit_*()` wrapper event durations (actual TPU kernel execution time)
+- Excludes host dispatch overhead, Python overhead, and data transfer
+- Falls back to wall-clock timing only for eager workloads (2 of 50)
+
+## TPU Support
+
+| TPU     | Peak TFLOPS (bf16) | HBM Bandwidth |
+|---------|-------------------|----------------|
+| v5e     | 197               | 819 GB/s       |
+| v6e     | 918               | 1,600 GB/s     |
+
+Use `--tpu auto` (default) to auto-detect from `jax.devices()`.
+
+## Directory Structure
+
+```
+JAXBench/
+├── __init__.py
+├── __main__.py              # CLI entry point
+├── README.md
+├── benchmark/               # 50 workloads
+│   ├── __init__.py          # Workload discovery
+│   ├── 1p_Flash_Attention/
+│   │   ├── baseline.py      # Reference JAX implementation
+│   │   └── optimized.py     # Hand-tuned Pallas kernel
+│   ├── 8p_GEMM/
+│   │   ├── baseline.py
+│   │   └── optimized.py
+│   ├── 19k_Matmul_.../
+│   │   └── baseline.py      # No optimized variant yet
+│   └── ...
+└── harness/
+    ├── __init__.py
+    ├── correctness.py       # Output comparison (atol=1e-2, rtol=1e-2)
+    ├── evaluator.py         # Agent evaluation pipeline
+    ├── loader.py            # Dynamic module loading
+    ├── profiler.py          # Device-side profiling (Perfetto)
+    ├── runner.py            # Benchmark runner
+    └── tpu_specs.py         # TPU hardware specs
+```

--- a/JAXBench/__init__.py
+++ b/JAXBench/__init__.py
@@ -1,0 +1,3 @@
+"""JAXBench: A TPU kernel benchmark suite for JAX."""
+
+__version__ = "0.1.0"

--- a/JAXBench/__main__.py
+++ b/JAXBench/__main__.py
@@ -1,0 +1,153 @@
+"""CLI entry point: python -m JAXBench <command> [options]
+
+Commands:
+    evaluate    Evaluate a candidate kernel against a workload
+    run         Run benchmark workloads
+    list        List available workloads
+"""
+
+import argparse
+import json
+import sys
+
+
+def cmd_evaluate(args):
+    """Evaluate a candidate kernel."""
+    from JAXBench.harness.evaluator import evaluate_kernel, format_eval_result
+
+    result = evaluate_kernel(
+        workload_name=args.workload,
+        kernel_path=args.kernel,
+        tpu=args.tpu,
+        num_warmup=args.num_warmup,
+        num_iters=args.num_iters,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(format_eval_result(result))
+
+    return 0 if result['status'] == 'correct' else 1
+
+
+def cmd_run(args):
+    """Run benchmark workloads."""
+    from JAXBench.harness.runner import run_workload, run_all
+
+    if args.all:
+        output = run_all(
+            tpu=args.tpu,
+            num_warmup=args.num_warmup,
+            num_iters=args.num_iters,
+        )
+        if args.json:
+            print(json.dumps(output, indent=2))
+        return 0
+
+    if args.workload:
+        results = []
+        for variant in ['baseline', 'optimized']:
+            r = run_workload(
+                name=args.workload,
+                variant=variant,
+                tpu=args.tpu,
+                num_warmup=args.num_warmup,
+                num_iters=args.num_iters,
+            )
+            if r is not None:
+                results.append(r)
+
+        if args.json:
+            print(json.dumps(results, indent=2))
+        else:
+            for r in results:
+                if r['status'] == 'success':
+                    print(f"{r['name']} ({r['variant']}): "
+                          f"{r['median_ms']:.3f}ms, "
+                          f"{r['tflops']:.1f} TFLOPS, "
+                          f"{r['utilization_pct']:.1f}% util "
+                          f"[{r['timing_method']}]")
+                else:
+                    print(f"{r['name']} ({r['variant']}): ERROR - {r.get('error', '?')}")
+        return 0
+
+    print("Error: specify --workload NAME or --all", file=sys.stderr)
+    return 1
+
+
+def cmd_list(args):
+    """List available workloads."""
+    from JAXBench.benchmark import list_workloads, has_optimized
+
+    workloads = list_workloads()
+    if args.json:
+        items = [{'name': w, 'has_optimized': has_optimized(w)} for w in workloads]
+        print(json.dumps(items, indent=2))
+    else:
+        print(f"JAXBench: {len(workloads)} workloads\n")
+        for w in workloads:
+            opt = " [+ optimized]" if has_optimized(w) else ""
+            print(f"  {w}{opt}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='JAXBench',
+        description='JAXBench: TPU kernel benchmark suite',
+    )
+    sub = parser.add_subparsers(dest='command')
+
+    # evaluate
+    eval_p = sub.add_parser('evaluate', help='Evaluate a candidate kernel')
+    eval_p.add_argument('--workload', required=True,
+                        help='Workload name (e.g. 1p_Flash_Attention)')
+    eval_p.add_argument('--kernel', required=True,
+                        help='Path to kernel file with workload() function')
+    eval_p.add_argument('--tpu', choices=['v5e', 'v6e', 'auto'], default='auto',
+                        help='TPU target (default: auto-detect)')
+    eval_p.add_argument('--num-warmup', type=int, default=5,
+                        help='Warmup iterations (default: 5)')
+    eval_p.add_argument('--num-iters', type=int, default=50,
+                        help='Benchmark iterations (default: 50)')
+    eval_p.add_argument('--json', action='store_true',
+                        help='Output as JSON (for agent consumption)')
+
+    # run
+    run_p = sub.add_parser('run', help='Run benchmark workloads')
+    run_p.add_argument('--workload', default=None,
+                       help='Workload name (run single workload)')
+    run_p.add_argument('--all', action='store_true',
+                       help='Run all workloads')
+    run_p.add_argument('--tpu', choices=['v5e', 'v6e', 'auto'], default='auto',
+                       help='TPU target (default: auto-detect)')
+    run_p.add_argument('--num-warmup', type=int, default=5,
+                       help='Warmup iterations (default: 5)')
+    run_p.add_argument('--num-iters', type=int, default=50,
+                       help='Benchmark iterations (default: 50)')
+    run_p.add_argument('--json', action='store_true',
+                       help='Output as JSON')
+
+    # list
+    list_p = sub.add_parser('list', help='List available workloads')
+    list_p.add_argument('--json', action='store_true',
+                        help='Output as JSON')
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    handlers = {
+        'evaluate': cmd_evaluate,
+        'run': cmd_run,
+        'list': cmd_list,
+    }
+
+    return handlers[args.command](args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/JAXBench/benchmark/10p_Sparse_MoE/baseline.py
+++ b/JAXBench/benchmark/10p_Sparse_MoE/baseline.py
@@ -1,0 +1,92 @@
+"""Sparse Mixture of Experts (MoE) — Mixtral 8x7B. Extracted from MaxText."""
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+CONFIG = {
+    'name': 'mixtral_8x7b_moe',
+    'model': 'Mixtral-8x7B',
+    'operator': 'sparse_moe',
+    'batch': 2,
+    'seq_len': 4096,
+    'emb_dim': 4096,
+    'mlp_dim': 14336,
+    'num_experts': 8,
+    'num_experts_per_tok': 2,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (x, router_weights, expert_gate, expert_up, expert_down)."""
+    key = jax.random.key(42)
+    keys = jax.random.split(key, 5)
+    B, S, E, M = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim'], CONFIG['mlp_dim']
+    N = CONFIG['num_experts']
+    x = jax.random.normal(keys[0], (B, S, E), dtype=dtype)
+    router = jax.random.normal(keys[1], (E, N), dtype=dtype) * 0.02
+    gate_k = jax.random.normal(keys[2], (N, E, M), dtype=dtype) * 0.02
+    up_k = jax.random.normal(keys[3], (N, E, M), dtype=dtype) * 0.02
+    down_k = jax.random.normal(keys[4], (N, M, E), dtype=dtype) * 0.02
+    return x, router, gate_k, up_k, down_k
+
+
+def workload(x, router_weights, expert_gate_kernels, expert_up_kernels, expert_down_kernels):
+    """Sparse MoE with einsum-based batched expert computation."""
+    B, S, E = x.shape
+    N = router_weights.shape[-1]
+    K = CONFIG['num_experts_per_tok']
+    # Routing
+    logits = jnp.dot(x, router_weights)
+    top_k_logits, top_k_indices = jax.lax.top_k(logits, K)
+    router_probs = jax.nn.softmax(top_k_logits, axis=-1)
+    # All experts in parallel
+    gate_out = jax.nn.silu(jnp.einsum('bse,nem->bsnm', x, expert_gate_kernels))
+    up_out = jnp.einsum('bse,nem->bsnm', x, expert_up_kernels)
+    hidden = gate_out * up_out
+    expert_outputs = jnp.einsum('bsnm,nme->bsne', hidden, expert_down_kernels)
+    # Weighted combination
+    one_hot = jax.nn.one_hot(top_k_indices, N)
+    weighted = one_hot * router_probs[..., None]
+    expert_weights = weighted.sum(axis=2)
+    output = jnp.einsum('bsne,bsn->bse', expert_outputs, expert_weights)
+    return output
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, E, M = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim'], CONFIG['mlp_dim']
+    K, N = CONFIG['num_experts_per_tok'], CONFIG['num_experts']
+    routing_flops = B * S * E * N * 2
+    expert_flops = B * S * K * (E * M * 2 * 3)
+    flops = routing_flops + expert_flops
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/11p_Megablox_GMM/baseline.py
+++ b/JAXBench/benchmark/11p_Megablox_GMM/baseline.py
@@ -1,0 +1,114 @@
+"""Grouped Matrix Multiply (Megablox GMM) — Qwen3-235B-A22B MoE dimensions.
+
+Reference grouped matmul: for each expert group, slice the input tokens
+and multiply with that expert's weight matrix. Core primitive for MoE layers.
+From JAX experimental pallas ops (reference_gmm).
+
+Not jit-compatible: uses data-dependent slicing on group_sizes.
+"""
+
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'megablox_gmm_qwen3_235b',
+    'model': 'Qwen3-235B-A22B',
+    'operator': 'grouped_matmul',
+    'num_experts': 128,
+    'num_experts_per_tok': 8,
+    'emb_dim': 4096,
+    'moe_mlp_dim': 1536,
+    'seq_len': 4096,
+}
+
+_skip_jit = True
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    G = CONFIG['num_experts']
+    top_k = CONFIG['num_experts_per_tok']
+    K = CONFIG['emb_dim']
+    N = CONFIG['moe_mlp_dim']
+    S = CONFIG['seq_len']
+    M = S * top_k
+    limit = 1 / (M * K)
+    lhs = jax.random.uniform(k1, (M, K), dtype=dtype, minval=-limit, maxval=limit)
+    lhs = lhs.astype(jnp.bfloat16).astype(dtype)
+    rhs = jax.random.uniform(k2, (G, K, N), dtype=dtype, minval=-limit, maxval=limit)
+    rhs = rhs.astype(jnp.bfloat16).astype(dtype)
+    tokens_per_expert = M // G
+    group_sizes = jnp.full((G,), tokens_per_expert, dtype=jnp.int32)
+    return lhs, rhs, group_sizes
+
+
+def workload(lhs, rhs, group_sizes):
+    """Reference grouped matmul from upstream JAX tests.
+
+    For each group i, slices lhs[start:start+size] and computes dot with rhs[i].
+    Uses data-dependent slicing so must be run eagerly (not under jax.jit).
+    """
+    start = 0
+    out = []
+    for i, size in enumerate(group_sizes):
+        result = jax.lax.dot(
+            lhs[start:start + size, :],
+            rhs[i, :, :],
+            preferred_element_type=jnp.float32,
+        )
+        out.append(result)
+        start += group_sizes[i]
+    return jnp.concatenate(out, axis=0)
+
+
+def get_flops():
+    """Total FLOPs: each expert does (M/G) x K x N matmul."""
+    top_k = CONFIG['num_experts_per_tok']
+    K = CONFIG['emb_dim']
+    N = CONFIG['moe_mlp_dim']
+    S = CONFIG['seq_len']
+    M = S * top_k
+    return 2 * M * K * N
+
+
+def benchmark(num_warmup=2, num_iters=10):
+    """Benchmark eagerly (no JIT — data-dependent control flow)."""
+    import time
+    inputs = create_inputs()
+    # Warmup
+    for _ in range(num_warmup):
+        out = workload(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = workload(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    G = CONFIG['num_experts']
+    top_k = CONFIG['num_experts_per_tok']
+    K = CONFIG['emb_dim']
+    N = CONFIG['moe_mlp_dim']
+    S = CONFIG['seq_len']
+    M = S * top_k
+    flops = 2 * M * K * N
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 4),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/11p_Megablox_GMM/optimized.py
+++ b/JAXBench/benchmark/11p_Megablox_GMM/optimized.py
@@ -1,0 +1,879 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pallas grouped matrix multiplication kernel — Qwen3-235B-A22B MoE dimensions.
+
+Upstream kernel from jax.experimental.pallas.ops.tpu.megablox.gmm, wrapped as a
+JAXBench workload with CONFIG / create_inputs / workload.
+
+Metadata/utilities imported from the installed JAX package (not optimizable).
+"""
+
+from collections.abc import Callable
+import functools
+from typing import Any, Optional
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas.ops.tpu.megablox import common
+import jax.numpy as jnp
+
+
+partial = functools.partial
+
+
+def _validate_args(
+    *,
+    lhs: jnp.ndarray,
+    rhs: jnp.ndarray,
+    group_sizes: jnp.ndarray,
+    expected_rhs_dims: int = 3,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.dtype]:
+  """Validates the arguments for the gmm function."""
+  # Validate 'lhs'.
+  if lhs.ndim != 2:
+    raise ValueError(f"Expected 2-tensor for 'lhs' but got {lhs.ndim}-tensor.")
+  common.assert_is_supported_dtype(lhs.dtype)
+
+  # Validate 'rhs'.
+  if rhs.ndim != expected_rhs_dims:
+    raise ValueError(
+        f"Expected {expected_rhs_dims}-tensor for 'rhs' but got"
+        f" {rhs.ndim}-tensor."
+    )
+  common.assert_is_supported_dtype(rhs.dtype)
+
+  # Validate 'group_sizes'.
+  if group_sizes.dtype != jnp.int32:
+    raise ValueError(
+        f"Expected 32-bit integer 'group_sizes' but got {group_sizes.dtype}."
+    )
+
+  return lhs, group_sizes, common.select_input_dtype(lhs, rhs)
+
+
+def _calculate_num_tiles(x: int, tx: int) -> int:
+  tiles, rem = divmod(x, tx)
+  if rem:
+    raise ValueError(f"{x} must be divisible by x-dimension tile size ({tx}).")
+  return tiles
+
+
+def _calculate_irregular_num_tiles(x: int, tx: int) -> tuple[int, int]:
+  tiles, rem = divmod(x, tx)
+  if rem:
+    tiles += 1
+  return tiles, rem
+
+
+GroupMetadata = Any  # TODO(enriqueps): Clean this up and use a namedtuple
+
+
+def make_group_metadata(
+    *,
+    group_sizes: jnp.ndarray,
+    m: int,
+    tm: int,
+    start_group: jnp.ndarray,
+    num_nonzero_groups: int,
+    visit_empty_groups: bool = True,
+) -> GroupMetadata:
+  """Create the metadata needed for grouped matmul computation.
+
+  Args:
+    group_sizes: A 1d, jnp.ndarray with shape [num_groups] and jnp.int32 dtype.
+    m: The number of rows in lhs.
+    tm: The m-dimension tile size being used.
+    start_group: The group in group sizes to start computing from. This is
+      particularly useful for when rhs num_groups is sharded.
+    num_nonzero_groups: Number of groups in group sizes to compute on. Useful in
+      combination with group_offset.
+    visit_empty_groups: If True, do not squeeze tiles for empty groups out of
+      the metadata. This is necessary for tgmm, where we at least need to zero
+      the output for each group.
+
+  Returns:
+    tuple of:
+      group_offsets: A 1d, jnp.ndarray with shape [num_groups+1] and jnp.int32
+        dtype. group_offsets[i] indicates the row at which group [i] starts in
+        the lhs matrix and group_offsets[i-1] = m.
+      group_ids: A 1d, jnp.ndarray with shape [m_tiles + num_groups] and
+        jnp.int32 dtype. group_ids[i] indicates which group grid index 'i' will
+        work on.
+      m_tile_ids: A 1d, jnp.ndarray with shape [m_tiles + num_groups] and
+        jnp.int32. m_tile_ids[i] indicates which m-dimension tile grid index 'i'
+        will work on.
+    num_tiles: The number of m-dimension tiles to execute.
+  """
+  num_groups = group_sizes.shape[0]
+  end_group = start_group + num_nonzero_groups - 1
+
+  # Calculate the offset of each group, starting at zero. This metadata is
+  # similar to row offsets in a CSR matrix. The following properties hold:
+  #
+  # group_offsets.shape = [num_groups + 1]
+  # group_offsets[0] = 0
+  # group_offsets[num_groups] = m
+  #
+  # The row at which group 'i' starts is group_offsets[i].
+  group_ends = jnp.cumsum(group_sizes)
+  group_offsets = jnp.concatenate([jnp.zeros(1, dtype=jnp.int32), group_ends])
+
+  # Assign a group id to each grid index.
+  #
+  # If a group starts somewhere other than the start of a tile or ends somewhere
+  # other than the end of a tile we need to compute that full tile. Calculate
+  # the number of tiles for each group by rounding their end up to the nearest
+  # 'tm' and their start down to the nearest 'tm'.
+
+  # (1) Round the group_ends up to the nearest multiple of 'tm'.
+  #
+  # NOTE: This does not change group_offsets[num_groups], which is m
+  # (because we enforce m is divisible by tm).
+  rounded_group_ends = ((group_ends + tm - 1) // tm * tm).astype(jnp.int32)
+
+  # (2) Round the group_starts down to the nearest multiple of 'tm'.
+  group_starts = jnp.concatenate(
+      [jnp.zeros(1, dtype=jnp.int32), group_ends[:-1]]
+  )
+  rounded_group_starts = group_starts // tm * tm
+
+  # (3) Calculate the number of rows in each group.
+  #
+  # NOTE: Handle zero-sized groups as a special case. If the start for a
+  # zero-sized group is not divisible by 'tm' its start will be rounded down and
+  # its end will be rounded up such that its size will become 1 tile here.
+  rounded_group_sizes = rounded_group_ends - rounded_group_starts
+  rounded_group_sizes = jnp.where(group_sizes == 0, 0, rounded_group_sizes)
+
+  # (4) Convert the group sizes from units of rows to unit of 'tm' sized tiles.
+  #
+  # An m-dimension tile is 'owned' by group 'i' if the first row of the tile
+  # belongs to group 'i'. In addition to owned tiles, each group can have 0 or 1
+  # initial partial tiles if it's first row does not occur in the first row of a
+  # tile. The '0-th' group never has a partial tile because it always starts at
+  # the 0-th row.
+  #
+  # If no group has a partial tile, the total number of tiles is equal to
+  # 'm // tm'. If every group has a partial except the 0-th group, the total
+  # number of tiles is equal to 'm // tm + num_groups - 1'. Thus we know that
+  #
+  # tiles_m <= group_tiles.sum() <= tiles_m + num_groups - 1
+  #
+  # Where tiles_m = m // tm.
+  #
+  # NOTE: All group sizes are divisible by 'tm' because of the rounding in steps
+  # (1) and (2) so this division is exact.
+  group_tiles = rounded_group_sizes // tm
+
+  if visit_empty_groups:
+    # Insert one tile for empty groups.
+    group_tiles = jnp.where(group_sizes == 0, 1, group_tiles)
+
+  # Create the group ids for each grid index based on the tile counts for each
+  # group.
+  #
+  # NOTE: This repeat(...) will pad group_ids with the final group id if
+  # group_tiles.sum() < tiles_m + num_groups - 1. The kernel grid will be sized
+  # such that we only execute the necessary number of tiles.
+  tiles_m = _calculate_num_tiles(m, tm)
+  group_ids = jnp.repeat(
+      jnp.arange(num_groups, dtype=jnp.int32),
+      group_tiles,
+      total_repeat_length=tiles_m + num_groups - 1,
+  )
+
+  # Assign an m-dimension tile id to each grid index.
+  #
+  # NOTE: Output tiles can only be re-visited consecutively. The following
+  # procedure guarantees that m-dimension tile indices respect this.
+
+  # (1) Calculate how many times each m-dimension tile will be visited.
+  #
+  # Each tile is guaranteed to be visited once by the group that owns the tile.
+  # The remaining possible visits occur when a group starts inside of a tile at
+  # a position other than the first row. We can calculate which m-dimension tile
+  # each group starts in by floor-dividing its offset with `tm` and then count
+  # tile visits with a histogram.
+  #
+  # To avoid double counting tile visits from the group that owns the tile,
+  # filter these out by assigning their tile id to `tile_m` (one beyond the max)
+  # such that they're ignored by the subsequent histogram. Also filter out any
+  # group which is empty.
+  #
+  # TODO(tgale): Invert the 'partial_tile_mask' predicates to be more clear.
+  partial_tile_mask = jnp.logical_or(
+      (group_offsets[:-1] % tm) == 0, group_sizes == 0
+  )
+
+  # Explicitly enable tiles for zero sized groups, if specified. This covers
+  # zero sized groups that start on a tile-aligned row and those that do not.
+  if visit_empty_groups:
+    partial_tile_mask = jnp.where(group_sizes == 0, 0, partial_tile_mask)
+
+  partial_tile_ids = jnp.where(
+      partial_tile_mask, tiles_m, group_offsets[:-1] // tm
+  )
+
+  tile_visits = (
+      jnp.histogram(partial_tile_ids, bins=tiles_m, range=(0, tiles_m - 1))[0]
+      + 1
+  )
+
+  # Create the m-dimension tile ids for each grid index based on the visit
+  # counts for each tile.
+  m_tile_ids = jnp.repeat(
+      jnp.arange(tiles_m, dtype=jnp.int32),
+      tile_visits.astype(jnp.int32),
+      total_repeat_length=tiles_m + num_groups - 1,
+  )
+
+  # Account for sharding.
+  #
+  # Find the start of the groups owned by our shard and shift the group_ids and
+  # m_tile_ids s.t. the metadata for our tiles are at the front of the arrays.
+  #
+  # TODO(tgale): Move this offset into the kernel to avoid these rolls.
+  first_tile_in_shard = (group_ids < start_group).sum()
+  group_ids = jnp.roll(group_ids, shift=-first_tile_in_shard, axis=0)
+  m_tile_ids = jnp.roll(m_tile_ids, shift=-first_tile_in_shard, axis=0)
+
+  # Calculate the number of tiles we need to compute for our shard.
+  #
+  # Remove tile visits that belong to a group not in our shard.
+  iota = jnp.arange(num_groups, dtype=jnp.int32)
+  active_group_mask = jnp.logical_and(iota <= end_group, iota >= start_group)
+  group_tiles = jnp.where(active_group_mask, group_tiles, 0)
+  num_tiles = group_tiles.sum()
+  return (group_offsets, group_ids, m_tile_ids), num_tiles
+
+
+def _get_group_size(
+    *, grid_id: jnp.ndarray, group_metadata: GroupMetadata
+) -> jnp.ndarray:
+  """Calculate the number of rows in the current group."""
+  group_offsets, group_ids = group_metadata[:2]
+  group_id = group_ids[grid_id]
+  group_start = group_offsets[group_id]
+  group_end = group_offsets[group_id + 1]
+  return group_end - group_start
+
+
+def _get_store_mask(
+    *,
+    grid_id: jnp.ndarray,
+    group_metadata: GroupMetadata,
+    tm: int,
+    tn: int,
+) -> jnp.ndarray:
+  """Mask for rows that belong to the current group in the current tile."""
+  group_offsets, group_ids, m_tile_ids = group_metadata[:3]
+  group_id = group_ids[grid_id]
+  group_start = group_offsets[group_id]
+  group_end = group_offsets[group_id + 1]
+  m_id = m_tile_ids[grid_id] * tm
+  iota = jax.lax.broadcasted_iota(jnp.int32, (tm, tn), 0) + m_id
+  return jnp.logical_and(iota >= group_start, iota < group_end)
+
+
+def _zero_uninitialized_memory(
+    out: jnp.ndarray,
+    *,
+    start_group: jnp.ndarray,
+    num_nonzero_groups: int,
+    group_metadata: GroupMetadata,
+) -> jnp.ndarray:
+  """Zero out uninitialized memory from output."""
+  group_offsets = group_metadata[0]
+  group_start = group_offsets[start_group]
+  group_end = group_offsets[start_group + num_nonzero_groups]
+  valid_mask = jax.lax.broadcasted_iota(jnp.int32, (out.shape[0],), 0)
+  valid_mask = (valid_mask >= group_start) & (valid_mask < group_end)
+  return jnp.where(valid_mask[:, None], out, 0)
+
+
+LutFn = Callable[[int, int, int], Optional[tuple[int, int, int]]]
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "preferred_element_type",
+        "tiling",
+        "transpose_rhs",
+        "interpret",
+    ],
+)
+def gmm(
+    lhs: jnp.ndarray,
+    rhs: jnp.ndarray,
+    group_sizes: jnp.ndarray,
+    preferred_element_type: jnp.dtype = jnp.float32,
+    tiling: tuple[int, int, int] | LutFn | None = (128, 128, 128),
+    group_offset: jnp.ndarray | None = None,
+    existing_out: jnp.ndarray | None = None,
+    transpose_rhs: bool = False,
+    interpret: bool = False,
+) -> jnp.ndarray:
+  """Compute lhs[sizes[i-1]:sizes[i], :] @ rhs for each group 'i'.
+
+  Args:
+    lhs: A 2d, jnp.ndarray with shape [m, k].
+    rhs: A 3d, jnp.ndarray with shape [num_groups, k, n].
+    group_sizes: A 1d, jnp.ndarray with shape [num_groups] and jnp.int32 dtype.
+    preferred_element_type: jnp.dtype, the element type for the output matrix.
+    tiling: 3-tuple of ints. The m, k and n-dimension tile sizes.
+    group_offset: The group in group sizes to start computing from. This is
+      particularly useful for when rhs num_groups is sharded.
+    existing_out: Existing output to write to.
+    transpose_rhs: True if the rhs needs to be transposed.
+    interpret: Whether or not to run the kernel in interpret mode, helpful for
+      testing and debugging.
+
+  Returns:
+    A 2d, jnp.ndarray with shape [m, n].
+  """
+
+  if existing_out is not None:
+    assert isinstance(existing_out, jax.Array)
+    expected_dtype = existing_out.dtype
+    if expected_dtype != preferred_element_type:
+      raise ValueError(
+          "Existing output dtype must match preferred_element_type."
+      )
+  if group_offset is None:
+    group_offset = jnp.array([0], dtype=jnp.int32)
+  else:
+    if group_offset.shape:
+      raise ValueError(
+          f"group_offset must be a ()-shaped array. Got: {group_offset.shape}."
+      )
+    group_offset = group_offset[None]
+  num_current_groups = rhs.shape[0]
+  num_total_groups = group_sizes.shape[0]
+  lhs, group_sizes, input_dtype = _validate_args(
+      lhs=lhs, rhs=rhs, group_sizes=group_sizes
+  )
+
+  # Gather shape information.
+  m, k, n = (lhs.shape[0], lhs.shape[1], rhs.shape[2])
+  if transpose_rhs:
+    n = rhs.shape[1]
+
+  # If tiling is callable, look up the problem dimensions in the LUT. If no tuned
+  # tile dimensions are available throw an error.
+  if callable(tiling):
+    tiling = tiling(m, k, n)
+
+  if tiling is None:
+    raise ValueError(f"No tuned tiling found for (m, k, n) = ({m}, {k}, {n})")
+
+  tm, tk, tn = tiling
+  tiles_k, k_rem = _calculate_irregular_num_tiles(k, tk)
+  tiles_n, n_rem = _calculate_irregular_num_tiles(n, tn)
+  del n_rem
+
+  # Create the metadata we need for computation.
+  group_metadata, num_active_tiles = make_group_metadata(  # pylint: disable=unbalanced-tuple-unpacking
+      group_sizes=group_sizes,
+      m=m,
+      tm=tm,
+      start_group=group_offset[0],
+      num_nonzero_groups=rhs.shape[0],
+      visit_empty_groups=False,
+  )
+
+  def kernel(
+      group_metadata,
+      group_offset,
+      lhs,
+      rhs,
+      existing_out,
+      out,
+      acc_scratch,
+  ):
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del group_offsets, group_ids, group_offset
+
+    grid_id = pl.program_id(1)
+    k_i = pl.program_id(2)
+
+    @pl.when(k_i == 0)
+    def _zero_acc():
+      acc_scratch[...] = jnp.zeros_like(acc_scratch)
+
+      if existing_out is not None:
+        prev_grid_id = jnp.where(grid_id > 0, grid_id - 1, 0)
+        is_first_processed_group = grid_id == 0
+        m_tile_changed = m_tile_ids[grid_id] != m_tile_ids[prev_grid_id]
+        first_time_seeing_out = jnp.logical_or(
+            is_first_processed_group, m_tile_changed
+        )
+
+        @pl.when(first_time_seeing_out)
+        def _init_out():
+          out[...] = existing_out[...]
+
+    def mask_k_rem(x, *, dim):
+      if k_rem == 0:
+        return x
+
+      orig_dtype = x.dtype
+      iota = lax.broadcasted_iota(jnp.int32, x.shape, dim)
+      x = x.astype(jnp.float32)
+      return jnp.where(iota < k_rem, x, 0).astype(orig_dtype)
+
+    def _store_accum():
+      mask = _get_store_mask(
+          grid_id=grid_id,
+          group_metadata=group_metadata,
+          tm=tm,
+          tn=tn,
+      )
+      to_store = acc_scratch[...]
+      out[...] = jax.lax.select(
+          mask[...], to_store, out[...].astype(jnp.float32)
+      ).astype(preferred_element_type)
+
+    def _accum(is_last_k_tile):
+      if is_last_k_tile:
+        mask_k_rem_lhs = partial(mask_k_rem, dim=1)
+        mask_k_rem_rhs = partial(mask_k_rem, dim=int(transpose_rhs))
+      else:
+        mask_k_rem_lhs = lambda x: x
+        mask_k_rem_rhs = lambda x: x
+
+      if transpose_rhs:
+        dot_general_dims = (((1,), (1,)), ((), ()))
+      else:
+        dot_general_dims = (((1,), (0,)), ((), ()))
+
+      loaded_lhs = lhs[...]
+      loaded_rhs = rhs[...]
+      acc_scratch[...] += lax.dot_general(
+          mask_k_rem_lhs(loaded_lhs).astype(input_dtype),
+          mask_k_rem_rhs(loaded_rhs).astype(input_dtype),
+          preferred_element_type=jnp.float32,
+          dimension_numbers=dot_general_dims,
+      )
+
+      if is_last_k_tile:
+        _store_accum()
+
+    lax.cond(
+        k_i == tiles_k - 1,
+        partial(_accum, True),
+        partial(_accum, False),
+    )
+
+  def lhs_transform_indices(n_i, grid_id, k_i, group_metadata, group_offset):
+    # lhs is (m, k). Load the [tm, tk] matrix for this m-tile.
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del n_i, group_offsets, group_ids, group_offset
+    return m_tile_ids[grid_id], k_i
+
+  def rhs_transform_indices(n_i, grid_id, k_i, group_metadata, group_offset):
+    # rhs is (num_groups, k, n). Load the [tk, tn] matrix based on the group id
+    # for this m-tile.
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del group_offsets, m_tile_ids
+    if transpose_rhs:
+      k_i, n_i = n_i, k_i
+
+    # NOTE: If we're working on only a shard of the rhs we need to adjust the
+    # group index we load from to account for this. The group_ids are in the
+    # "unsharded" domain.
+    return group_ids[grid_id] - group_offset[0], k_i, n_i
+
+  def out_transform_indices(n_i, grid_id, k_i, group_metadata, group_offset):
+    # out is (m, n). Load the [tm, tn] matrix for this m-tile.
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del k_i, group_offsets, group_ids, group_offset
+    return m_tile_ids[grid_id], n_i
+
+  out_block_spec = pl.BlockSpec((tm, tn), out_transform_indices)
+  if existing_out is None:
+    in_out_block_spec: Any = None
+    input_output_aliases = {}
+  else:
+    in_out_block_spec = out_block_spec
+    input_output_aliases = {6: 0}
+
+  lhs_block_spec = pl.BlockSpec((tm, tk), lhs_transform_indices)
+  if transpose_rhs:
+    rhs_block_spec = pl.BlockSpec((None, tn, tk), rhs_transform_indices)
+  else:
+    rhs_block_spec = pl.BlockSpec((None, tk, tn), rhs_transform_indices)
+
+  lhs_bytes = lhs.size * lhs.itemsize
+  rhs_bytes = (k * n) * rhs.itemsize  # We don't read all of rhs
+  out_bytes = (m * n) * jnp.dtype(preferred_element_type).itemsize
+  max_active_tiles = group_metadata[1].size
+  bytes_accessed = (
+      (lhs_bytes * tiles_n) + (rhs_bytes * max_active_tiles) + out_bytes
+  )
+  flops = 2 * m * k * n
+  cost_estimate = pl.CostEstimate(
+      flops=flops, bytes_accessed=bytes_accessed, transcendentals=0
+  )
+  call_gmm = pl.pallas_call(
+      kernel,
+      out_shape=jax.ShapeDtypeStruct((m, n), preferred_element_type),
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          num_scalar_prefetch=2,
+          in_specs=[
+              lhs_block_spec,
+              rhs_block_spec,
+              in_out_block_spec,
+          ],
+          out_specs=out_block_spec,
+          grid=(tiles_n, num_active_tiles, tiles_k),
+          scratch_shapes=[pltpu.VMEM((tm, tn), jnp.float32)],
+      ),
+      input_output_aliases=input_output_aliases,
+      compiler_params=pltpu.CompilerParams(
+              dimension_semantics=("parallel", "arbitrary", "arbitrary")),
+      interpret=interpret,
+      cost_estimate=cost_estimate,
+  )
+
+  out = call_gmm(
+      group_metadata,
+      group_offset,
+      lhs,
+      rhs,
+      existing_out,
+  )
+  if existing_out is None and num_current_groups < num_total_groups:
+    out = _zero_uninitialized_memory(
+        out,
+        start_group=group_offset[0],
+        num_nonzero_groups=rhs.shape[0],
+        group_metadata=group_metadata,
+    )
+  return out
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "preferred_element_type",
+        "tiling",
+        "num_actual_groups",
+        "interpret",
+    ],
+)
+def tgmm(
+    lhs: jnp.ndarray,
+    rhs: jnp.ndarray,
+    group_sizes: jnp.ndarray,
+    preferred_element_type: jnp.dtype = jnp.float32,
+    tiling: tuple[int, int, int] | LutFn | None = (128, 128, 128),
+    group_offset: jnp.ndarray | None = None,
+    num_actual_groups: int | None = None,
+    existing_out: jnp.ndarray | None = None,
+    interpret: bool = False,
+) -> jnp.ndarray:
+  """Compute lhs[:, sizes[i-1]:sizes[i]] @ rhs[sizes[i-1]:sizes[i], :].
+
+  Args:
+    lhs: A 2d, jnp.ndarray with shape [k, m].
+    rhs: A 2d, jnp.ndarray with shape [m, n].
+    group_sizes: A 1d, jnp.ndarray with shape [num_groups] and jnp.int32 dtype.
+    preferred_element_type: jnp.dtype, the element type for the output matrix.
+    tiling: 3-tuple of ints. The m, k and n-dimension tile sizes.
+    group_offset: The group in group sizes to start computing from. This is
+      particularly useful for when rhs num_groups is sharded.
+    num_actual_groups: For when num_groups is sharded and we should only compute
+      the groups that are local, starting from group_offset.
+    existing_out: Existing output to write to.
+    interpret: Whether or not to run the kernel in interpret mode, helpful for
+      testing and debugging.
+
+  Returns:
+    A  3d, jnp.ndarray with shape [num_groups, k, n].
+  """
+  if group_offset is None:
+    group_offset = jnp.array([0], dtype=jnp.int32)
+  else:
+    group_offset = group_offset[None]
+  lhs, group_sizes, input_dtype = _validate_args(
+      lhs=lhs, rhs=rhs, group_sizes=group_sizes, expected_rhs_dims=2
+  )
+
+  # Gather shape information.
+  k, m, n = (lhs.shape[0], lhs.shape[1], rhs.shape[1])
+  num_groups = group_sizes.shape[0]
+  num_actual_groups = (
+      num_actual_groups if num_actual_groups is not None else num_groups
+  )
+
+  # If tiling is callable, look up the problem dimensions in the LUT. If no tuned
+  # tile dimensions are available throw an error.
+  if callable(tiling):
+    tiling = tiling(m, k, n)
+
+  if tiling is None:
+    raise ValueError(f"No tuned tiling found for (m, k, n) = ({m}, {k}, {n})")
+
+  tm, tk, tn = tiling
+  tiles_k, k_rem = _calculate_irregular_num_tiles(k, tk)
+  del k_rem
+  tiles_n, n_rem = _calculate_irregular_num_tiles(n, tn)
+  del n_rem
+
+  # Create the metadata we need for computation.
+  group_metadata, num_active_tiles = make_group_metadata(
+      group_sizes=group_sizes,
+      m=m,
+      tm=tm,
+      start_group=group_offset[0],
+      num_nonzero_groups=num_actual_groups,
+      visit_empty_groups=True,
+  )
+
+  def kernel(
+      group_metadata,
+      group_offset,
+      lhs,
+      rhs,
+      existing_out,
+      out,
+      acc_scratch,
+  ):
+    grid_id = pl.program_id(2)
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del group_offsets, group_offset, m_tile_ids
+
+    group = group_ids[grid_id]
+    prev_grid_id = jnp.where(grid_id > 0, grid_id - 1, 0)
+    prev_group = group_ids[prev_grid_id]
+
+    group_has_changed = jnp.logical_or(grid_id == 0, prev_group != group)
+
+    @pl.when(group_has_changed)
+    def _zero_acc():
+      acc_scratch[...] = jnp.zeros_like(acc_scratch)
+
+    # We'll only do computation if our group has a nonzero number of rows in it.
+    dont_skip = (
+        _get_group_size(grid_id=grid_id, group_metadata=group_metadata) > 0
+    )
+
+    @pl.when(dont_skip)
+    def _do():
+      rhs_mask = _get_store_mask(
+          grid_id=grid_id,
+          group_metadata=group_metadata,
+          tm=tm,
+          tn=tn,
+      )
+      lhs_mask = _get_store_mask(
+          grid_id=grid_id,
+          group_metadata=group_metadata,
+          tm=tm,
+          tn=tk,
+      )
+
+      loaded_lhs = lhs[...]
+      loaded_rhs = rhs[...]
+      loaded_lhs = lax.select(
+          lhs_mask[...],
+          loaded_lhs.astype(jnp.float32),
+          jnp.zeros_like(lhs, jnp.float32),
+      ).swapaxes(0, 1)
+      loaded_rhs = lax.select(
+          rhs_mask[...],
+          loaded_rhs.astype(jnp.float32),
+          jnp.zeros_like(rhs, jnp.float32),
+      )
+
+      acc_scratch[...] += lax.dot(
+          loaded_lhs.astype(input_dtype),
+          loaded_rhs.astype(input_dtype),
+          preferred_element_type=jnp.float32,
+      )
+
+    is_end_of_grid = grid_id == (pl.num_programs(2) - 1)
+    next_grid_id = jnp.where(is_end_of_grid, grid_id, grid_id + 1)
+    next_group = group_ids[next_grid_id]
+
+    group_is_changing = jnp.logical_or(is_end_of_grid, group != next_group)
+
+    @pl.when(group_is_changing)
+    def _store_accum():
+      to_store = acc_scratch[...]
+      if existing_out is not None:
+        to_store += existing_out[...].astype(jnp.float32)
+      out[...] = to_store.astype(preferred_element_type)
+
+  def lhs_transform_indices(n_i, k_i, grid_id, group_metadata, group_offset):
+    # lhs is (m, k). Load the [tm, tk] matrix for this m-tile.
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del n_i, group_offsets, group_ids, group_offset
+    return m_tile_ids[grid_id], k_i
+
+  def rhs_transform_indices(n_i, k_i, grid_id, group_metadata, group_offset):
+    # rhs is (m, n). Load the [tm, tn] matrix for this m-tile.
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del k_i, group_offsets, group_ids, group_offset
+    return m_tile_ids[grid_id], n_i
+
+  def out_transform_indices(n_i, k_i, grid_id, group_metadata, group_offset):
+    # out is (num_groups, k, n). Load the [tk, tn] matrix based on the group id
+    # for this m-tile.
+    group_offsets, group_ids, m_tile_ids = group_metadata
+    del group_offsets, m_tile_ids
+
+    # NOTE: If we're working on only a shard of the output we need to adjust the
+    # group index we load from to account for this. The group_ids are in the
+    # "unsharded" domain.
+    return group_ids[grid_id] - group_offset[0], k_i, n_i
+
+  out_block_spec = pl.BlockSpec((None, tk, tn), out_transform_indices)
+  if existing_out is None:
+    in_out_block_spec: Any = None
+    input_output_aliases = {}
+  else:
+    in_out_block_spec = out_block_spec
+    input_output_aliases = {6: 0}
+
+  lhs_block_spec = pl.BlockSpec((tm, tk), lhs_transform_indices)
+  rhs_block_spec = pl.BlockSpec((tm, tn), rhs_transform_indices)
+
+  lhs_bytes = lhs.size * lhs.itemsize
+  rhs_bytes = rhs.size * rhs.itemsize
+  out_bytewidth = jnp.dtype(preferred_element_type).itemsize
+  out_bytes = (num_actual_groups * k * n) * out_bytewidth
+  bytes_accessed = (
+      (lhs_bytes * tiles_n) + (rhs_bytes * tiles_k) + out_bytes
+  )
+  flops = 2 * m * k * n
+  cost_estimate = pl.CostEstimate(
+      flops=flops, bytes_accessed=bytes_accessed, transcendentals=0
+  )
+  lhs = lhs.swapaxes(0, 1)
+  call_gmm = pl.pallas_call(
+      kernel,
+      out_shape=jax.ShapeDtypeStruct(
+          (num_actual_groups, k, n), preferred_element_type
+      ),
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          num_scalar_prefetch=2,
+          in_specs=[
+              lhs_block_spec,
+              rhs_block_spec,
+              in_out_block_spec,
+          ],
+          out_specs=out_block_spec,
+          grid=(tiles_n, tiles_k, num_active_tiles),
+          scratch_shapes=[pltpu.VMEM((tk, tn), jnp.float32)],
+      ),
+      input_output_aliases=input_output_aliases,
+      compiler_params=pltpu.CompilerParams(
+              dimension_semantics=("parallel", "arbitrary", "arbitrary")),
+      interpret=interpret,
+      cost_estimate=cost_estimate,
+  )
+
+  out = call_gmm(
+      group_metadata,
+      group_offset,
+      lhs,
+      rhs,
+      existing_out,
+  )
+  return out
+
+
+CONFIG = {
+    'name': 'pallas_megablox_gmm_qwen3_235b',
+    'model': 'Qwen3-235B-A22B',
+    'operator': 'pallas_gmm',
+    'num_experts': 128,
+    'num_experts_per_tok': 8,
+    'emb_dim': 4096,
+    'moe_mlp_dim': 1536,
+    'seq_len': 4096,
+    'atol': 1e-3,
+    'rtol': 1e-2,
+}
+
+# Tuned by autotune_block_sizes.py. Re-run to update.
+TUNED_PARAMS = {'tiling': [256, 1024, 1024]}
+
+
+def get_flops():
+    top_k = CONFIG['num_experts_per_tok']
+    K = CONFIG['emb_dim']
+    N = CONFIG['moe_mlp_dim']
+    S = CONFIG['seq_len']
+    M = S * top_k
+    return 2 * M * K * N
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    G = CONFIG['num_experts']
+    top_k = CONFIG['num_experts_per_tok']
+    K = CONFIG['emb_dim']
+    N = CONFIG['moe_mlp_dim']
+    S = CONFIG['seq_len']
+    M = S * top_k
+    lhs = jax.random.normal(k1, (M, K), dtype=dtype)
+    rhs = jax.random.normal(k2, (G, K, N), dtype=dtype) * 0.02
+    tokens_per_expert = M // G
+    group_sizes = jnp.full((G,), tokens_per_expert, dtype=jnp.int32)
+    return lhs, rhs, group_sizes
+
+
+def workload(lhs, rhs, group_sizes):
+    return gmm(lhs, rhs, group_sizes, tiling=tuple(TUNED_PARAMS['tiling']))
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator', 'atol', 'rtol')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/12p_RMSNorm/baseline.py
+++ b/JAXBench/benchmark/12p_RMSNorm/baseline.py
@@ -1,0 +1,82 @@
+"""RMSNorm — Llama-3.1-70B pre-attention normalization.
+
+Root Mean Square Layer Normalization at Llama-3.1-70B scale.
+Input shape: (batch=1, seq_len=2048, emb_dim=8192).
+From MaxText layers/normalizations.py.
+"""
+import jax
+import jax.numpy as jnp
+from jax import lax
+
+CONFIG = {
+    'name': 'llama3_70b_rmsnorm',
+    'model': 'Llama-3.1-70B',
+    'operator': 'rms_norm',
+    'batch': 8,
+    'seq_len': 4096,
+    'emb_dim': 8192,
+    'epsilon': 1e-5,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (x, scale) tensors."""
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    B, S, D = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim']
+    x = jax.random.normal(k1, (B, S, D), dtype=dtype)
+    scale = jax.random.normal(k2, (D,), dtype=dtype) * 0.1 + 1.0
+    return x, scale
+
+
+def workload(x, scale):
+    """RMSNorm: x * rsqrt(mean(x^2) + eps) * scale"""
+    x_f32 = jnp.asarray(x, jnp.float32)
+    mean2 = jnp.mean(lax.square(x_f32), axis=-1, keepdims=True)
+    normed = x_f32 * lax.rsqrt(mean2 + CONFIG['epsilon'])
+    normed = jnp.asarray(normed, x.dtype)
+    return normed * scale
+
+
+def get_flops():
+    """RMSNorm FLOPs: square + mean + rsqrt + 2x mul over B*S*D."""
+    B, S, D = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim']
+    return 5 * B * S * D
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, D = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim']
+    # square + mean + rsqrt + mul + mul: ~5 elementwise ops over B*S*D
+    flops = 5 * B * S * D
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 4),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/13p_Cross_Entropy/baseline.py
+++ b/JAXBench/benchmark/13p_Cross_Entropy/baseline.py
@@ -1,0 +1,69 @@
+"""Fused Linear + Cross-Entropy Loss — Llama 3.1 8B. From openxla/tokamax."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'llama3_8b_cross_entropy',
+    'model': 'Llama-3.1-8B',
+    'operator': 'fused_cross_entropy',
+    'batch_tokens': 8192,
+    'hidden_dim': 4096,
+    'vocab_size': 128256,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (hidden_states, lm_head_weight, labels)."""
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    B, H, V = CONFIG['batch_tokens'], CONFIG['hidden_dim'], CONFIG['vocab_size']
+    hidden = jax.random.normal(k1, (B, H), dtype=dtype)
+    weight = jax.random.normal(k2, (H, V), dtype=dtype) * 0.02
+    labels = jax.random.randint(k3, (B,), 0, V)
+    return hidden, weight, labels
+
+
+def workload(hidden, weight, labels):
+    """Fused linear projection + softmax cross-entropy loss."""
+    logits = jnp.dot(hidden, weight)
+    log_probs = jax.nn.log_softmax(logits, axis=-1)
+    one_hot = jax.nn.one_hot(labels, logits.shape[-1])
+    loss = -jnp.sum(one_hot * log_probs, axis=-1)
+    return jnp.mean(loss)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, H, V = CONFIG['batch_tokens'], CONFIG['hidden_dim'], CONFIG['vocab_size']
+    flops = B * H * V * 2 + B * V * 3  # matmul + softmax + loss
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/14p_Ragged_Dot/baseline.py
+++ b/JAXBench/benchmark/14p_Ragged_Dot/baseline.py
@@ -1,0 +1,67 @@
+"""Grouped Matmul (Ragged Dot) for MoE — Mixtral 8x7B. From openxla/tokamax."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'mixtral_8x7b_ragged_dot',
+    'model': 'Mixtral-8x7B',
+    'operator': 'ragged_dot',
+    'num_groups': 8,
+    'M': 8192,
+    'K': 4096,
+    'N': 14336,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (x, weights, group_sizes) for grouped matmul."""
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    G, M, K, N = CONFIG['num_groups'], CONFIG['M'], CONFIG['K'], CONFIG['N']
+    # Each group gets M/G rows
+    x = jax.random.normal(k1, (G, M // G, K), dtype=dtype)
+    weights = jax.random.normal(k2, (G, K, N), dtype=dtype) * 0.02
+    return x, weights
+
+
+def workload(x, weights):
+    """Grouped matmul: each group does independent matmul. Equivalent to ragged dot."""
+    # x: (G, M/G, K), weights: (G, K, N) -> out: (G, M/G, N)
+    return jnp.einsum('gmk,gkn->gmn', x, weights)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    G, M, K, N = CONFIG['num_groups'], CONFIG['M'], CONFIG['K'], CONFIG['N']
+    flops = G * (M // G) * K * N * 2
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/15p_RetNet_Retention/baseline.py
+++ b/JAXBench/benchmark/15p_RetNet_Retention/baseline.py
@@ -1,0 +1,119 @@
+"""Multi-Scale Retention — Microsoft RetNet.
+
+Replaces softmax attention with retention: a causal linear attention mechanism
+with fixed exponential decay per head. Different heads use different decay rates
+(multi-scale), giving each head a different "memory horizon".
+
+Paper: "Retentive Network: A Successor to Transformer" (Sun et al., 2023)
+Used in RetNet models and influenced Mamba-2, GLA, and other recent architectures.
+
+Config based on RetNet-6.7B from the paper.
+"""
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+CONFIG = {
+    'name': 'retnet_6_7b_retention',
+    'model': 'RetNet-6.7B',
+    'operator': 'multi_scale_retention',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_heads': 16,
+    'head_dim': 256,
+    'd_model': 4096,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (query, key, value)."""
+    key = jax.random.key(42)
+    keys = jax.random.split(key, 3)
+    B, S = CONFIG['batch'], CONFIG['seq_len']
+    H, D = CONFIG['num_heads'], CONFIG['head_dim']
+    query = jax.random.normal(keys[0], (B, H, S, D), dtype=dtype)
+    key_t = jax.random.normal(keys[1], (B, H, S, D), dtype=dtype)
+    value = jax.random.normal(keys[2], (B, H, S, D), dtype=dtype)
+    return query, key_t, value
+
+
+def workload(query, key, value):
+    """Multi-scale retention with per-head exponential decay.
+
+    Retention(X) = (Q K^T ⊙ D) V
+    where D[i,j] = γ^(i-j) if i >= j, else 0
+
+    Each head has a different decay rate γ_h, creating a multi-scale
+    representation: some heads attend locally, others globally.
+    """
+    B, H, S, D = query.shape
+
+    # Multi-scale decay rates (from RetNet paper)
+    # γ_h = 1 - 2^(-5 - arange(H))
+    gammas = 1.0 - jnp.exp2(-5.0 - jnp.arange(H, dtype=jnp.float32))  # (H,)
+    # Gammas range from ~0.97 (long range) to ~1.0 (very long range)
+
+    # Build causal decay matrix D[i,j] = γ^(i-j) for i >= j
+    positions = jnp.arange(S, dtype=jnp.float32)
+    # distance[i,j] = i - j
+    distance = positions[:, None] - positions[None, :]  # (S, S)
+    # D[h,i,j] = γ_h^(i-j) * (i >= j)
+    causal_mask = (distance >= 0).astype(jnp.float32)
+    # γ^distance: (H, S, S)
+    log_gamma = jnp.log(gammas)  # (H,)
+    decay = jnp.exp(log_gamma[:, None, None] * distance[None, :, :])  # (H, S, S)
+    decay = decay * causal_mask[None, :, :]  # apply causal mask
+
+    # Retention: (Q K^T ⊙ D) V
+    # QK^T: (B, H, S, S)
+    qk = jnp.einsum('bhsd,bhtd->bhst', query.astype(jnp.float32), key.astype(jnp.float32))
+
+    # Apply decay mask
+    qk = qk * decay[None, :, :, :]  # (B, H, S, S)
+
+    # Normalize by retention sum (per-query normalization)
+    retention_sum = jnp.sum(jnp.abs(qk), axis=-1, keepdims=True)
+    retention_sum = jnp.maximum(retention_sum, 1.0)
+    qk = qk / retention_sum
+
+    # Output
+    output = jnp.einsum('bhst,bhtd->bhsd', qk.astype(query.dtype), value)
+    return output
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, H, D = CONFIG['batch'], CONFIG['seq_len'], CONFIG['num_heads'], CONFIG['head_dim']
+    # QK^T: 2*B*H*S*S*D, AV: 2*B*H*S*S*D
+    flops = 2 * B * H * S * S * D * 2
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/16p_Mamba2_SSD/baseline.py
+++ b/JAXBench/benchmark/16p_Mamba2_SSD/baseline.py
@@ -1,0 +1,121 @@
+"""Mamba-2 State Space Duality (SSD) — Dao & Gu.
+
+The SSD layer shows that structured state space models are equivalent to a form
+of linear attention with input-dependent (selective) decay. This is the matrix
+(parallel) form of Mamba-2's core computation.
+
+Paper: "Transformers are SSMs" (Dao & Gu, 2024)
+Mamba-2 is the dominant alternative to standard transformers in 2024-2025.
+
+Config based on Mamba-2-2.7B from the paper.
+"""
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+CONFIG = {
+    'name': 'mamba2_2_7b_ssd',
+    'model': 'Mamba-2-2.7B',
+    'operator': 'state_space_duality',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_heads': 64,
+    'head_dim': 64,
+    'd_state': 128,
+    'd_model': 2560,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (query, key, value, A_log)."""
+    rng = jax.random.key(42)
+    keys = jax.random.split(rng, 5)
+    B, S = CONFIG['batch'], CONFIG['seq_len']
+    H, D = CONFIG['num_heads'], CONFIG['head_dim']
+    # In Mamba-2 SSD: C maps to Q, B maps to K, x maps to V
+    query = jax.random.normal(keys[0], (B, H, S, D), dtype=dtype)  # C (output projection)
+    key_t = jax.random.normal(keys[1], (B, H, S, D), dtype=dtype)  # B (input projection)
+    value = jax.random.normal(keys[2], (B, H, S, D), dtype=dtype)  # x (hidden state)
+    # A: input-dependent decay (after log-space parameterization)
+    # Initialized negative (stable decay), per-head scalar
+    A_log = jax.random.normal(keys[3], (B, H, S), dtype=jnp.float32) * 0.5 - 4.0
+    return query, key_t, value, A_log
+
+
+def workload(query, key, value, A_log):
+    """Mamba-2 SSD: structured linear attention with selective decay.
+
+    y = (L ⊙ (C B^T)) x
+    where L[i,j] = Π_{k=j+1}^{i} a_k for i > j, 1 for i=j, 0 for i<j
+    and a_k = exp(A_log_k) is the selective (input-dependent) decay.
+    """
+    B, H, S, D = query.shape
+
+    # Compute per-position decay: a = sigmoid(A_log) to keep in (0, 1)
+    a = jax.nn.sigmoid(A_log.astype(jnp.float32))  # (B, H, S)
+
+    # Build causal mask L with cumulative decay
+    # log(a) cumsum then exponentiate: L[i,j] = exp(Σ_{k=j+1}^{i} log(a_k))
+    log_a = jnp.log(a + 1e-8)  # (B, H, S)
+    log_a_cumsum = jnp.cumsum(log_a, axis=-1)  # (B, H, S)
+
+    # L[i,j] = exp(cumsum[i] - cumsum[j]) for i >= j, 0 for i < j
+    diff = log_a_cumsum[:, :, :, None] - log_a_cumsum[:, :, None, :]
+    causal = jnp.tril(jnp.ones((S, S), dtype=jnp.bool_))
+    L = jnp.exp(jnp.where(causal[None, None, :, :], diff, -1e30))
+
+    # SSD attention: (L ⊙ CB^T) x
+    # CB^T: (B, H, S, S) — "attention scores"
+    scores = jnp.einsum('bhsd,bhtd->bhst',
+                        query.astype(jnp.float32),
+                        key.astype(jnp.float32))
+
+    # Apply selective decay mask
+    scores = scores * L
+
+    # Normalize
+    scores_sum = jnp.sum(scores, axis=-1, keepdims=True)
+    scores_sum = jnp.where(jnp.abs(scores_sum) < 1e-6, 1.0, scores_sum)
+    scores = scores / jnp.maximum(jnp.abs(scores_sum), 1.0)
+
+    # Output
+    output = jnp.einsum('bhst,bhtd->bhsd', scores.astype(query.dtype), value)
+    return output
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, H, D = CONFIG['batch'], CONFIG['seq_len'], CONFIG['num_heads'], CONFIG['head_dim']
+    # Scores CB^T: 2*B*H*S*S*D, output: 2*B*H*S*S*D
+    flops = 2 * B * H * S * S * D * 2
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/17p_Triangle_Multiplication/baseline.py
+++ b/JAXBench/benchmark/17p_Triangle_Multiplication/baseline.py
@@ -1,0 +1,96 @@
+"""Triangle Multiplicative Update (Outgoing) — AlphaFold2 768.
+
+Contracts over the second residue index with gated projections and
+layer normalization. Core structural operation in AlphaFold2.
+From openxla/tokamax triangle_mult benchmarks.
+"""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'alphafold_768_triangle_mult',
+    'model': 'AlphaFold2',
+    'operator': 'triangle_mult_outgoing',
+    'N': 1536,
+    'C': 128,
+    'direction': 'outgoing',
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (pair_act, mask, left_proj_w, right_proj_w, left_gate_w, right_gate_w, center_norm_scale, output_proj_w, output_gate_w)."""
+    key = jax.random.key(42)
+    keys = jax.random.split(key, 9)
+    N, C = CONFIG['N'], CONFIG['C']
+    pair_act = jax.random.normal(keys[0], (N, N, C), dtype=dtype)
+    mask = jnp.ones((N, N, 1), dtype=dtype)
+    left_proj = jax.random.normal(keys[1], (C, C), dtype=dtype) * 0.02
+    right_proj = jax.random.normal(keys[2], (C, C), dtype=dtype) * 0.02
+    left_gate = jax.random.normal(keys[3], (C, C), dtype=dtype) * 0.02
+    right_gate = jax.random.normal(keys[4], (C, C), dtype=dtype) * 0.02
+    center_scale = jax.random.normal(keys[5], (C,), dtype=dtype) * 0.1 + 1.0
+    out_proj = jax.random.normal(keys[6], (C, C), dtype=dtype) * 0.02
+    out_gate = jax.random.normal(keys[7], (C, C), dtype=dtype) * 0.02
+    return pair_act, mask, left_proj, right_proj, left_gate, right_gate, center_scale, out_proj, out_gate
+
+
+def workload(pair_act, mask, left_proj_w, right_proj_w, left_gate_w, right_gate_w, center_scale, out_proj_w, out_gate_w):
+    """Triangle multiplicative update (outgoing): contracts over the second residue index."""
+    act = pair_act * mask
+    left_proj = jnp.dot(act, left_proj_w)
+    right_proj = jnp.dot(act, right_proj_w)
+    left_gate = jax.nn.sigmoid(jnp.dot(act, left_gate_w))
+    right_gate = jax.nn.sigmoid(jnp.dot(act, right_gate_w))
+    left_proj = left_proj * left_gate
+    right_proj = right_proj * right_gate
+    # Outgoing: contract over k dimension (second index)
+    # pair_act[i,j] = sum_k left[i,k] * right[j,k]
+    result = jnp.einsum('ikc,jkc->ijc', left_proj, right_proj)
+    # Center layer norm (RMS)
+    eps = 1e-6
+    rms = jnp.sqrt(jnp.mean(result * result, axis=-1, keepdims=True) + eps)
+    result = result / rms * center_scale
+    # Output projection + gating
+    output = jnp.dot(result, out_proj_w)
+    gate = jax.nn.sigmoid(jnp.dot(pair_act, out_gate_w))
+    return output * gate
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    N, C = CONFIG['N'], CONFIG['C']
+    proj_flops = 4 * N * N * C * C * 2
+    einsum_flops = N * N * N * C * 2
+    out_flops = 2 * N * N * C * C * 2
+    flops = proj_flops + einsum_flops + out_flops
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 4),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/18k_Conv2D_ReLU_BiasAdd/baseline.py
+++ b/JAXBench/benchmark/18k_Conv2D_ReLU_BiasAdd/baseline.py
@@ -1,0 +1,75 @@
+"""1_Conv2D_ReLU_BiasAdd — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '1_Conv2D_ReLU_BiasAdd',
+    'batch_size': 128,
+    'in_channels': 64,
+    'out_channels': 128,
+    'kernel_size': 3,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    k1, k2 = jax.random.split(key)
+    batch_size, in_channels, out_channels, kernel_size = 128, 64, 128, 3
+    height = width = 128
+    x = jax.random.uniform(k1, (batch_size, in_channels, height, width), dtype=dtype)
+    weight = jnp.zeros((out_channels, in_channels, kernel_size, kernel_size), dtype=dtype)
+    conv_bias = jnp.zeros(out_channels, dtype=dtype)
+    bias = jnp.zeros((out_channels, 1, 1), dtype=dtype)
+    return x, weight, conv_bias, bias
+
+
+def workload(x, weight, conv_bias, bias):
+    """Conv2D + ReLU + BiasAdd."""
+    # NCHW -> NHWC
+    x = jnp.transpose(x, (0, 2, 3, 1))
+    kernel = jnp.transpose(weight, (2, 3, 1, 0))  # OIHW -> HWIO
+    x = jax.lax.conv_general_dilated(
+        x, kernel,
+        window_strides=(1, 1),
+        padding='VALID',
+        dimension_numbers=('NHWC', 'HWIO', 'NHWC')
+    )
+    x = x + conv_bias.reshape(1, 1, 1, -1)
+    x = jax.nn.relu(x)
+    x = jnp.transpose(x, (0, 3, 1, 2))  # NHWC -> NCHW
+    x = x + bias
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/19k_Matmul_Subtract_Multiply_ReLU/baseline.py
+++ b/JAXBench/benchmark/19k_Matmul_Subtract_Multiply_ReLU/baseline.py
@@ -1,0 +1,63 @@
+"""9_Matmul_Subtract_Multiply_ReLU — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '9_Matmul_Subtract_Multiply_ReLU',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'subtract_value': 2.0,
+    'multiply_value': 1.5,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Subtract + Multiply + ReLU."""
+    x = jnp.matmul(x, weight) + bias
+    x = x - 2.0
+    x = x * 1.5
+    x = jax.nn.relu(x)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/1p_Flash_Attention/baseline.py
+++ b/JAXBench/benchmark/1p_Flash_Attention/baseline.py
@@ -1,0 +1,84 @@
+"""Vanilla Multi-Head Causal Attention — Baseline (64 heads, seq=2048).
+
+Standard scaled dot-product attention with causal mask.
+No GQA, no softcap, no sliding window — pure MHA baseline.
+Matches Pallas flash_attention kernel config.
+"""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'flash_attention_baseline',
+    'model': 'Baseline-MHA',
+    'operator': 'causal_mha',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_heads': 64,
+    'head_dim': 128,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (query, key, value) tensors."""
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    B, S = CONFIG['batch'], CONFIG['seq_len']
+    H, D = CONFIG['num_heads'], CONFIG['head_dim']
+    query = jax.random.normal(k1, (B, H, S, D), dtype=dtype)
+    key_t = jax.random.normal(k2, (B, H, S, D), dtype=dtype)
+    value = jax.random.normal(k3, (B, H, S, D), dtype=dtype)
+    return query, key_t, value
+
+
+def workload(query, key, value):
+    """Standard causal multi-head attention: QK^T -> mask -> softmax -> AV."""
+    B, H, S, D = query.shape
+    scale = D ** -0.5
+    # QK^T
+    attn = jnp.einsum('bhqd,bhkd->bhqk', query, key) * scale
+    # Causal mask
+    mask = jnp.tril(jnp.ones((S, S)))
+    attn = jnp.where(mask, attn, -1e9)
+    # Softmax
+    attn = jax.nn.softmax(attn, axis=-1)
+    # AV
+    output = jnp.einsum('bhqk,bhkd->bhqd', attn, value)
+    return output
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, H, D = CONFIG['batch'], CONFIG['seq_len'], CONFIG['num_heads'], CONFIG['head_dim']
+    # QK^T: 2*B*H*S*S*D, AV: 2*B*H*S*S*D
+    flops = 4 * B * H * S * S * D
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/1p_Flash_Attention/optimized.py
+++ b/JAXBench/benchmark/1p_Flash_Attention/optimized.py
@@ -1,0 +1,1818 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flash Attention TPU kernel."""
+from __future__ import annotations
+
+import dataclasses
+import functools
+import math
+from typing import Any, NamedTuple
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
+
+DEFAULT_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.dtype("float32")).max)
+NUM_LANES = 128
+NUM_SUBLANES = 8
+
+
+class SegmentIds(NamedTuple):
+  """SegmentIds for Q and KV sequences.
+
+  SegmentIds are used to generate segment mask, which prevents attention between
+  different segments in the input sequence. Each array is a list of ids
+  (integers).
+  Only the token with the same id can attend to each other.
+
+  Attributes:
+    q: segment ids along the Q sequence.
+    kv: segment ids along the KV sequence.
+  """
+
+  q: jax.Array  # [batch_size, q_seq_len]
+  kv: jax.Array  # [batch_size, kv_seq_len]
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockSizes:
+  """Tile sizes parameterizing FlashAttention kernels.
+
+  Those parameters have negligible effect on numerics, but affect performance
+  greatly.
+  """
+  block_q: int
+  block_k_major: int
+  block_k: int
+  block_b: int
+
+  block_q_major_dkv: int | None = None
+  block_k_major_dkv: int | None = None
+  block_k_dkv: int | None = None
+  block_q_dkv: int | None = None
+
+  block_k_major_dq: int | None = None
+  block_k_dq: int | None = None
+  block_q_dq: int | None = None
+
+  def __post_init__(self):
+    def verify_major_minor(prefix, suffix, major, minor):
+      if minor > major:
+        raise ValueError(
+            f"{prefix}{suffix}={minor} should be smaller than"
+            f" {prefix}_major{suffix}={major}"
+        )
+      if major % minor != 0:
+        raise ValueError(
+            f"{prefix}{suffix}={minor} should divide"
+            f" {prefix}_major{suffix}={major}"
+        )
+
+    verify_major_minor("block_k", "", self.block_k_major, self.block_k)
+    if self.block_q_major_dkv is not None and self.block_q_dkv is not None:
+      verify_major_minor(
+          "block_q", "_dkv", self.block_q_major_dkv, self.block_q_dkv
+      )
+    if self.block_k_major_dkv is not None and self.block_k_dkv is not None:
+      verify_major_minor(
+          "block_k", "_dkv", self.block_k_major_dkv, self.block_k_dkv
+      )
+    if self.block_k_major_dq is not None and self.block_k_dq is not None:
+      verify_major_minor(
+          "block_k", "_dq", self.block_k_major_dq, self.block_k_dq
+      )
+
+  @property
+  def has_backward_blocks(self) -> bool:
+    backward_blocks = (
+        self.block_q_major_dkv,
+        self.block_k_major_dkv,
+        self.block_q_dkv,
+        self.block_k_dkv,
+        self.block_k_major_dq,
+        self.block_k_dq,
+        self.block_q_dq,
+    )
+    return all(b is not None for b in backward_blocks)
+
+  @classmethod
+  def get_default(cls, batch_size, num_heads, q_seq_len, kv_len, d_model):
+    # TODO(apaszke,sharadmv): Select better parameters based on a heuristic.
+    del batch_size, num_heads, q_seq_len, kv_len, d_model  # Unused.
+    return BlockSizes(
+        block_q=128,
+        block_k_major=128,
+        block_k=128,
+        block_b=1,
+        block_q_major_dkv=128,
+        block_k_major_dkv=128,
+        block_k_dkv=128,
+        block_q_dkv=128,
+        block_k_major_dq=128,
+        block_k_dq=128,
+        block_q_dq=128,
+    )
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "causal",
+        "sm_scale",
+        "block_sizes",
+        "debug",
+    ],
+)
+def flash_attention(
+    q,  # [batch_size, num_heads, q_seq_len, d_model]
+    k,  # [batch_size, num_heads, kv_seq_len, d_model]
+    v,  # [batch_size, num_heads, kv_seq_len, d_model]
+    ab=None,  # [batch_size, num_heads, q_seq_len, kv_seq_len]
+    segment_ids=None,  # q of [batch_size, q_seq_len] and kv of [batch_size, kv_seq_len]
+    *,
+    causal: bool = False,
+    sm_scale: float = 1.0,
+    block_sizes: BlockSizes | None = None,
+    debug: bool = False,
+):
+  batch_size, num_heads, q_seq_len, d_model = q.shape
+  batch_size_k, num_heads_k, kv_seq_len, d_model_k = k.shape
+  batch_size_v, num_heads_v, kv_seq_len_v, d_model_v = v.shape
+  if batch_size != batch_size_k or batch_size != batch_size_v:
+    raise ValueError(
+        f"Batch size mismatch: got {batch_size}, {batch_size_k} and"
+        f" {batch_size_v} (for q, k, v respectively)"
+    )
+  if num_heads != num_heads_k or num_heads != num_heads_v:
+    raise ValueError(
+        f"Head count mismatch: got {num_heads}, {num_heads_k},"
+        f" {num_heads_v} (for q, k, v respectively)"
+    )
+  if d_model != d_model_k:
+    raise ValueError(
+        f"Model dimension mismatch: got {d_model} and {d_model_k} (for q and k"
+        " respectively)"
+    )
+  if d_model != d_model_v:
+    raise NotImplementedError(
+        "V model dimension unequal to KV model dimension unsupported"
+    )
+  if kv_seq_len != kv_seq_len_v:
+    raise ValueError(
+        f"KV sequence length mismatch: got {kv_seq_len} and {kv_seq_len_v}"
+    )
+  if ab is not None:
+    if ab.shape != (batch_size, num_heads, q_seq_len, kv_seq_len):
+      raise ValueError(
+          f"Attention bias shape mismatch: expected ({batch_size=},"
+          f" {num_heads=}, {q_seq_len=}, {kv_seq_len=}), got {ab.shape}"
+      )
+  if segment_ids is not None:
+    if segment_ids.q.shape != (batch_size, q_seq_len):
+      raise ValueError(
+          f"Q segment ids shape mismatch: expected ({batch_size=},"
+          f" {q_seq_len=},), got {segment_ids.q.shape}"
+      )
+    if segment_ids.kv.shape != (batch_size, kv_seq_len):
+      raise ValueError(
+          f"KV segment ids shape mismatch: expected ({batch_size=},"
+          f" {kv_seq_len=},), got {segment_ids.kv.shape}"
+      )
+  if block_sizes is None:
+    block_sizes = BlockSizes.get_default(
+        batch_size, num_heads, q_seq_len, kv_seq_len, d_model
+    )
+  return _flash_attention(
+      q, k, v, ab, segment_ids, False, causal, sm_scale, block_sizes, debug
+  )
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnames=("save_residuals", "causal", "sm_scale", "block_sizes", "debug"))
+def _flash_attention(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+):
+  return _flash_attention_impl(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      save_residuals,
+      causal,
+      sm_scale,
+      block_sizes.block_b,
+      block_sizes.block_q,
+      block_sizes.block_k_major,
+      block_sizes.block_k,
+      debug,
+  )
+
+
+def _flash_attention_fwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+):
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported")
+  o, l, m = _flash_attention(
+      q, k, v, ab, segment_ids, True, causal, sm_scale, block_sizes, debug
+  )
+  return o, (q, k, v, ab, segment_ids, o, l, m)
+
+
+def _flash_attention_bwd(
+    save_residuals: bool,
+    causal: bool,
+    sm_scale: float,
+    block_sizes: BlockSizes,
+    debug: bool,
+    residuals,
+    do,
+):
+  """VJP rule for FlashAttention."""
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported")
+  (q, k, v, ab, segment_ids, o, l, m) = residuals
+  if not block_sizes.has_backward_blocks:
+    raise ValueError(
+        "Program is being differentiated, but not all backward blocks are"
+        " specified"
+    )
+
+  di = jnp.sum(
+      o.astype(jnp.float32) * do.astype(jnp.float32), axis=-1
+  )  # [batch_size, num_heads, q_seq_len]
+
+  dk, dv = _flash_attention_bwd_dkv(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      l,
+      m,
+      do,
+      di,
+      block_q_major=block_sizes.block_q_major_dkv,
+      block_k_major=block_sizes.block_k_major_dkv,
+      block_k=block_sizes.block_k_dkv,
+      block_q=block_sizes.block_q_dkv,
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=DEFAULT_MASK_VALUE,
+      debug=debug,
+  )
+
+  dq, ds = _flash_attention_bwd_dq(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      l,
+      m,
+      do,
+      di,
+      block_q_major=block_sizes.block_q_dq,
+      block_k_major=block_sizes.block_k_major_dq,
+      block_k=block_sizes.block_k_dq,
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=DEFAULT_MASK_VALUE,
+      debug=debug,
+  )
+  return dq, dk, dv, ds, None
+
+
+_flash_attention.defvjp(fwd=_flash_attention_fwd, bwd=_flash_attention_bwd)
+
+
+MIN_BLOCK_SIZE = 128
+TRANS_B_DIM_NUMBERS = (((1,), (1,)), ((), ()))
+
+
+def below_or_on_diag(r, r_blk_size, c, c_blk_size):
+  # A block is considered below or on diagonal as long as the bottom left
+  # corner of the block is below or on diagonal.
+  return ((r + 1) * r_blk_size - 1) > (c * c_blk_size)
+
+
+def _flash_attention_kernel(q_tile_ref, *args, **kwargs):
+  block_b = q_tile_ref.shape[0]
+  # If we're not going to tile the softmax, then we can avoid a bunch of VPU ops.
+  if kwargs["block_k"] == kwargs["kv_seq_len"]:
+    kernel = _flash_attention_kernel_single_batch_single_step
+  else:
+    kernel = _flash_attention_kernel_single_batch
+  for batch_idx in range(block_b):
+    kernel((batch_idx, 0), q_tile_ref, *args, **kwargs)
+
+
+def _flash_attention_kernel_single_batch(
+    batch_idx: tuple[int, ...],
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,  # Input arrays
+    o_tile_ref,  # Output arrays
+    l_ref,
+    m_ref,
+    m_scratch_ref,
+    l_scratch_ref,
+    acc_scratch_ref,
+    *,
+    causal,
+    sm_scale,
+    block_k,
+    kv_seq_len,
+    mask_value,
+):
+  block_k_major = k_tile_ref.shape[2]
+  block_q = q_tile_ref.shape[2]
+  head_dim = q_tile_ref.shape[-1]
+
+  kv_seq_idx = pl.program_id(3)
+  @pl.when(kv_seq_idx == 0)
+  def start_new_sequence():
+    m_scratch_ref[batch_idx] = jnp.full(
+        m_scratch_ref.shape[2:], -jnp.inf, jnp.float32
+    )
+    l_scratch_ref[batch_idx] = jnp.zeros(l_scratch_ref.shape[2:], jnp.float32)
+    acc_scratch_ref[batch_idx] = jnp.zeros(
+        acc_scratch_ref.shape[2:], jnp.float32
+    )
+
+  q_seq_idx = pl.program_id(2)
+  if causal:
+    should_run = below_or_on_diag(q_seq_idx, block_q, kv_seq_idx, block_k_major)
+  else:
+    should_run = True
+
+  @pl.when(should_run)
+  def run():
+    @pl.loop(0, block_k_major, step=block_k, unroll=True)
+    def _body(start_k):
+      m_prev = m_scratch_ref[batch_idx]
+      l_prev = l_scratch_ref[batch_idx]
+      q = q_tile_ref[batch_idx]  # [block_q, head_dim]
+      k = k_tile_ref[
+          (*batch_idx, pl.dslice(start_k, block_k), slice(None))
+      ]  # [block_k, head_dim]
+
+      s = jax.lax.dot_general(
+          q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+      )  # [block_q, block_k]
+
+      # Add attention bias if needed.
+      # TODO(tanburn) Should the attention bias be added before or after
+      # multiplication by sm_scale?
+      if ab_tile_ref is not None:
+        ab = ab_tile_ref[
+            (*batch_idx, pl.dslice(None), pl.dslice(start_k, block_k))
+        ].astype(jnp.float32)
+        s += ab
+
+      if sm_scale != 1.0:
+        s *= sm_scale
+
+      mask = None
+      if q_segment_ids_tile_ref is not None:
+        repeats, rem = divmod(block_k, NUM_LANES)
+        if rem:
+          raise NotImplementedError(
+              f"kv block size must be a multiple of {NUM_LANES}"
+          )
+        q_segment_ids = jnp.tile(
+            q_segment_ids_tile_ref[batch_idx[0]], (1, repeats)
+        )  # [block_q, block_k].
+        kv_segment_ids = kv_segment_ids_tile_ref[
+            batch_idx[0], :1, pl.dslice(start_k, block_k)
+        ]  # [1, block_k].
+        mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+      if causal:
+        mask_shape = (block_q, block_k)
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        row_ids += q_seq_idx * block_q
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        col_ids += kv_seq_idx * block_k_major + start_k
+        causal_mask = col_ids <= row_ids
+        mask = (
+            causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+        )
+
+      s = s if mask is None else s + jnp.where(mask, 0.0, mask_value)
+
+      m_curr = jnp.max(s, axis=1)[:, None]  # Row max, shape [block_q, 1].
+      m_next = jnp.maximum(m_prev, m_curr)  # Shape [block_q, 128].
+
+      block_k_repeats, rem = divmod(block_k, MIN_BLOCK_SIZE)
+      if rem:
+        raise NotImplementedError(
+            f"{block_k=} should be a multiple of {MIN_BLOCK_SIZE}"
+        )
+      p = jnp.exp(s - jnp.tile(m_next, (1, block_k_repeats)))
+
+      alpha = jnp.exp(m_prev - m_next)  # Shape [block_q, 128].
+
+      l_corr = alpha * l_prev
+
+      l_next = jnp.sum(p, axis=1)[:, None] + l_corr  # Shape [block_q, 128]
+
+      head_dim_repeats, rem = divmod(head_dim, MIN_BLOCK_SIZE)
+      l_broadcast = lambda l: jnp.tile(l, (1, head_dim_repeats))
+      if rem:
+        if head_dim_repeats == 0:
+          l_broadcast = lambda l: l[:, :head_dim]
+        else:
+          raise NotImplementedError(
+              f"{head_dim=} should be a multiple of {MIN_BLOCK_SIZE} if larger"
+          )
+      l_scratch_ref[batch_idx] = l_next
+      m_scratch_ref[batch_idx] = m_next
+
+      l_next_inv_safe = jnp.where(l_next == 0.0, 1.0, 1.0 / l_next)
+      acc_scratch_ref[batch_idx] *= l_broadcast(l_corr * l_next_inv_safe)
+      v = v_tile_ref[(*batch_idx, pl.dslice(start_k, block_k), slice(None))]
+      o_curr = jax.lax.dot(
+          p.astype(v.dtype), v, preferred_element_type=jnp.float32
+      )
+      acc_scratch_ref[batch_idx] += o_curr * l_broadcast(l_next_inv_safe)
+
+  @pl.when(kv_seq_idx == (kv_seq_len // block_k_major) - 1)
+  def store_output():
+    o_tile_ref[batch_idx] = acc_scratch_ref[batch_idx].astype(o_tile_ref.dtype)
+    if l_ref is not None:
+      l_ref[batch_idx] = l_scratch_ref[batch_idx].astype(l_ref.dtype)
+    if m_ref is not None:
+      m_ref[batch_idx] = m_scratch_ref[batch_idx].astype(m_ref.dtype)
+
+
+def _flash_attention_kernel_single_batch_single_step(
+    batch_idx: tuple[int, ...],
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,  # Input arrays
+    o_tile_ref,  # Output arrays
+    l_ref: Any | None = None,
+    m_ref: Any | None = None,
+    *,
+    causal,
+    sm_scale,
+    block_k,
+    kv_seq_len,
+    mask_value,
+):
+  block_k_major = k_tile_ref.shape[2]
+  block_q = q_tile_ref.shape[2]
+
+  assert kv_seq_len == block_k_major == block_k
+
+  q = q_tile_ref[batch_idx]  # [block_q, head_dim]
+  k = k_tile_ref[batch_idx]  # [block_k, head_dim]
+  s = jax.lax.dot_general(
+      q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+  )  # [block_q, block_k]
+
+  if ab_tile_ref is not None:
+    s += ab_tile_ref[batch_idx].astype(jnp.float32)
+  if sm_scale != 1.0:
+    s *= sm_scale
+
+  mask = None
+  if q_segment_ids_tile_ref is not None:
+    repeats, rem = divmod(block_k, NUM_LANES)
+    if rem:
+      raise NotImplementedError(
+          f"kv block size must be a multiple of {NUM_LANES}"
+      )
+    q_segment_ids = q_segment_ids_tile_ref[
+        batch_idx[0]
+    ]  # [block_q, NUM_LANES].
+    q_segment_ids = jnp.tile(
+        q_segment_ids, (1, repeats)
+    )  # [block_q, block_k].
+    kv_segment_ids = kv_segment_ids_tile_ref[batch_idx[0], :1]  # [1, block_k].
+    mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+  if causal:
+    q_seq_idx = pl.program_id(2)
+    mask_shape = (block_q, block_k)
+    row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+    row_ids += q_seq_idx * block_q
+    col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+    causal_mask = col_ids <= row_ids
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+  s = s if mask is None else s + jnp.where(mask, 0.0, mask_value)
+
+  m = jnp.max(s, axis=1)[:, None]
+  p = jnp.exp(s - m)
+  l = jnp.sum(p, axis=1)[:, None]
+  p /= l
+
+  if m_ref is not None:
+    m_ref[batch_idx] = lax.broadcast_in_dim(m, m_ref.shape[2:], range(2))
+  if l_ref is not None:
+    l_ref[batch_idx] = lax.broadcast_in_dim(l, l_ref.shape[2:], range(2))
+
+  v = v_tile_ref[batch_idx]
+  o_tile_ref[batch_idx] = jax.lax.dot(
+      p.astype(v.dtype), v, preferred_element_type=jnp.float32
+  ).astype(o_tile_ref.dtype)
+
+
+def _bytes(x: jax.Array | jax.ShapeDtypeStruct) -> int:
+  return math.prod(x.shape) * x.dtype.itemsize
+
+
+def _fwd_cost_estimate(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    ab: jax.Array | None,
+    segment_ids: SegmentIds | None,
+    *,
+    causal: bool,
+    sm_scale: jax.Array | None,
+    kernel_inputs_specs,
+    kernel_outputs_specs,
+) -> pl.CostEstimate | None:
+  body_cost = pl.estimate_cost(
+    mha_reference,
+    q, k, v, ab, segment_ids, causal=causal, sm_scale=sm_scale
+  )
+  input_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_inputs_specs))
+  output_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_outputs_specs))
+  return pl.CostEstimate(
+      flops=body_cost.flops,
+      transcendentals=body_cost.transcendentals,
+      bytes_accessed=input_bytes + output_bytes,
+  )
+
+
+def _flash_attention_impl(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_b,
+    block_q,
+    block_k_major,
+    block_k,
+    debug,
+):
+  batch_size, num_heads, q_seq_len, head_dim = q.shape
+  _, _, kv_seq_len, _ = k.shape
+  _verify_block("block_q", "q_seq_len", block_q, q_seq_len, should_divide=False)
+  _verify_block("block_k_major", "kv_seq_len", block_k_major, kv_seq_len)
+  _verify_block("block_k", "kv_seq_len", block_k, kv_seq_len)
+  _verify_block("block_b", "batch", block_b, batch_size, should_divide=False)
+
+  # TODO(apaszke): Tile over heads as well.
+  grid = (
+      pl.cdiv(batch_size, block_b),
+      num_heads,
+      pl.cdiv(q_seq_len, block_q),
+      kv_seq_len // block_k_major,
+  )
+
+  def q_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  def kv_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    if causal:
+      # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+      # 0th one to be used for the next block_q rows.
+      next_kv_index = lax.select(
+          below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+          kv_seq_index,
+          0,
+      )
+    else:
+      next_kv_index = kv_seq_index
+    return (batch_index, head_index, next_kv_index, 0)
+
+  def ab_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    if causal:
+      should_run = below_or_on_diag(
+          q_seq_index, block_q, kv_seq_index, block_k_major
+      )
+      # If the ab block is skipped, prefetch the next valid ab block, i.e. the
+      # 0th kv to be used for the next block_q rows.
+      next_q_index = lax.select(
+          should_run,
+          q_seq_index,
+          lax.select(
+              q_seq_index == (q_seq_len // block_q) - 1, 0, q_seq_index + 1
+          ),
+      )
+      next_kv_index = lax.select(should_run, kv_seq_index, 0)
+    else:
+      next_q_index = q_seq_index
+      next_kv_index = kv_seq_index
+
+    return (batch_index, head_index, next_q_index, next_kv_index)
+
+  def o_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  def lm_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  kernel = functools.partial(
+      _flash_attention_kernel,
+      causal=causal,
+      mask_value=DEFAULT_MASK_VALUE,
+      sm_scale=sm_scale,
+      block_k=block_k,
+      kv_seq_len=kv_seq_len,
+  )
+  out_shape = jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype)
+  out_shape = [out_shape]
+  out_specs = [pl.BlockSpec((block_b, 1, block_q, head_dim), o_index_map)]
+
+  if block_k != kv_seq_len:
+    m_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+    l_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+    acc_scratch = pltpu.VMEM((block_b, 1, block_q, head_dim), jnp.float32)
+    scratch_shapes = [m_scratch, l_scratch, acc_scratch]
+  else:
+    scratch_shapes = []
+
+  if save_residuals:
+    out_specs = [
+        *out_specs,
+        pl.BlockSpec((block_b, 1, block_q, MIN_BLOCK_SIZE), lm_index_map),
+        pl.BlockSpec((block_b, 1, block_q, MIN_BLOCK_SIZE), lm_index_map),
+    ]
+    l = jax.ShapeDtypeStruct(
+        (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+    )
+    m = jax.ShapeDtypeStruct(
+        (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+    )
+    out_shape = (*out_shape, l, m)
+  else:
+    out_specs = [*out_specs, None, None]
+    out_shape = (*out_shape, None, None)
+
+  ab_block_spec = (
+      pl.BlockSpec((block_b, 1, block_q, block_k_major), ab_index_map)
+      if ab is not None else None)
+
+  q_segment_ids_spec = kv_segment_ids_spec = None
+  q_segment_ids = kv_segment_ids = None
+  if segment_ids is not None:
+
+    def q_segment_ids_index_map(batch_index, head_index, q_seq_index, _):
+      del head_index
+      return (batch_index, q_seq_index, 0)
+
+    def kv_segment_ids_index_map(
+        batch_index, head_index, q_seq_index, kv_seq_index
+    ):
+      del head_index
+      if causal:
+        next_kv_index = lax.select(
+            below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+            kv_seq_index,
+            0,
+        )
+      else:
+        next_kv_index = kv_seq_index
+      return (batch_index, 0, next_kv_index)
+
+    q_segment_ids_spec = pl.BlockSpec(
+        (block_b, block_q, NUM_LANES), q_segment_ids_index_map
+    )
+    kv_segment_ids_spec = pl.BlockSpec(
+        (block_b, NUM_SUBLANES, block_k_major), kv_segment_ids_index_map
+    )
+
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q,
+        (batch_size, q_seq_len, NUM_LANES),
+        (
+            0,
+            1,
+        ),
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv,
+        (batch_size, NUM_SUBLANES, kv_seq_len),
+        (
+            0,
+            2,
+        ),
+    )
+
+  in_specs = [
+      pl.BlockSpec((block_b, 1, block_q, head_dim), q_index_map),
+      pl.BlockSpec((block_b, 1, block_k_major, head_dim), kv_index_map),
+      pl.BlockSpec((block_b, 1, block_k_major, head_dim), kv_index_map),
+      ab_block_spec,
+      q_segment_ids_spec,
+      kv_segment_ids_spec,
+  ]
+
+  o, *aux = pl.pallas_call(
+      kernel,
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          num_scalar_prefetch=0,
+          grid=grid,
+          in_specs=in_specs,
+          out_specs=out_specs,
+          scratch_shapes=scratch_shapes,
+      ),
+      out_shape=out_shape,
+      debug=debug,
+      compiler_params=pltpu.CompilerParams(
+          dimension_semantics=(
+              "parallel",
+              "parallel",
+              "parallel",
+              "arbitrary",
+          )
+      ),
+      cost_estimate=_fwd_cost_estimate(
+          q,
+          k,
+          v,
+          ab,
+          segment_ids,
+          causal=causal,
+          sm_scale=sm_scale,
+          kernel_inputs_specs=(q, k, v, ab, q_segment_ids, kv_segment_ids),
+          kernel_outputs_specs=out_shape,
+      ),
+  )(q, k, v, ab, q_segment_ids, kv_segment_ids)
+  if save_residuals:
+    l, m = (v[..., 0] for v in aux[-2:])
+    return (o, l, m)
+  else:
+    return o
+
+
+def _flash_attention_dkv_kernel(
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,
+    l_tile_ref,
+    m_tile_ref,
+    do_tile_ref,
+    di_tile_ref,
+    dk_tile_ref,
+    dv_tile_ref,
+    dk_scratch_ref,
+    dv_scratch_ref,
+    *,
+    sm_scale: float,
+    causal: bool,
+    mask_value: float,
+    q_seq_len: int,
+    block_q: int,
+    block_k: int,
+):
+  _, _, block_q_major, _ = q_tile_ref.shape
+  _, _, block_k_major, _ = k_tile_ref.shape
+
+  q_seq_index = pl.program_id(axis=3)
+  kv_seq_index = pl.program_id(axis=2)
+
+  @pl.when(q_seq_index == 0)
+  def start_new_sequence():
+    dk_scratch_ref[:, :] = jnp.zeros(dk_scratch_ref.shape, dk_scratch_ref.dtype)
+    dv_scratch_ref[:, :] = jnp.zeros(dv_scratch_ref.shape, dv_scratch_ref.dtype)
+
+  def q_body(j, _):
+    start_q = j * block_q
+    def k_body(i, _):
+      start_k = i * block_k
+      k = k_tile_ref[0, 0, pl.ds(start_k, block_k), :]
+      v = v_tile_ref[0, 0, pl.ds(start_k, block_k), :]
+      q = q_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, head_dim]
+      l = l_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, 128]
+      m = m_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, 128]
+      do = do_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, 128]
+      di = di_tile_ref[0, 0, pl.ds(start_q, block_q), :].astype(
+          jnp.float32
+      )  # [block_q, 128]
+
+      capped_logits = lax.dot_general(
+          q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+      )  # [block_q_major, block_k]
+
+      if ab_tile_ref is not None:
+        ab = ab_tile_ref[
+            0,
+            0,
+            pl.dslice(j * block_q, block_q),
+            pl.dslice(i * block_k, block_k),
+        ].astype(jnp.float32)
+        capped_logits += ab
+
+      if sm_scale != 1.0:
+        capped_logits *= sm_scale
+
+      mask = None
+      if q_segment_ids_tile_ref is not None:
+        repeats, rem = divmod(block_k, NUM_LANES)
+        if rem:
+          raise NotImplementedError(
+          )
+        q_segment_ids = q_segment_ids_tile_ref[
+            0, pl.ds(start_q, block_q), :
+        ]  # [block_q, NUM_LANES].
+        q_segment_ids = jnp.tile(
+            q_segment_ids, (1, repeats)
+        )  # [block_q, block_k].
+        kv_segment_ids = kv_segment_ids_tile_ref[
+            :, 0, pl.ds(start_k, block_k)
+        ]  # [1, block_k].
+        mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+      if causal:
+        mask_shape = (block_q, block_k)
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        row_ids += q_seq_index * block_q_major + start_q
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        col_ids += kv_seq_index * block_k_major + start_k
+        causal_mask = col_ids <= row_ids
+        mask = (
+            causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+        )
+
+      capped_logits = (
+          capped_logits
+          if mask is None
+          else capped_logits + jnp.where(mask, 0.0, mask_value)
+      )
+
+      p = jnp.exp(
+          capped_logits - jnp.tile(m, (1, block_k // MIN_BLOCK_SIZE))
+      )
+      p = p * jnp.tile(
+          1 / l, (1, block_k // MIN_BLOCK_SIZE)
+      )  # [block_q_major, block_k_major]
+      dv = lax.dot(p.T.astype(do.dtype), do, preferred_element_type=jnp.float32)
+      dv_scratch_ref[pl.ds(start_k, block_k), :] += dv.astype(
+          dv_scratch_ref.dtype
+      )
+
+      # di: [block_q, 128]
+      # do: [block_q, head_dim]
+      # v: [block_k_major, head_dim]
+      dp = lax.dot_general(
+          do, v, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+      )
+      ds = (dp - jnp.tile(di, (1, block_k // MIN_BLOCK_SIZE))) * p
+
+      if sm_scale != 1.0:
+        ds = ds * sm_scale
+
+      # ds: [block_q_major, block_k_major]
+      # q: [block_q_major, head_dim]
+      dk = lax.dot(ds.T.astype(do.dtype), q, preferred_element_type=jnp.float32)
+      dk_scratch_ref[pl.ds(start_k, block_k), :] += dk.astype(
+          dk_scratch_ref.dtype
+      )
+    lax.fori_loop(0, block_k_major // block_k, k_body, None, unroll=True)
+
+  if causal:
+    should_run = below_or_on_diag(
+        q_seq_index, block_q_major, kv_seq_index, block_k_major
+    )
+  else:
+    should_run = True
+
+  @pl.when(should_run)
+  def run():
+    lax.fori_loop(0, block_q_major // block_q, q_body, None, unroll=True)
+
+  @pl.when(q_seq_index == q_seq_len // block_q_major - 1)
+  def end_of_q_sequence():
+    dv_tile_ref[0, 0, :, :] = dv_scratch_ref[...].astype(dv_tile_ref.dtype)
+    dk_tile_ref[0, 0, :, :] = dk_scratch_ref[...].astype(dk_tile_ref.dtype)
+
+
+def _flash_attention_bwd_dkv(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    l,
+    m,
+    do,
+    di,
+    *,
+    block_q_major: int | None,
+    block_q: int | None,
+    block_k_major: int | None,
+    block_k: int | None,
+    sm_scale: float,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    debug: bool = False,
+):
+  batch_size, num_heads, q_seq_len, head_dim = q.shape
+  _, _, kv_seq_len, _ = k.shape
+  _verify_block("block_q_major_dkv", "q_seq_len", block_q_major, q_seq_len)
+  _verify_block("block_q_dkv", "q_seq_len", block_q, q_seq_len)
+  _verify_block("block_k_major_dkv", "kv_seq_len", block_k_major, kv_seq_len)
+  _verify_block("block_k_dkv", "kv_seq_len", block_k, kv_seq_len)
+
+  # Broadcast out scalar values
+  m = jnp.broadcast_to(m[..., None], (*m.shape, MIN_BLOCK_SIZE))
+  l = jnp.broadcast_to(l[..., None], (*l.shape, MIN_BLOCK_SIZE))
+  # Preprocess contraction for bwd pass
+  di = jnp.broadcast_to(di[..., None], (*di.shape, MIN_BLOCK_SIZE))
+
+  # kv index needs to be before q index since q index is the contractng
+  # dimension.
+  grid = (
+      batch_size,
+      num_heads,
+      kv_seq_len // block_k_major,
+      q_seq_len // block_q_major,
+  )
+
+  def qo_index_map(batch_index, head_index, kv_seq_index, q_seq_index):
+    if causal:
+      # If the q block is skipped, stay at the 0th q block.
+      next_q_index = lax.select(
+          below_or_on_diag(
+              q_seq_index, block_q_major, kv_seq_index, block_k_major
+          ),
+          q_seq_index,
+          0,
+      )
+    else:
+      next_q_index = q_seq_index
+
+    return (batch_index, head_index, next_q_index, 0)
+
+  qo_spec = pl.BlockSpec((1, 1, block_q_major, head_dim), qo_index_map)
+  assert qo_spec.block_shape is not None
+  assert q.ndim == len(qo_spec.block_shape)
+  do_spec = qo_spec
+  assert do.ndim == len(qo_spec.block_shape)
+
+  def kv_index_map(batch_index, head_index, kv_seq_index, _):
+    return (batch_index, head_index, kv_seq_index, 0)
+
+  kv_spec = pl.BlockSpec((1, 1, block_k_major, head_dim), kv_index_map)
+  assert kv_spec.block_shape is not None
+  assert k.ndim == len(kv_spec.block_shape)
+  assert v.ndim == len(kv_spec.block_shape)
+
+  def lm_index_map(batch_index, head_index, _, q_seq_index):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  lm_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), lm_index_map)
+  assert lm_spec.block_shape is not None
+  assert l.ndim == len(lm_spec.block_shape)
+  assert m.ndim == len(lm_spec.block_shape)
+
+  di_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), qo_index_map)
+  assert di_spec.block_shape is not None
+  assert di.ndim == len(di_spec.block_shape)
+
+  def ab_index_map(batch_index, head_index, kv_seq_index, q_seq_index):
+    return (batch_index, head_index, q_seq_index, kv_seq_index)
+
+  dab_spec = (
+      pl.BlockSpec((1, 1, block_q_major, block_k_major), ab_index_map)
+      if ab is not None
+      else None
+  )
+
+  q_segment_ids_spec = kv_segment_ids_spec = None
+  q_segment_ids = kv_segment_ids = None
+  if segment_ids is not None:
+
+    def q_segment_ids_index_map(
+        batch_index, head_index, kv_seq_index, q_seq_index
+    ):
+      del head_index
+      if causal:
+        next_q_index = lax.select(
+            below_or_on_diag(
+                q_seq_index, block_q_major, kv_seq_index, block_k_major
+            ),
+            q_seq_index,
+            0,
+        )
+      else:
+        next_q_index = q_seq_index
+      return (batch_index, next_q_index, 0)
+
+    def kv_segment_ids_index_map(batch_index, head_index, kv_seq_index, _):
+      del head_index
+      return (batch_index, 0, kv_seq_index)
+
+    q_segment_ids_spec = pl.BlockSpec(
+        (1, block_q_major, NUM_LANES), q_segment_ids_index_map
+    )
+    kv_segment_ids_spec = pl.BlockSpec(
+        (1, NUM_SUBLANES, block_k_major), kv_segment_ids_index_map
+    )
+
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q,
+        (batch_size, q_seq_len, NUM_LANES),
+        (
+            0,
+            1,
+        ),
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv,
+        (batch_size, NUM_SUBLANES, kv_seq_len),
+        (
+            0,
+            2,
+        ),
+    )
+
+  in_specs = [
+      qo_spec,
+      kv_spec,
+      kv_spec,
+      dab_spec,
+      q_segment_ids_spec,
+      kv_segment_ids_spec,
+      lm_spec,
+      lm_spec,
+      do_spec,
+      di_spec,
+  ]
+
+  out_shapes = [
+      jax.ShapeDtypeStruct((batch_size, num_heads, kv_seq_len, head_dim),
+                           k.dtype),
+      jax.ShapeDtypeStruct((batch_size, num_heads, kv_seq_len, head_dim),
+                           v.dtype),
+  ]
+  def dkv_index_map(batch_index, head_index, kv_seq_index, _):
+    return (batch_index, head_index, kv_seq_index, 0)
+
+  dkv_spec = pl.BlockSpec((1, 1, block_k_major, head_dim), dkv_index_map)
+  out_specs = [dkv_spec, dkv_spec]
+  scratch_shapes = [
+      pltpu.VMEM((block_k_major, head_dim), jnp.float32),  # type: ignore
+      pltpu.VMEM((block_k_major, head_dim), jnp.float32),  # type: ignore
+  ]
+
+  kernel = functools.partial(
+      _flash_attention_dkv_kernel,
+      block_q=block_q,  # type: ignore
+      block_k=block_k,  # type: ignore
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=mask_value,
+      q_seq_len=q_seq_len,
+  )
+  name_scope = f"flash_mha_bwd_dkv_{block_q_major=}_{block_q=}_{block_k_major=}_{block_k=}"
+  with jax.named_scope(name_scope):
+    dk, dv = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            grid=grid,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            scratch_shapes=scratch_shapes,
+        ),
+        out_shape=out_shapes,
+        debug=debug,
+        compiler_params=pltpu.CompilerParams(
+                dimension_semantics=(
+                    "parallel",
+                    "parallel",
+                    "parallel",
+                    "arbitrary",
+                )
+        ),
+    )(q, k, v, ab, q_segment_ids, kv_segment_ids, l, m, do, di)
+    assert dk.shape == k.shape
+    assert dv.shape == v.shape
+  return dk, dv
+
+
+def _flash_attention_dq_kernel(
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,
+    l_tile_ref,
+    m_tile_ref,
+    do_tile_ref,
+    di_tile_ref,
+    dq_tile_ref,
+    ds_tile_ref,
+    dq_scratch_ref,
+    *,
+    sm_scale: float,
+    causal: bool,
+    mask_value: float,
+    kv_seq_len: int,
+    block_k: int,
+):
+  _, _, block_k_major, _ = k_tile_ref.shape
+  _, _, block_q_major, _ = q_tile_ref.shape
+
+  kv_seq_index = pl.program_id(axis=3)
+  q_seq_index = pl.program_id(axis=2)
+
+  @pl.when(kv_seq_index == 0)
+  def start_new_sequence():
+    dq_scratch_ref[:, :] = jnp.zeros(dq_scratch_ref.shape, dq_scratch_ref.dtype)
+
+  def body(i, _):
+    k_slice = pl.ds(i * block_k, block_k)
+    q = q_tile_ref[0, 0, :, :]
+    k = k_tile_ref[0, 0, k_slice, :]  # [block_k, head_dim]
+    v = v_tile_ref[0, 0, k_slice, :]  # [block_k, head_dim]
+    l = l_tile_ref[0, 0, :, :]  # [block_q_major, 128]
+    m = m_tile_ref[0, 0, :, :]  # [block_q_major, 128]
+    do = do_tile_ref[0, 0, :, :]  # [block_q_major, head_dim]
+    di = di_tile_ref[0, 0, :].astype(jnp.float32)  # [block_q_major, 128]
+
+    capped_logits = jax.lax.dot_general(
+        q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+    )
+
+    if ab_tile_ref is not None:
+      ab = ab_tile_ref[0, 0, :, pl.dslice(i * block_k, block_k)].astype(
+          jnp.float32
+      )
+      capped_logits += ab
+
+    if sm_scale != 1.0:
+      capped_logits *= sm_scale
+
+    mask = None
+    if q_segment_ids_tile_ref is not None:
+      repeats, rem = divmod(block_k, NUM_LANES)
+      if rem:
+        raise NotImplementedError(
+            f"kv block size must be a multiple of {NUM_LANES}"
+        )
+      q_segment_ids = jnp.tile(
+          q_segment_ids_tile_ref[0], (1, repeats)
+      )  # [block_q, block_k].
+      kv_segment_ids = kv_segment_ids_tile_ref[:, 0, k_slice]  # [1, block_k].
+      mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+    if causal:
+      mask_shape = (block_q_major, block_k)
+      row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+      row_ids += q_seq_index * block_q_major
+      col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+      col_ids += kv_seq_index * block_k_major + i * block_k
+      causal_mask = col_ids <= row_ids
+      mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+    capped_logits = (
+        capped_logits
+        if mask is None
+        else capped_logits + jnp.where(mask, 0.0, mask_value)
+    )
+
+    p = jnp.exp(
+        capped_logits - jnp.tile(m, (1, block_k // MIN_BLOCK_SIZE))
+    )
+    p = p * jnp.tile(
+        1 / l, (1, block_k // MIN_BLOCK_SIZE)
+    )  # [block_q_major, block_k]
+
+    # di: [block_q_major, 128]
+    # do: [block_q_major, head_dim]
+    # v: [block_k_major, head_dim]
+    dp = jax.lax.dot_general(
+        do,
+        v,
+        TRANS_B_DIM_NUMBERS,
+        preferred_element_type=jnp.float32,
+    )
+    ds = (dp - jnp.tile(di, (1, block_k // MIN_BLOCK_SIZE))) * p
+    # dp = jnp.dot(do, v.T)
+    # ds = (dp - (dp * p).sum(axis=1)[:, None]) * p
+
+    if sm_scale != 1.0:
+      ds = ds * sm_scale
+
+    if ds_tile_ref is not None:
+      ds_tile_ref[0, 0, :, pl.dslice(i * block_k, block_k)] = ds.astype(
+          ds_tile_ref.dtype
+      )
+
+    # dp: [block_q_major, block_k]
+    # k: [block_k, head_dim]
+    dq_scratch_ref[:, :] += lax.dot(
+        ds.astype(k.dtype),
+        k,
+        preferred_element_type=jnp.float32,
+    ).astype(dq_scratch_ref.dtype)
+
+  if causal:
+    should_run = below_or_on_diag(
+        q_seq_index, block_q_major, kv_seq_index, block_k_major
+    )
+    should_not_run = lax.select(should_run, False, True)
+  else:
+    should_run = True
+    should_not_run = False  # type: ignore
+
+  @pl.when(should_run)
+  def run():
+    lax.fori_loop(0, block_k_major // block_k, body, None, unroll=True)
+
+  @pl.when(should_not_run)
+  def zero_out_ds():
+    if ds_tile_ref is not None:
+      ds_tile_ref[...] = jnp.zeros_like(ds_tile_ref)
+
+  @pl.when(kv_seq_index == kv_seq_len // block_k_major - 1)
+  def end_of_kv_sequence():
+    dq_tile_ref[0, 0, :, :] = dq_scratch_ref[...].astype(dq_tile_ref.dtype)
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+
+def _flash_attention_bwd_dq(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    l,
+    m,
+    do,
+    di,
+    *,
+    block_q_major: int | None,
+    block_k_major: int | None,
+    block_k: int | None,
+    sm_scale: float,
+    causal: bool,
+    mask_value: float,
+    debug: bool,
+):
+  batch_size, num_heads, q_seq_len, head_dim = q.shape
+  _, _, kv_seq_len, _ = k.shape
+  _verify_block("block_q_dq", "q_seq_len", block_q_major, q_seq_len)
+  _verify_block("block_k_major_dq", "kv_seq_len", block_k_major, kv_seq_len)
+  _verify_block("block_k_dq", "block_k", block_k, kv_seq_len)
+
+  # Broadcast out scalar values
+  m = jnp.broadcast_to(m[..., None], (*m.shape, MIN_BLOCK_SIZE))
+  l = jnp.broadcast_to(l[..., None], (*l.shape, MIN_BLOCK_SIZE))
+  # Preprocess contraction for bwd pass
+  di = jnp.broadcast_to(di[..., None], (*di.shape, block_k_major))
+
+  grid = (
+      batch_size,
+      num_heads,
+      q_seq_len // block_q_major,
+      kv_seq_len // block_k_major,
+  )
+
+  def qo_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  qo_spec = pl.BlockSpec((1, 1, block_q_major, head_dim), qo_index_map)
+  do_spec = qo_spec
+
+  def kv_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    if causal:
+      # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+      # 0th one to be used for the next block_q rows.
+      next_kv_index = lax.select(
+          below_or_on_diag(
+              q_seq_index, block_q_major, kv_seq_index, block_k_major
+          ),
+          kv_seq_index,
+          0,
+      )
+    else:
+      next_kv_index = kv_seq_index
+    return (batch_index, head_index, next_kv_index, 0)
+
+  kv_spec = pl.BlockSpec((1, 1, block_k_major, head_dim), kv_index_map)
+  assert kv_spec.block_shape is not None
+  assert k.ndim == len(kv_spec.block_shape)
+  assert v.ndim == len(kv_spec.block_shape)
+
+  def lm_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  lm_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), lm_index_map)
+  assert lm_spec.block_shape is not None
+  assert l.ndim == len(lm_spec.block_shape)
+  assert m.ndim == len(lm_spec.block_shape)
+
+  di_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), qo_index_map)
+  assert di_spec.block_shape is not None
+  assert di.ndim == len(di_spec.block_shape)
+
+  def ab_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    return (batch_index, head_index, q_seq_index, kv_seq_index)
+
+  dab_spec = (
+      pl.BlockSpec((1, 1, block_q_major, block_k_major), ab_index_map)
+      if ab is not None
+      else None
+  )
+
+  q_segment_ids_spec = kv_segment_ids_spec = None
+  q_segment_ids = kv_segment_ids = None
+  if segment_ids is not None:
+
+    def q_segment_ids_index_map(batch_index, head_index, q_seq_index, _):
+      del head_index
+      return (batch_index, q_seq_index, 0)
+
+    def kv_segment_ids_index_map(
+        batch_index, head_index, q_seq_index, kv_seq_index
+    ):
+      del head_index
+      if causal:
+        # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+        # 0th one to be used for the next block_q rows.
+        next_kv_index = lax.select(
+            below_or_on_diag(
+                q_seq_index, block_q_major, kv_seq_index, block_k_major
+            ),
+            kv_seq_index,
+            0,
+        )
+      else:
+        next_kv_index = kv_seq_index
+      return (batch_index, 0, next_kv_index)
+
+    q_segment_ids_spec = pl.BlockSpec(
+        (1, block_q_major, NUM_LANES), q_segment_ids_index_map
+    )
+    kv_segment_ids_spec = pl.BlockSpec(
+        (1, NUM_SUBLANES, block_k_major), kv_segment_ids_index_map
+    )
+
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q,
+        (batch_size, q_seq_len, NUM_LANES),
+        (
+            0,
+            1,
+        ),
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv,
+        (batch_size, NUM_SUBLANES, kv_seq_len),
+        (
+            0,
+            2,
+        ),
+    )
+
+  in_specs = [
+      qo_spec,
+      kv_spec,
+      kv_spec,
+      dab_spec,
+      q_segment_ids_spec,
+      kv_segment_ids_spec,
+      lm_spec,
+      lm_spec,
+      do_spec,
+      di_spec,
+  ]
+
+  out_shapes = [
+      jax.ShapeDtypeStruct(q.shape, q.dtype),
+      jax.ShapeDtypeStruct(ab.shape, ab.dtype) if ab is not None else None,
+  ]
+  dq_spec = pl.BlockSpec((1, 1, block_q_major, head_dim), qo_index_map)
+  out_specs = [
+      dq_spec,
+      dab_spec,
+  ]
+  scratch_shapes = [pltpu.VMEM((block_q_major, head_dim), jnp.float32)]  # type: ignore
+
+  kernel = functools.partial(
+      _flash_attention_dq_kernel,
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=mask_value,
+      block_k=block_k,  # type: ignore
+      kv_seq_len=kv_seq_len,
+  )
+  name_scope = f"flash_mha_bwd_dq_{block_q_major=}_{block_k_major=}_{block_k=}"
+  with jax.named_scope(name_scope):
+    dq, ds = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            grid=grid,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            scratch_shapes=scratch_shapes,
+        ),
+        out_shape=out_shapes,
+        debug=debug,
+        compiler_params=pltpu.CompilerParams(
+                dimension_semantics=(
+                    "parallel",
+                    "parallel",
+                    "parallel",
+                    "arbitrary",
+                )
+        ),
+    )(q, k, v, ab, q_segment_ids, kv_segment_ids, l, m, do, di)
+
+  # dab is just ds
+  return dq, ds
+
+
+# For autograd testing.
+def mha_reference_no_custom_vjp(
+    q,
+    k,
+    v,
+    ab: jax.Array | None = None,
+    segment_ids: SegmentIds | None = None,
+    *,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale: float = 1.0,
+    save_residuals: bool = False,
+):
+  logits = jnp.einsum("bhqc,bhkc->bhqk", q, k)
+  if ab is not None:
+    logits += ab
+  if sm_scale != 1.0:
+    logits *= sm_scale
+
+  mask = None
+  if segment_ids is not None:
+    mask = segment_ids.q[:, :, None] == segment_ids.kv[:, None, :]
+    mask = mask[:, None, :, :]
+
+  if causal:
+    _, _, q_seq_len, _ = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    mask_shape = (q_seq_len, kv_seq_len)
+    row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+    col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+    causal_mask = (col_ids <= row_ids)[None, None, :, :]
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+
+  logits = logits if mask is None else logits + jnp.where(mask, 0.0, mask_value)
+
+  m = logits.max(axis=-1)
+  unnormalized = jnp.exp(logits - m[..., None])
+  l = unnormalized.sum(axis=-1)
+  weights = unnormalized / l[..., None]
+  out = jnp.einsum("bhqk,bhkc->bhqc", weights, v)
+  if save_residuals:
+    return out, l, m
+  return out
+
+
+@functools.partial(
+    jax.jit, static_argnames=["causal", "mask_value", "sm_scale"]
+)
+@jax.default_matmul_precision("bfloat16")
+def mha_reference(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None = None,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale=1.0,
+):
+  return _mha_reference(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+      save_residuals=False,
+  )
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnames=("causal", "mask_value", "sm_scale", "save_residuals"))
+def _mha_reference(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+):
+  return mha_reference_no_custom_vjp(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+      save_residuals=save_residuals,
+  )
+
+
+def _mha_reference_fwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+):
+  if save_residuals:
+    raise NotImplementedError
+  res = _mha_reference(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+      save_residuals=True,
+  )
+  assert isinstance(res, tuple)
+  out, l, m = res
+  return out, (q, k, v, ab, segment_ids, out, l, m)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "causal",
+        "mask_value",
+        "sm_scale",
+    ],
+)
+def mha_reference_bwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    o,
+    l,
+    m,
+    do,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale: float = 1.0,
+):
+  if sm_scale != 1.0:
+    raise NotImplementedError
+
+  logits = jnp.einsum(
+      "bhqc,bhkc->bhqk",
+      q.astype(jnp.float32),
+      k.astype(jnp.float32),
+  )
+  if ab is not None:
+    logits += ab
+
+  mask = None
+  if segment_ids is not None:
+    mask = segment_ids.q[:, :, None] == segment_ids.kv[:, None, :]
+    mask = mask[:, None, :, :]
+
+  if causal:
+    _, _, q_seq_len, _ = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    mask_shape = (q_seq_len, kv_seq_len)
+    row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+    col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+    causal_mask = (col_ids <= row_ids)[None, None, :, :]
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+
+  logits = logits if mask is None else logits + jnp.where(mask, 0.0, mask_value)
+
+  unnormalized = jnp.exp(logits - m[..., None])
+  p = unnormalized / l[..., None]
+  dv = jnp.einsum("bhpt,bhpd->bhtd", p, do.astype(jnp.float32)).astype(v.dtype)
+
+  dp = jnp.einsum(
+      "bhpd,bhtd->bhpt", do.astype(jnp.float32), v.astype(jnp.float32)
+  )
+
+  di = jnp.sum(o.astype(jnp.float32) * do.astype(jnp.float32), axis=-1)[
+      ..., None
+  ]  # [batch_size, num_heads, q_seq_len]
+
+  ds = (dp - di) * p
+  dk = jnp.einsum("bhsd,bhst->bhtd", q.astype(jnp.float32), ds).astype(k.dtype)
+  dq = jnp.einsum("bhst,bhtd->bhsd", ds, k.astype(jnp.float32)).astype(q.dtype)
+
+  # dab is just ds
+  dab = ds if ab is not None else None
+  return dq, dk, dv, dab
+
+
+def _mha_reference_bwd(
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+    residuals,
+    do,
+):
+  del save_residuals
+  q, k, v, ab, segment_ids, o, l, m = residuals
+  dq, dk, dv, dab = mha_reference_bwd(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      o,
+      l,
+      m,
+      do,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+  )
+  return dq, dk, dv, dab, None
+
+
+_mha_reference.defvjp(fwd=_mha_reference_fwd, bwd=_mha_reference_bwd)
+
+
+def _verify_block(block_name, dim_name, block, dim, should_divide=True):
+  if block > dim:
+    raise ValueError(
+        f"{block_name}={block} should be smaller or equal to {dim_name}={dim}"
+    )
+  if should_divide and dim % block != 0:
+    raise ValueError(
+        f"{dim_name}={dim} should be divisible by {block_name}={block}"
+    )
+
+
+CONFIG = {
+    'name': 'pallas_flash_attention_llama70b',
+    'model': 'Llama-3.1-70B',
+    'operator': 'pallas_flash_attention',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_heads': 64,
+    'head_dim': 128,
+    'atol': 2e-3,
+    'rtol': 2e-3,
+}
+
+# Tuned by autotune_block_sizes.py. Re-run to update.
+TUNED_PARAMS = {
+    # Autotuned (forward pass).
+    'block_q': 2048,
+    'block_k_major': 2048,
+    'block_k': 1024,
+    # Not autotuned (batch=1, backward-only).
+    'block_b': 1,
+    'block_q_major_dkv': 128,
+    'block_k_major_dkv': 128,
+    'block_k_dkv': 128,
+    'block_q_dkv': 128,
+    'block_k_major_dq': 128,
+    'block_k_dq': 128,
+    'block_q_dq': 128,
+}
+
+
+def get_flops():
+    B, S = CONFIG['batch'], CONFIG['seq_len']
+    H, D = CONFIG['num_heads'], CONFIG['head_dim']
+    return 4 * B * H * S * S * D
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    B = CONFIG['batch']
+    H = CONFIG['num_heads']
+    S = CONFIG['seq_len']
+    D = CONFIG['head_dim']
+    q = jax.random.normal(k1, (B, H, S, D), dtype=dtype)
+    k = jax.random.normal(k2, (B, H, S, D), dtype=dtype)
+    v = jax.random.normal(k3, (B, H, S, D), dtype=dtype)
+    return q, k, v
+
+
+def workload(q, k, v):
+    sm_scale = 1.0 / math.sqrt(CONFIG['head_dim'])
+    block_sizes = BlockSizes(
+        block_q=TUNED_PARAMS['block_q'],
+        block_k_major=TUNED_PARAMS['block_k_major'],
+        block_k=TUNED_PARAMS['block_k'],
+        block_b=TUNED_PARAMS['block_b'],
+        block_q_major_dkv=TUNED_PARAMS['block_q_major_dkv'],
+        block_k_major_dkv=TUNED_PARAMS['block_k_major_dkv'],
+        block_k_dkv=TUNED_PARAMS['block_k_dkv'],
+        block_q_dkv=TUNED_PARAMS['block_q_dkv'],
+        block_k_major_dq=TUNED_PARAMS['block_k_major_dq'],
+        block_k_dq=TUNED_PARAMS['block_k_dq'],
+        block_q_dq=TUNED_PARAMS['block_q_dq'],
+    )
+    return flash_attention(
+        q, k, v, causal=True, sm_scale=sm_scale, block_sizes=block_sizes,
+    )
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator', 'atol', 'rtol')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/20k_Gemm_Multiply_LeakyReLU/baseline.py
+++ b/JAXBench/benchmark/20k_Gemm_Multiply_LeakyReLU/baseline.py
@@ -1,0 +1,62 @@
+"""12_Gemm_Multiply_LeakyReLU — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '12_Gemm_Multiply_LeakyReLU',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'multiplier': 2.0,
+    'negative_slope': 0.1,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Gemm + Multiply + LeakyReLU."""
+    x = jnp.matmul(x, weight) + bias
+    x = x * 2.0
+    x = jnp.where(x >= 0, x, x * 0.1)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/21k_Gemm_Divide_Sum_Scaling/baseline.py
+++ b/JAXBench/benchmark/21k_Gemm_Divide_Sum_Scaling/baseline.py
@@ -1,0 +1,67 @@
+"""14_Gemm_Divide_Sum_Scaling — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+import jax.lax as lax
+
+CONFIG = {
+    'name': '14_Gemm_Divide_Sum_Scaling',
+    'batch_size': 4096,
+    'input_size': 8192,
+    'hidden_size': 8192,
+    'scaling_factor': 1.5,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    k1, k2 = jax.random.split(key)
+    x = jax.random.uniform(k1, (4096, 8192), dtype=dtype)
+    weight = jax.random.normal(k2, (8192, 8192), dtype=dtype)
+    return x, weight
+
+
+def workload(x, weight):
+    """Gemm + Divide + Sum + Scaling."""
+    x = lax.dot_general(
+        x, weight.T,
+        dimension_numbers=(((1,), (0,)), ((), ())),
+        precision=lax.Precision.HIGHEST
+    )
+    x = x / 2.0
+    x = jnp.sum(x, axis=1, keepdims=True)
+    x = x * 1.5
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/22k_Conv2d_InstanceNorm_Divide/baseline.py
+++ b/JAXBench/benchmark/22k_Conv2d_InstanceNorm_Divide/baseline.py
@@ -1,0 +1,83 @@
+"""17_Conv2d_InstanceNorm_Divide — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '17_Conv2d_InstanceNorm_Divide',
+    'batch_size': 128,
+    'in_channels': 64,
+    'out_channels': 128,
+    'kernel_size': 3,
+    'divide_by': 2.0,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_channels, out_channels, kernel_size = 128, 64, 128, 3
+    height = width = 128
+    x = jax.random.uniform(key, (batch_size, in_channels, height, width), dtype=dtype)
+    weight = jnp.zeros((out_channels, in_channels, kernel_size, kernel_size), dtype=dtype)
+    conv_bias = jnp.zeros(out_channels, dtype=dtype)
+    in_weight = jnp.ones(out_channels, dtype=dtype)
+    in_bias = jnp.zeros(out_channels, dtype=dtype)
+    return x, weight, conv_bias, in_weight, in_bias
+
+
+def workload(x, weight, conv_bias, in_weight, in_bias):
+    """Conv2d + InstanceNorm + Divide."""
+    # Conv2d
+    x_nhwc = jnp.transpose(x, (0, 2, 3, 1))
+    kernel = jnp.transpose(weight, (2, 3, 1, 0))
+    x = jax.lax.conv_general_dilated(
+        x_nhwc, kernel,
+        window_strides=(1, 1),
+        padding='VALID',
+        dimension_numbers=('NHWC', 'HWIO', 'NHWC')
+    )
+    x = x + conv_bias.reshape(1, 1, 1, -1)
+    x = jnp.transpose(x, (0, 3, 1, 2))  # NHWC -> NCHW
+
+    # Instance Normalization
+    mean = jnp.mean(x, axis=(2, 3), keepdims=True)
+    var = jnp.var(x, axis=(2, 3), keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + 1e-5)
+    x = x * in_weight.reshape(1, -1, 1, 1) + in_bias.reshape(1, -1, 1, 1)
+
+    # Divide
+    x = x / 2.0
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/23k_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp/baseline.py
+++ b/JAXBench/benchmark/23k_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp/baseline.py
@@ -1,0 +1,63 @@
+"""18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Sum + Max + AvgPool + LogSumExp + LogSumExp."""
+    x = jnp.matmul(x, weight.T) + bias
+    x = jnp.sum(x, axis=1, keepdims=True)
+    x = jnp.max(x, axis=1, keepdims=True)
+    x = jnp.mean(x, axis=1, keepdims=True)
+    x = jax.scipy.special.logsumexp(x, axis=1, keepdims=True)
+    x = jax.scipy.special.logsumexp(x, axis=1, keepdims=True)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/24k_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish/baseline.py
+++ b/JAXBench/benchmark/24k_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish/baseline.py
@@ -1,0 +1,68 @@
+"""22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish',
+    'batch_size': 4096,
+    'input_size': 8192,
+    'hidden_size': 8192,
+    'scale_factor': 2.0,
+    'clamp_min': -10.0,
+    'clamp_max': 10.0,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Scale + ResidualAdd + Clamp + LogSumExp + Mish."""
+    x = jnp.matmul(x, weight.T) + bias
+    x = x * 2.0
+    x = x + x
+    x = jnp.clip(x, -10.0, 10.0)
+    x = jax.scipy.special.logsumexp(x, axis=1, keepdims=True)
+    softplus_x = jnp.logaddexp(x, 0.0)
+    mish_x = x * jnp.tanh(softplus_x)
+    x = x * mish_x
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/25k_Conv3d_GroupNorm_Mean/baseline.py
+++ b/JAXBench/benchmark/25k_Conv3d_GroupNorm_Mean/baseline.py
@@ -1,0 +1,88 @@
+"""23_Conv3d_GroupNorm_Mean — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '23_Conv3d_GroupNorm_Mean',
+    'batch_size': 128,
+    'in_channels': 3,
+    'out_channels': 24,
+    'kernel_size': 3,
+    'num_groups': 8,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_channels, out_channels, kernel_size, num_groups = 128, 3, 24, 3, 8
+    D, H, W = 24, 32, 32
+    x = jax.random.uniform(key, (batch_size, in_channels, D, H, W), dtype=dtype)
+    weight = jnp.zeros((out_channels, in_channels, kernel_size, kernel_size, kernel_size), dtype=dtype)
+    conv_bias = jnp.zeros(out_channels, dtype=dtype)
+    gamma = jnp.ones(out_channels, dtype=dtype)
+    beta = jnp.zeros(out_channels, dtype=dtype)
+    return x, weight, conv_bias, gamma, beta
+
+
+def workload(x, weight, conv_bias, gamma, beta):
+    """Conv3d + GroupNorm + Mean."""
+    num_groups = 8
+    # Conv3d: NCDHW -> NDHWC
+    x = jnp.transpose(x, (0, 2, 3, 4, 1))
+    kernel = jnp.transpose(weight, (2, 3, 4, 1, 0))
+    x = jax.lax.conv_general_dilated(
+        x, kernel,
+        window_strides=(1, 1, 1),
+        padding='VALID',
+        dimension_numbers=('NDHWC', 'DHWIO', 'NDHWC')
+    )
+    x = x + conv_bias.reshape(1, 1, 1, 1, -1)
+    x = jnp.transpose(x, (0, 4, 1, 2, 3))  # NDHWC -> NCDHW
+
+    # Group Normalization
+    N, C, D, H, W = x.shape
+    G = num_groups
+    x = x.reshape(N, G, C // G, D, H, W)
+    mean = jnp.mean(x, axis=(2, 3, 4, 5), keepdims=True)
+    var = jnp.var(x, axis=(2, 3, 4, 5), keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + 1e-5)
+    x = x.reshape(N, C, D, H, W)
+    x = x * gamma.reshape(1, -1, 1, 1, 1) + beta.reshape(1, -1, 1, 1, 1)
+
+    # Mean across all dims except batch
+    x = jnp.mean(x, axis=(1, 2, 3, 4))
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/26k_BMM_InstanceNorm_Sum_ResidualAdd_Multiply/baseline.py
+++ b/JAXBench/benchmark/26k_BMM_InstanceNorm_Sum_ResidualAdd_Multiply/baseline.py
@@ -1,0 +1,77 @@
+"""28_BMM_InstanceNorm_Sum_ResidualAdd_Multiply — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '28_BMM_InstanceNorm_Sum_ResidualAdd_Multiply',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    k1, k2 = jax.random.split(key)
+    batch_size, in_features, out_features = 4096, 8192, 8192
+    x = jax.random.uniform(k1, (batch_size, in_features), dtype=dtype)
+    y = jax.random.uniform(k2, (batch_size, out_features), dtype=dtype)
+    bmm_weight = jnp.zeros((out_features, in_features), dtype=dtype)
+    bmm_bias = jnp.zeros(out_features, dtype=dtype)
+    in_weight = jnp.ones(out_features, dtype=dtype)
+    in_bias = jnp.zeros(out_features, dtype=dtype)
+    return x, y, bmm_weight, bmm_bias, in_weight, in_bias
+
+
+def workload(x, y, bmm_weight, bmm_bias, in_weight, in_bias):
+    """BMM + InstanceNorm + Sum + ResidualAdd + Multiply."""
+    eps = 1e-5
+    # Linear
+    x = x @ bmm_weight.T + bmm_bias
+
+    # InstanceNorm2d on (N, C, 1, 1)
+    x = jnp.expand_dims(jnp.expand_dims(x, 2), 3)
+    mean = jnp.mean(x, axis=(2, 3), keepdims=True)
+    var = jnp.var(x, axis=(2, 3), keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + eps)
+    x = x * jnp.reshape(in_weight, (1, -1, 1, 1)) + jnp.reshape(in_bias, (1, -1, 1, 1))
+    x = jnp.squeeze(jnp.squeeze(x, axis=3), axis=2)
+
+    # Residual add and multiply
+    x = x + y
+    x = x * y
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/27k_Matmul_Mish_Mish/baseline.py
+++ b/JAXBench/benchmark/27k_Matmul_Mish_Mish/baseline.py
@@ -1,0 +1,60 @@
+"""29_Matmul_Mish_Mish — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '29_Matmul_Mish_Mish',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Mish + Mish."""
+    x = x @ weight + bias
+    x = x * jnp.tanh(jax.nn.softplus(x))  # mish
+    x = x * jnp.tanh(jax.nn.softplus(x))  # mish
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/28k_ConvTranspose3d_LayerNorm_GELU_Scaling/baseline.py
+++ b/JAXBench/benchmark/28k_ConvTranspose3d_LayerNorm_GELU_Scaling/baseline.py
@@ -1,0 +1,114 @@
+"""34_ConvTranspose3d_LayerNorm_GELU_Scaling — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+import jax.lax as lax
+
+CONFIG = {
+    'name': '34_ConvTranspose3d_LayerNorm_GELU_Scaling',
+    'batch_size': 32,
+    'in_channels': 32,
+    'out_channels': 64,
+    'kernel_size': 4,
+    'stride': 2,
+    'padding': 1,
+    'bias': True,
+    'eps': 1e-05,
+    'scaling_factor': 1.0,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    k1, k2 = jax.random.split(key)
+    batch_size, in_channels, out_channels, kernel_size = 32, 32, 64, 4
+    D, H, W = 16, 32, 32
+    x = jax.random.uniform(k1, (batch_size, in_channels, D, H, W), dtype=dtype)
+    conv_weight = jax.random.normal(k2, (in_channels, out_channels, kernel_size, kernel_size, kernel_size), dtype=dtype)
+    conv_bias = jnp.zeros(out_channels, dtype=dtype)
+    ln_weight = jnp.ones(out_channels, dtype=dtype)
+    ln_bias = jnp.zeros(out_channels, dtype=dtype)
+    return x, conv_weight, conv_bias, ln_weight, ln_bias
+
+
+def workload(x, conv_weight, conv_bias, ln_weight, ln_bias):
+    """ConvTranspose3d + LayerNorm + GELU + Scaling."""
+    stride = 2
+    padding = 1
+    kernel_size = 4
+    eps = 1e-5
+    scaling_factor = 1.0
+
+    # NCDHW -> NDHWC
+    x = jnp.transpose(x, (0, 2, 3, 4, 1))
+    kernel = jnp.transpose(conv_weight, (2, 3, 4, 1, 0))
+    kernel = jnp.flip(kernel, axis=(0, 1, 2))
+
+    batch_size, d_in, h_in, w_in, channels = x.shape
+    k = kernel_size
+
+    # Dilate input for transposed conv
+    d_dilated = d_in + (d_in - 1) * (stride - 1)
+    h_dilated = h_in + (h_in - 1) * (stride - 1)
+    w_dilated = w_in + (w_in - 1) * (stride - 1)
+    x_dilated = jnp.zeros((batch_size, d_dilated, h_dilated, w_dilated, channels), dtype=x.dtype)
+    x_dilated = x_dilated.at[:, ::stride, ::stride, ::stride, :].set(x)
+    x = x_dilated
+
+    pad = k - 1 - padding
+    jax_padding = ((pad, pad), (pad, pad), (pad, pad))
+
+    x = lax.conv_general_dilated(
+        x, kernel,
+        window_strides=(1, 1, 1),
+        padding=jax_padding,
+        dimension_numbers=('NDHWC', 'DHWOI', 'NDHWC')
+    )
+    x = x + conv_bias.reshape(1, 1, 1, 1, -1)
+
+    # NDHWC -> NCDHW
+    x = jnp.transpose(x, (0, 4, 1, 2, 3))
+
+    # LayerNorm over last dimension
+    mean = jnp.mean(x, axis=-1, keepdims=True)
+    var = jnp.mean((x - mean) ** 2, axis=-1, keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + eps)
+    x = x * ln_weight + ln_bias
+
+    # GELU + Scaling
+    x = jax.nn.gelu(x)
+    x = x * scaling_factor
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/29k_Matmul_Swish_Sum_GroupNorm/baseline.py
+++ b/JAXBench/benchmark/29k_Matmul_Swish_Sum_GroupNorm/baseline.py
@@ -1,0 +1,77 @@
+"""37_Matmul_Swish_Sum_GroupNorm — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '37_Matmul_Swish_Sum_GroupNorm',
+    'batch_size': 8192,
+    'in_features': 4096,
+    'out_features': 4096,
+    'num_groups': 64,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_features, out_features, num_groups = 8192, 4096, 4096, 64
+    x = jax.random.uniform(key, (batch_size, in_features), dtype=dtype)
+    weight = jnp.zeros((in_features, out_features), dtype=dtype)
+    bias = jnp.zeros(out_features, dtype=dtype)
+    gn_weight = jnp.ones(out_features, dtype=dtype)
+    gn_bias = jnp.zeros(out_features, dtype=dtype)
+    return x, weight, bias, gn_weight, gn_bias
+
+
+def workload(x, weight, bias, gn_weight, gn_bias):
+    """Matmul + Swish + Sum(bias) + GroupNorm."""
+    num_groups = 64
+    out_features = 4096
+    # Linear
+    x = jnp.matmul(x, weight)
+    # Swish
+    x = jax.nn.sigmoid(x) * x
+    # Add bias
+    x = x + bias
+    # GroupNorm
+    group_size = out_features // num_groups
+    x = x.reshape(-1, num_groups, group_size)
+    mean = jnp.mean(x, axis=-1, keepdims=True)
+    var = jnp.var(x, axis=-1, keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + 1e-5)
+    x = x.reshape(-1, out_features)
+    x = x * gn_weight + gn_bias
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/2p_GQA_Attention/baseline.py
+++ b/JAXBench/benchmark/2p_GQA_Attention/baseline.py
@@ -1,0 +1,84 @@
+"""Grouped Query Attention (GQA) — Llama 3.1 405B. Extracted from MaxText."""
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+CONFIG = {
+    'name': 'llama3_405b_gqa',
+    'model': 'Llama-3.1-405B',
+    'operator': 'gqa_attention',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_query_heads': 128,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+    'emb_dim': 16384,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (query, key, value) tensors."""
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    B, S = CONFIG['batch'], CONFIG['seq_len']
+    Hq, Hkv, D = CONFIG['num_query_heads'], CONFIG['num_kv_heads'], CONFIG['head_dim']
+    query = jax.random.normal(k1, (B, S, Hq, D), dtype=dtype)
+    key_t = jax.random.normal(k2, (B, S, Hkv, D), dtype=dtype)
+    value = jax.random.normal(k3, (B, S, Hkv, D), dtype=dtype)
+    return query, key_t, value
+
+
+def workload(query, key, value):
+    """GQA attention: expand KV heads, scaled dot-product with causal mask."""
+    B, S, Hq, D = query.shape
+    Hkv = key.shape[2]
+    G = Hq // Hkv
+    key = jnp.repeat(key[:, :, :, None, :], G, axis=3).reshape(B, S, Hq, D)
+    value = jnp.repeat(value[:, :, :, None, :], G, axis=3).reshape(B, S, Hq, D)
+    q = query.transpose(0, 2, 1, 3)
+    k = key.transpose(0, 2, 1, 3)
+    v = value.transpose(0, 2, 1, 3)
+    scale = D ** -0.5
+    attn = jnp.einsum('bhqd,bhkd->bhqk', q, k) * scale
+    mask = jnp.tril(jnp.ones((S, S)))
+    attn = jnp.where(mask, attn, -1e9)
+    attn = jax.nn.softmax(attn, axis=-1)
+    out = jnp.einsum('bhqk,bhkd->bhqd', attn, v)
+    return out.transpose(0, 2, 1, 3)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, Hq, D = CONFIG['batch'], CONFIG['seq_len'], CONFIG['num_query_heads'], CONFIG['head_dim']
+    flops = B * Hq * S * S * D * 4
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/2p_GQA_Attention/optimized.py
+++ b/JAXBench/benchmark/2p_GQA_Attention/optimized.py
@@ -1,0 +1,2650 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of Sparse Flash Attention, a.k.a. "Splash" attention."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+import dataclasses
+import enum
+import functools
+from typing import Any, Literal, NamedTuple, Optional, Union, overload
+
+import jax
+from jax import ad_checkpoint
+from jax import lax
+from jax import tree_util
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask as mask_lib
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask_info as mask_info_lib
+import jax.numpy as jnp
+import numpy as np
+
+partial = functools.partial
+DEFAULT_MASK_VALUE = -0.7 * float(np.finfo(np.dtype("float32")).max)
+NUM_LANES = 128
+NUM_SUBLANES = 8
+# We predefine some useful dimension numbers for dot_general
+NN_DIM_NUMBERS = (((1,), (0,)), ((), ()))  # standard matmul
+NT_DIM_NUMBERS = (((1,), (1,)), ((), ()))  # RHS transposed
+
+# mypy: ignore-errors
+
+class SegmentIds(NamedTuple):
+  """SegmentIds for Q and KV sequences.
+
+  SegmentIds are a mechanism to ensure that there is no cross-attention between
+  segments (fraction of a sequence) that have been concatenated together into a
+  sequence. Each array is a list of ids (integers). Only tokens with the same
+  id are allowed to attend to each other.
+
+  The static mask (e.g. causal) is "and-ed" with the segment id mask to form
+  the actual attention mask. It is important that the latter does not have any
+  all-zero rows (along dimension kv). Otherwise it would result in a invalid
+  softmax (the denominator would be 0).
+  This condition holds for causal self-attention because in this case segment
+  ids form a block diagonal matrix so at least one element in each row is set.
+  It is easy to break this condition with non-self-attention configurations.
+  Attributes:
+    q: segment ids along the Q sequence
+    kv: segment ids along the KV sequence
+  """
+
+  q: jax.Array  # [q_seq_len]
+  kv: jax.Array  # [kv_seq_len]
+
+
+# Return type of SplashAttention function that implements the custom vjp rule.
+SplashCustomReturnType = Union[
+    # out, no residuals
+    jax.Array,
+    # out, residuals:
+    tuple[jax.Array, tuple[jax.Array,]]
+]
+
+SplashResidualsType = tuple[
+    jax.Array,  # q
+    jax.Array,  # k
+    jax.Array,  # v
+    Optional[SegmentIds],  # segment_ids
+    jax.Array,  # out
+    jax.Array,  # logsumexp
+    Optional[mask_info_lib.MaskInfo],  # dq_mask_info
+    Optional[mask_info_lib.MaskInfo],  # dkv_mask_info
+]
+
+MaskFunctionType = Callable[..., jax.Array]
+
+
+def get_kernel_name(
+    block_metadata: Mapping[str, Any],
+    is_mqa: bool,
+    save_residuals: bool,
+    is_segmented: bool,
+    phase: str,
+) -> str:
+  """Returns a unique name for all SplashAttention kernel variants."""
+  assert phase == "dq" or phase == "dkv" or phase == "fwd"
+  # Saving residuals is supported only for the fwd phase.
+  assert not save_residuals or phase == "fwd"
+  residuals = ""
+  if save_residuals:
+    residuals = "_residuals"
+  elif phase == "fwd":
+    residuals = "_no_residuals"
+  attention_type = "mqa" if is_mqa else "mha"
+  segments = "_segmented" if is_segmented else ""
+  return f"splash_{attention_type}_{phase}{segments}{residuals}_" + "_".join(
+      f"{k}={v}" for k, v in sorted(block_metadata.items())
+  )
+
+
+# Reference attention implementations
+
+
+@overload
+def _attention_reference(
+    mask: jax.Array,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: Literal[False],
+    mask_value: float,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+) -> jax.Array:
+  ...
+
+
+@overload
+def _attention_reference(
+    mask: jax.Array,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: Literal[True],
+    mask_value: float,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+) -> tuple[jax.Array, tuple[jax.Array]]:
+  ...
+
+
+def _attention_reference(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+):
+  return _attention_reference_default(  # pytype: disable=bad-return-type
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value,
+      save_residuals,
+      custom_type,
+      attn_logits_soft_cap,
+  )
+
+
+def _attention_reference_default(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+):
+  del custom_type
+  logits = jnp.einsum("sd,td->st", q.astype(jnp.float32), k.astype(jnp.float32))
+
+  if segment_ids is not None:
+    mask = jnp.logical_and(
+        mask, segment_ids.q[:, None] == segment_ids.kv[None, :]
+    )
+
+  if attn_logits_soft_cap is not None:
+    logits = jnp.tanh(logits / attn_logits_soft_cap)
+    logits = logits * attn_logits_soft_cap
+
+  logits = jnp.where(mask, logits, mask_value)
+  m = logits.max(axis=-1)
+  s = jnp.exp(logits - m[..., None])
+  l = s.sum(axis=-1)
+  s = s / l[..., None]
+
+  o = jnp.einsum("st,td->sd", s, v.astype(jnp.float32))
+
+  logsumexp = m + jnp.log(l)
+  if save_residuals:
+    return o, (logsumexp,)
+  return o
+
+
+def attention_reference(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    *,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    save_residuals: bool = False,
+    custom_type: str = "flash",
+    attn_logits_soft_cap: float | None = None,
+) -> SplashCustomReturnType:
+  return _attention_reference(  # pytype: disable=wrong-arg-types
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      save_residuals=save_residuals,
+      custom_type=custom_type,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+  )
+
+
+def _attention_reference_custom_fwd(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+):
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported.")
+
+  o, (logsumexp,) = _attention_reference(
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      save_residuals=True,
+      custom_type=custom_type,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+  )
+  return o, (mask, q, k, v, segment_ids, o, logsumexp)
+
+
+def _attention_reference_custom_bwd(
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+    res,
+    do: jax.Array,
+) -> tuple[None, jax.Array, jax.Array, jax.Array, None]:
+  del save_residuals
+  mask, q, k, v, segment_ids, o, logsumexp = res
+
+  uncapped_logits = jnp.einsum(
+      "qc,kc->qk", q, k, preferred_element_type=jnp.float32)
+
+  if attn_logits_soft_cap is not None:
+    logits = jnp.tanh(uncapped_logits / attn_logits_soft_cap)
+    logits = logits * attn_logits_soft_cap
+  else:
+    logits = uncapped_logits
+
+  if segment_ids is not None:
+    mask = jnp.logical_and(
+        mask, segment_ids.q[:, None] == segment_ids.kv[None, :]
+    )
+  logits = jnp.where(mask, logits, mask_value)
+
+  p = jnp.exp(logits - logsumexp[..., None])
+  do = do.astype(jnp.float32)  # pytype: disable=attribute-error
+  dv = jnp.einsum("pt,pd->td", p, do).astype(v.dtype)
+  dp = jnp.einsum("pd,td->pt", do, v.astype(jnp.float32))
+
+  # These two ways of computing ds are mathematically equivalent. The first
+  # involves reducing over the head_dim dimension and the second involves
+  # reducing over a sequence dimension. They tend to produce slightly different
+  # numerics.
+  if custom_type == "flash":
+    di = jnp.sum(o.astype(jnp.float32) * do, axis=-1)[..., None]
+  else:
+    di = jnp.einsum("st,st->s", dp, p)[:, None]
+  ds = (dp - di) * p
+  if attn_logits_soft_cap is not None:
+    normalized = uncapped_logits / attn_logits_soft_cap
+    d = jnp.tanh(normalized)
+    g = ds * (1 - d)
+    ds = g + g * d
+  dk = jnp.einsum("sd,st->td", q.astype(jnp.float32), ds).astype(k.dtype)
+  dq = jnp.einsum("st,td->sd", ds, k.astype(jnp.float32)).astype(q.dtype)
+  return None, dq, dk, dv, None
+
+
+_attention_reference_custom = jax.custom_vjp(
+    _attention_reference, nondiff_argnames=(
+    "mask_value", "save_residuals", "custom_type", "attn_logits_soft_cap")
+)
+_attention_reference_custom.defvjp(_attention_reference_custom_fwd,
+                                   _attention_reference_custom_bwd)
+
+
+def attention_reference_custom(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    *,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    save_residuals: bool = False,
+    custom_type: str = "flash",
+    attn_logits_soft_cap: float | None = None,
+):
+  return _attention_reference_custom(
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value,
+      save_residuals,
+      custom_type=custom_type,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+  )
+
+
+def make_attention_reference(
+    mask: mask_lib.Mask | np.ndarray,
+    is_mqa: bool,
+    backward_impl: str = "vanilla",
+    **params: Any,
+) -> Callable:
+  @partial(
+      jax.jit,
+      static_argnames=[
+          "mask_value",
+          "save_residuals",
+          "attn_logits_soft_cap",
+      ],
+  )
+  def _wrapped(
+      mask: jax.Array,
+      q: jax.Array,
+      k: jax.Array,
+      v: jax.Array,
+      segment_ids: SegmentIds | None = None,
+      *,
+      mask_value: float = DEFAULT_MASK_VALUE,
+      save_residuals: bool = False,
+      attn_logits_soft_cap: float | None = None,
+  ):
+    if backward_impl == "custom":
+      attn_impl = partial(
+          attention_reference_custom, custom_type="flash",
+      )
+    elif backward_impl == "custom_vanilla":
+      attn_impl = partial(
+          attention_reference_custom, custom_type="vanilla",
+      )
+    else:
+      attn_impl = attention_reference
+    func = partial(
+        attn_impl,
+        mask_value=mask_value,
+        save_residuals=save_residuals,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        **params,
+    )
+
+    if is_mqa:
+      func = jax.vmap(func, in_axes=(0, 0, None, None, None))
+      is_grouped = False
+    else:
+      # In grouped attention (1 < num_kv_heads && num_kv_heads < num_q_heads).
+      # We interleave the KV heads across the Q heads.
+      # For example: for 8 Q heads and 4 KV heads:
+      # Q head [0, 1] see KV head 0
+      # Q head [2, 3] see KV head 1
+      # Q head [4, 5] see KV head 2
+      # Q head [6, 7] see KV head 3
+      #
+      # The following implementation reshapes Q to expose KV heads and vmaps
+      # Across the Q heads so it is similar to MQA.
+      # Alternatively we can replicate K/V to match Q like so:
+      # k = jnp.repeat(k, q_heads_per_kv_head, axis=0)
+      # v = jnp.repeat(v, q_heads_per_kv_head, axis=0)
+
+      kv_heads = k.shape[0]
+      assert kv_heads == v.shape[0]
+      q_heads, q_seq_len, head_dim = q.shape
+      is_grouped = kv_heads < q_heads
+      if is_grouped:
+        assert q_heads % kv_heads == 0
+        assert mask.shape[0] == q_heads
+        q_heads_per_kv_head = q_heads // kv_heads
+        q = q.reshape((kv_heads, q_heads_per_kv_head, q_seq_len, head_dim))
+        mask = mask.reshape((kv_heads, q_heads_per_kv_head, *mask.shape[1:]))
+
+        # Inner-most vmap: iterate over the q heads.
+        func = jax.vmap(func, in_axes=(0, 0, None, None, None))
+
+      # Outer-most vmap: iterate over the kv heads.
+      func = jax.vmap(func, in_axes=(0, 0, 0, 0, None))
+
+    out = func(mask, q, k, v, segment_ids)
+
+    if is_grouped:
+
+      def reshape_activations(activations):
+        if activations.ndim == 4:  # pytype: disable=attribute-error
+          kv_heads, q_heads_per_kv_head, q_seq_len, head_dim = activations.shape  # pytype: disable=attribute-error
+          return activations.reshape(  # pytype: disable=attribute-error
+              kv_heads * q_heads_per_kv_head, q_seq_len, head_dim
+          )
+        return activations
+
+      def reshape_residuals(residuals):
+        if residuals.ndim == 3:
+          kv_heads, q_heads_per_kv_head, q_seq_len = residuals.shape
+          return residuals.reshape(kv_heads * q_heads_per_kv_head, q_seq_len)
+        return residuals
+
+      if save_residuals:
+        assert isinstance(out, tuple)
+        assert isinstance(out[1], tuple)
+
+        return (reshape_activations(out[0]), (reshape_residuals(out[1][0]),))
+      else:
+        return reshape_activations(out)
+    else:
+      return out
+
+  return functools.partial(_wrapped, jnp.array(mask[:, :, :]))
+
+
+make_masked_mha_reference = partial(make_attention_reference, is_mqa=False)
+make_masked_mqa_reference = partial(make_attention_reference, is_mqa=True)
+
+
+# Splash attention implementation
+
+# We use an IntEnum to make it JSON serializable as regen metadata.
+class QKVLayout(enum.IntEnum):
+  HEAD_DIM_MINOR = enum.auto()  # [..., seq_len, head_dim]
+  SEQ_MINOR = enum.auto()  # [..., head_dim, seq_len]
+
+
+def from_head_minor(vals: tuple[Any, ...], layout: QKVLayout):
+  if layout == QKVLayout.HEAD_DIM_MINOR:
+    return vals
+  return (*vals[:-2], vals[-1], vals[-2])
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BlockSizes:
+  """Tile sizes parameterizing SplashAttention kernels.
+
+  Those parameters have negligible effect on numerics, but affect performance
+  greatly.
+
+  Note that changing the layouts only influences the physical layout that the
+  kernel will enforce. The logical interface to splash attention always takes
+  the head dimension as the minormost one.
+  """
+  block_q: int
+  block_kv: int
+  block_kv_compute: int | None = None
+
+  block_q_dkv: int | None = None
+  block_kv_dkv: int | None = None
+  block_kv_dkv_compute: int | None = None
+
+  block_q_dq: int | None = None
+  block_kv_dq: int | None = None
+
+  use_fused_bwd_kernel: bool = False
+
+  q_layout: QKVLayout = QKVLayout.HEAD_DIM_MINOR
+  k_layout: QKVLayout = QKVLayout.HEAD_DIM_MINOR
+  v_layout: QKVLayout = QKVLayout.HEAD_DIM_MINOR
+
+  def __post_init__(self):
+    if self.block_kv_compute is None:
+      object.__setattr__(self, "block_kv_compute", self.block_kv)
+    if self.block_kv_dkv_compute is None:
+      object.__setattr__(self, "block_kv_dkv_compute", self.block_kv_dkv)
+    if self.use_fused_bwd_kernel:
+      if self.block_q_dq is not None or self.block_kv_dq is not None:
+        raise ValueError(
+            "Block sizes for dq kernel are not needed with a fused kernel."
+        )
+
+  @property
+  def has_backward_blocks(self) -> bool:
+    backward_blocks = (
+        self.block_q_dkv, self.block_kv_dkv, self.block_kv_dkv_compute,
+    )
+    if not self.use_fused_bwd_kernel:
+      backward_blocks += (self.block_q_dq, self.block_kv_dq)
+    return all(b is not None for b in backward_blocks)
+
+  @classmethod
+  def get_default(cls):
+    # TODO(apaszke,sharadmv): Select better parameters based on a heuristic.
+    return BlockSizes(
+        block_q=128,
+        block_kv=128,
+        block_kv_compute=128,
+        block_q_dkv=128,
+        block_kv_dkv=128,
+        block_kv_dkv_compute=128,
+        block_q_dq=128,
+        block_kv_dq=128,
+    )
+
+
+def _next_nonzero(
+    h,
+    i,
+    j,
+    data_next_ref,
+    block_mask_ref,
+    m_next_ref,
+    next_i=False,
+):
+  assert (data_next_ref is None) == (block_mask_ref is None)
+
+  if data_next_ref is None and block_mask_ref is None:
+    # Handle the case in which we have no masking nor next data information.
+    # Simply fetch the next data and apply the mask for every block.
+    assert m_next_ref is None
+    next_data = i if next_i else j
+    return (
+        next_data,
+        None,  # next mask
+        True,  # should run
+        False,  # should not mask
+    )
+
+  assert data_next_ref.shape == block_mask_ref.shape
+  assert m_next_ref is None or data_next_ref.shape[0] == m_next_ref.shape[0]
+
+  # We are working with one head only. Force the head index to 0.
+  if data_next_ref.shape[0] == 1:
+    h = 0
+
+  # When scalar-memory data is of types smaller than int32, then we have to
+  # upcast it back to use it in the kernel.
+
+  to_i32 = lambda x: x.astype(jnp.int32)
+
+  is_nonzero = to_i32(block_mask_ref[h, i, j]) > 0
+  if m_next_ref is None:
+    should_not_mask = True
+    next_m = None
+  else:
+    should_not_mask = to_i32(block_mask_ref[h, i, j]) != 1
+    next_m = to_i32(m_next_ref[h, i, j])
+  next_j = to_i32(data_next_ref[h, i, j])
+  return next_j, next_m, is_nonzero, should_not_mask
+
+
+def _apply_mask_and_soft_cap(
+    qk: jax.Array,
+    mask_value: float,
+    should_not_mask,
+    mask_ref,
+    q_sequence_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    *,
+    attn_logits_soft_cap: float,
+    k_slice: pl.Slice,
+    k_offset: int | jax.Array,
+    bq: int,
+    k_in_lanes=True,
+    mask_function=None,
+) -> jax.Array | tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+  assert mask_ref is None or q_sequence_ref is None
+  assert (q_sequence_ref is None) == (mask_function is None)
+
+  masks = []
+  if mask_ref is not None:
+    if k_in_lanes:
+      mask = mask_ref[:, k_slice]
+    else:
+      mask = mask_ref[k_slice, :]
+
+    masks.append(
+        jnp.bitwise_or(mask, jnp.broadcast_to(should_not_mask, mask.shape))
+    )
+  if mask_function is not None:
+    # Compute the mask using the given q_sequence indices.
+    # KV indices are computed on the fly. This works because we only support Q
+    # sequence sharding. If we wanted to compute Q indices too, then we would
+    # need to keep into account the current shard along Q sequence.
+
+    if k_in_lanes:
+      assert q_sequence_ref.shape == (bq, NUM_LANES)
+
+      k_sequence = k_offset + jax.lax.broadcasted_iota(
+          jnp.int32, (bq, k_slice.size), 1
+      )
+
+      repeats, rem = divmod(k_slice.size, NUM_LANES)
+      assert rem == 0
+      q_sequence = jnp.tile(
+          q_sequence_ref[...], (1, repeats)
+      )  # [bq, k_slice.size]
+    else:
+      assert q_sequence_ref.shape == (NUM_SUBLANES, bq)
+
+      k_sequence = k_offset + jax.lax.broadcasted_iota(
+          jnp.int32, (k_slice.size, bq), 0
+      )
+      q_sequence = q_sequence_ref[:1, :]  # [1, bq]
+      q_sequence = jnp.broadcast_to(q_sequence, (k_slice.size, bq))
+
+    assert q_sequence.shape == k_sequence.shape
+    computed_mask = mask_function(q_sequence, k_sequence)  # pytype: disable=wrong-arg-count
+    if computed_mask.dtype != jnp.dtype(jnp.bool_):
+      raise ValueError(
+          "Mask function must return a boolean-valued array, but got:"
+          f" {computed_mask.dtype}"
+      )
+    masks.append(computed_mask)
+
+  if q_segment_ids_ref is not None:
+    if k_in_lanes:
+      kv_ids = kv_segment_ids_ref[:1, k_slice]  # [1, k_slice]
+      repeats, rem = divmod(kv_ids.shape[1], NUM_LANES)
+      if rem:
+        raise NotImplementedError(f"block_kv must be a multiple of {NUM_LANES}")
+      q_ids = jnp.tile(q_segment_ids_ref[:], (1, repeats))  # [bq, bkv]
+    else:
+      assert bq == q_segment_ids_ref.shape[-1]
+      repeats, rem = divmod(bq, NUM_LANES)
+      if rem:
+        raise NotImplementedError(f"block_q must be a multiple of {NUM_LANES}")
+      kv_ids = jnp.tile(
+          kv_segment_ids_ref[k_slice, :], (1, repeats)
+      )  # [k_slice, bq]
+      q_ids = q_segment_ids_ref[:1, :]  # [1, bq]
+    masks.append(q_ids == kv_ids)
+
+  def cap_logits(logits):
+    if attn_logits_soft_cap is not None:
+      logits = jnp.tanh(qk / attn_logits_soft_cap)
+      return logits * attn_logits_soft_cap
+    else:
+      return logits
+
+  if masks:
+    mask = functools.reduce(jnp.logical_and, masks)
+    qk = cap_logits(qk)
+    qk = jnp.where(mask, qk, mask_value)
+  else:
+    qk = cap_logits(qk)
+  return qk
+
+
+def flash_attention_kernel(
+    # Prefetched inputs
+    data_next_ref,
+    block_mask_ref,
+    mask_next_ref,
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    mask_ref,
+    q_sequence_ref,
+    # Outputs
+    m_scratch_ref,
+    l_scratch_ref,
+    o_scratch_ref,
+    o_ref,
+    logsumexp_ref=None,
+    *,
+    mask_value: float,
+    grid_width: int,
+    bq: int,
+    bkv: int,
+    bkv_compute: int,
+    head_dim_v: int,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    attn_logits_soft_cap: float | None,
+    mask_function: MaskFunctionType | None,
+):
+  float32 = jnp.float32
+  HEAD_DIM_MINOR = QKVLayout.HEAD_DIM_MINOR
+
+  head_dim_v_repeats, rem = divmod(head_dim_v, NUM_LANES)
+  if rem != 0:
+    raise NotImplementedError(
+        f"{head_dim_v=} should be a multiple of {NUM_LANES}"
+    )
+
+  h, i, j = pl.program_id(0), pl.program_id(1), pl.program_id(2)
+
+  @pl.when(j == 0)
+  def init():
+    o_scratch_ref[...] = jnp.zeros_like(o_scratch_ref)
+    m_scratch_ref[...] = jnp.full_like(m_scratch_ref, mask_value)
+    l_scratch_ref[...] = jnp.zeros_like(l_scratch_ref)
+
+  global_kv_index, _, should_run, should_not_mask = _next_nonzero(
+      h,
+      i,
+      j,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref,
+  )
+
+  def body(kv_compute_index, _):
+    slice_k = pl.ds(kv_compute_index * bkv_compute, bkv_compute)
+    m_prev, l_prev = m_scratch_ref[...], l_scratch_ref[...]
+    assert m_prev.shape == (bq, NUM_LANES)
+    assert l_prev.shape == (bq, NUM_LANES)
+
+    q = q_ref[...] if q_layout == HEAD_DIM_MINOR else q_ref[...].T
+    qk_dims = NT_DIM_NUMBERS if k_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    if k_layout == HEAD_DIM_MINOR:
+      k = k_ref[slice_k, :]
+    else:
+      k = k_ref[:, slice_k]
+    qk = lax.dot_general(q, k, qk_dims, preferred_element_type=float32)
+
+    assert qk.shape == (bq, bkv_compute)
+    apply_mask_and_soft_cap = functools.partial(
+        _apply_mask_and_soft_cap,
+        qk,
+        mask_value,
+        should_not_mask,
+        mask_ref,
+        q_sequence_ref,
+        q_segment_ids_ref,
+        kv_segment_ids_ref,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        k_slice=slice_k,
+        # When the iteration space is shrunk (for local attention for example),
+        # the kv_index program_id does not correspond to the actual coordinates
+        # of the KV data. Make sure to use the 'unshrunk' index (coming from the
+        # data_next array) when computing the mask.
+        k_offset=global_kv_index * bkv + kv_compute_index * bkv_compute,
+        bq=bq,
+        mask_function=mask_function,
+    )
+
+    qk = apply_mask_and_soft_cap()
+
+    m_curr = qk.max(axis=-1)[:, None]  # pytype: disable=attribute-error
+    assert m_curr.shape == (bq, 1)
+    m_next = jnp.maximum(m_prev, m_curr)
+    assert m_next.shape == (bq, NUM_LANES)
+
+    bkv_repeats, rem = divmod(bkv_compute, NUM_LANES)
+    if rem != 0:
+      raise NotImplementedError(
+          f"{bkv_compute=} should be a multiple of {NUM_LANES}"
+      )
+
+    s_curr = jnp.exp(qk - jnp.tile(m_next, (1, bkv_repeats)))
+    assert s_curr.shape == (bq, bkv_compute)
+
+    l_curr = jax.lax.broadcast_in_dim(s_curr.sum(axis=-1), l_prev.shape, (0,))
+    assert l_curr.shape == (bq, NUM_LANES)
+
+    alpha = jnp.exp(m_prev - m_next)
+    l_next = l_curr + alpha * l_prev
+    m_scratch_ref[...], l_scratch_ref[...] = m_next, l_next
+
+    sv_dims = NN_DIM_NUMBERS if v_layout == HEAD_DIM_MINOR else NT_DIM_NUMBERS
+    if v_layout == HEAD_DIM_MINOR:
+      v = v_ref[slice_k, :]
+    else:
+      v = v_ref[:, slice_k]
+    v = v.astype(float32)
+    o_curr = lax.dot_general(s_curr, v, sv_dims)
+
+    alpha_o = jnp.tile(alpha, (1, head_dim_v_repeats))
+    o_scratch_ref[:] = alpha_o * o_scratch_ref[:] + o_curr
+
+  @pl.when(should_run)
+  def run():
+    assert bkv % bkv_compute == 0
+    num_iters = (
+        k_ref.shape[0 if k_layout == HEAD_DIM_MINOR else 1] // bkv_compute
+    )
+    lax.fori_loop(0, num_iters, body, None, unroll=True)
+
+  @pl.when(j == grid_width - 1)
+  def end():
+    l = l_scratch_ref[...]
+    l_inv = jnp.tile(1.0 / l, (1, head_dim_v_repeats))
+    o_ref[...] = (o_scratch_ref[...] * l_inv).astype(o_ref.dtype)
+    if logsumexp_ref is not None:
+      assert logsumexp_ref.shape == (bq, NUM_LANES)
+      logsumexp_ref[...] = (jnp.log(l) + m_scratch_ref[...]).astype(
+          logsumexp_ref.dtype
+      )
+
+    m_scratch_ref[...] = jnp.zeros_like(m_scratch_ref)
+    l_scratch_ref[...] = jnp.zeros_like(l_scratch_ref)
+    o_scratch_ref[...] = jnp.zeros_like(o_scratch_ref)
+
+
+@overload
+def _splash_attention_forward(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    save_residuals: Literal[False] = False,
+    attn_logits_soft_cap: float | None = None,
+) -> jax.Array:
+  ...
+
+
+@overload
+def _splash_attention_forward(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    save_residuals: Literal[True],
+    attn_logits_soft_cap: float | None = None,
+) -> SplashCustomReturnType:
+  ...
+
+
+def _div(dividend: int, divisor: int):
+  if divisor == 1:
+    return dividend
+
+  return lax.div(dividend, divisor)
+
+
+def _splash_attention_forward(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    save_residuals: bool,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None = None,
+    interpret: bool = False
+) -> SplashCustomReturnType:
+  num_q_heads, q_seq_len, head_dim_qk = q.shape
+  head_dim_v = v.shape[-1]
+  bq, bkv = block_sizes.block_q, block_sizes.block_kv
+  bkv_compute = block_sizes.block_kv_compute
+
+  if is_mqa:
+    expected_kv_rank = 2
+    kv_head_dimension = 1
+    kv_seq_len_dimension = 0
+    num_kv_heads = 1
+  else:
+    expected_kv_rank = 3
+    kv_head_dimension = 2
+    kv_seq_len_dimension = 1
+    num_kv_heads = k.shape[0]
+
+  partial_mask_blocks = fwd_mask_info.partial_mask_blocks
+  if (
+      partial_mask_blocks is not None
+      and jnp.dtype(partial_mask_blocks.dtype) != np.bool_
+  ):
+    raise ValueError(
+        "partial_mask_blocks must be of type np.bool_ but got"
+        f" {partial_mask_blocks.dtype}"
+    )
+
+  if len(k.shape) != expected_kv_rank:
+    raise ValueError(
+        f"Expected {expected_kv_rank}-dim 'key' tensor for MQA. Instead got a"
+        f" {len(k.shape)}-dim one."
+    )
+
+  if k.shape[kv_head_dimension] != head_dim_qk:
+    raise ValueError(
+        f"Expected 'key' head dimension to be: {head_dim_qk}. Instead got:"
+        f" {k.shape[kv_head_dimension]}."
+    )
+
+  if not is_mqa and num_q_heads % num_kv_heads != 0:
+    raise ValueError(
+        f"In MHA, expected number of 'key' heads ({num_kv_heads}) to be a"
+        f" multiple of the number of 'query' heads ({num_q_heads})"
+    )
+
+  if k.shape[:-1] != v.shape[:-1]:
+    raise ValueError(
+        f"Expected 'key' {k.shape} and 'value' {v.shape} to have the same "
+        "leading dimensions."
+    )
+
+  if bkv % bkv_compute:
+    raise ValueError(f"{bkv=} must be a multiple of {bkv_compute=}.")
+  if bkv_compute % NUM_LANES:
+    raise ValueError(f"{bkv_compute=} must be a multiple of {NUM_LANES}.")
+
+  kv_seq_len = k.shape[kv_seq_len_dimension]
+
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+
+  if segment_ids is not None:
+    if segment_ids.q.shape != (q_seq_len,):
+      raise ValueError(
+          "Invalid shape for q segment_ids: "
+          f"{segment_ids.q.shape}. Expected: {(q_seq_len,)}"
+      )
+    if segment_ids.kv.shape != (kv_seq_len,):
+      raise ValueError(
+          "Invalid shape for kv segment_ids: "
+          f"{segment_ids.kv.shape}. Expected: {(kv_seq_len,)}"
+      )
+
+  q_layout = block_sizes.q_layout
+  def q_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    del j, data_next_ref, mask_next_ref, block_mask_ref
+    return from_head_minor((h, i, 0), q_layout)
+  def out_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    del j, data_next_ref, mask_next_ref, block_mask_ref
+    return h, i, 0
+
+  k_layout = block_sizes.k_layout
+  def k_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), k_layout)
+
+  v_layout = block_sizes.v_layout
+  def v_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), v_layout)
+
+  def mask_index_map(h, i, j, data_next_ref, block_mask_ref,
+                     mask_next_ref=None):
+    _, next_m, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    return next_m, 0, 0
+
+  def q_segment_ids_index_map(h, i, j, *_):
+    del h, j  # Unused.
+    return i, 0
+
+  def kv_segment_ids_index_map(h, i, j, data_next_ref, block_mask_ref,
+                               mask_next_ref=None):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    return 0, next_j
+
+  # Convert the logical shape from head-minor to sequence-minor.
+  in_specs = [
+      pl.BlockSpec(
+          from_head_minor((None, bq, head_dim_qk), q_layout), q_index_map
+      ),
+      pl.BlockSpec(
+          from_head_minor(
+              (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk), k_layout
+          ),
+          k_index_map,
+      ),
+      pl.BlockSpec(
+          from_head_minor(
+              (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v), v_layout
+          ),
+          v_index_map,
+      ),
+  ]
+  if segment_ids is not None:
+    in_specs += [
+        pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map),
+        pl.BlockSpec((NUM_SUBLANES, bkv), kv_segment_ids_index_map),
+    ]
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q, (q_seq_len, NUM_LANES), (0,)
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv, (NUM_SUBLANES, kv_seq_len), (1,)
+    )
+  else:
+    in_specs += [None, None]
+    q_segment_ids = kv_segment_ids = None
+
+  if fwd_mask_info.partial_mask_blocks is not None:
+    in_specs.append(pl.BlockSpec((None, bq, bkv), mask_index_map))
+  else:
+    in_specs.append(None)
+
+  assert (
+      fwd_mask_info.partial_mask_blocks is None
+      or fwd_mask_info.q_sequence is None
+  )
+
+  if fwd_mask_info.q_sequence is not None:
+    q_sequence = jax.lax.broadcast_in_dim(
+        fwd_mask_info.q_sequence, (q_seq_len, NUM_LANES), (0,)
+    )
+    in_specs.append(pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map))
+  else:
+    q_sequence = None
+    in_specs.append(None)
+
+  num_scalar_prefetch = 3
+
+  out_shapes = [
+      jax.ShapeDtypeStruct((bq, NUM_LANES), jnp.float32),  # m_scratch
+      jax.ShapeDtypeStruct((bq, NUM_LANES), jnp.float32),  # l_scratch
+      jax.ShapeDtypeStruct((bq, head_dim_v), jnp.float32),  # o_scratch
+      jax.ShapeDtypeStruct((num_q_heads, q_seq_len, head_dim_v), q.dtype),
+  ]
+  out_specs = [
+      # TODO(sharadmv): convert m/l to be scratch
+      pl.BlockSpec((bq, NUM_LANES), lambda h, i, j, *_: (0, 0)),
+      pl.BlockSpec((bq, NUM_LANES), lambda h, i, j, *_: (0, 0)),
+      pl.BlockSpec((bq, head_dim_v), lambda h, i, j, *_: (0, 0)),
+      pl.BlockSpec((None, bq, head_dim_v), out_index_map),
+  ]
+  if save_residuals:
+    out_shapes += [
+        jax.ShapeDtypeStruct(
+            (num_q_heads, q_seq_len, NUM_LANES), jnp.float32
+        ),  # logsumexp
+    ]
+
+    def logsumexp_index_map(h, i, *_):
+      return h, i, 0
+
+    out_specs += [
+        pl.BlockSpec((None, bq, NUM_LANES), logsumexp_index_map),
+    ]
+  else:
+    out_shapes += [None]
+    out_specs += [None]
+
+  kernel_name = get_kernel_name(
+      dataclasses.asdict(block_sizes),
+      is_mqa=is_mqa,
+      save_residuals=save_residuals,
+      is_segmented=segment_ids is not None,
+      phase="fwd",
+  )
+
+  if fwd_mask_info.data_next is not None:
+    grid_width = fwd_mask_info.data_next.shape[-1]
+  else:
+    grid_width = kv_seq_len // bkv
+
+  grid = (num_q_heads, q_seq_len // bq, grid_width)
+  with jax.named_scope(kernel_name):
+    all_out = pl.pallas_call(
+        partial(
+            flash_attention_kernel,
+            mask_value=mask_value,
+            grid_width=grid_width,
+            bq=bq,
+            bkv=bkv,
+            bkv_compute=bkv_compute,
+            head_dim_v=head_dim_v,
+            q_layout=q_layout,
+            k_layout=k_layout,
+            v_layout=v_layout,
+            attn_logits_soft_cap=attn_logits_soft_cap,
+            mask_function=mask_function,
+        ),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=num_scalar_prefetch,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            grid=grid,
+        ),
+        compiler_params=pltpu.CompilerParams(
+          dimension_semantics=("parallel", "arbitrary", "arbitrary"),
+        ),
+        out_shape=out_shapes,
+        name=kernel_name,
+        interpret=interpret,
+    )(
+        fwd_mask_info.data_next,
+        fwd_mask_info.block_mask,
+        fwd_mask_info.mask_next,
+        q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
+        k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
+        v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
+        q_segment_ids,
+        kv_segment_ids,
+        fwd_mask_info.partial_mask_blocks,
+        q_sequence,
+    )
+
+  (
+      _,
+      _,
+      _,
+      out,
+      logsumexp,
+  ) = all_out
+
+  if save_residuals:
+    assert logsumexp is not None
+    logsumexp = logsumexp[..., 0]
+
+  if residual_checkpoint_name is not None:
+    out = ad_checkpoint.checkpoint_name(out, name=residual_checkpoint_name)
+    if logsumexp is not None:
+      logsumexp = ad_checkpoint.checkpoint_name(
+          logsumexp, name=residual_checkpoint_name
+      )
+  if save_residuals:
+    return out, (logsumexp,)
+  return out
+
+
+@partial(jax.custom_vjp, nondiff_argnames=(
+  "save_residuals", "mask_value", "is_mqa", "block_sizes",
+  "residual_checkpoint_name", "mask_function", "attn_logits_soft_cap",
+  "interpret")
+)
+def _splash_attention_custom(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    dq_mask_info: mask_info_lib.MaskInfo | None,
+    dkv_mask_info: mask_info_lib.MaskInfo | None,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: bool,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None = None,
+    interpret: bool = False,
+) -> SplashCustomReturnType:
+  # The forward function does not use the dq and dkv MaskInfos, it just forwards
+  # them to the backward function as residuals. This is a way to communicate
+  # arbitrary Arrays to the backward function. Since the three MaskInfos are
+  # constants there is no overhead in passing them to the backward function as
+  # residuals. When sharding computation MaskInfos are partitioned so both the
+  # forward and the backward kernels need to work on the relevant slice. If we
+  # recomputed the backward MaskInfos in the backward function from the numpy
+  # mask then we would not work with the MaskInfo slice relevant to the current
+  # device.
+  del dq_mask_info, dkv_mask_info
+
+  return _splash_attention_forward(  # pytype: disable=wrong-arg-types
+      fwd_mask_info,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      is_mqa=is_mqa,
+      block_sizes=block_sizes,
+      residual_checkpoint_name=residual_checkpoint_name,
+      save_residuals=save_residuals,
+      mask_function=mask_function,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      interpret=interpret,
+  )
+
+
+def _splash_attention_fwd(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    dq_mask_info: mask_info_lib.MaskInfo | None,
+    dkv_mask_info: mask_info_lib.MaskInfo | None,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: bool,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None = None,
+    interpret: bool = False,
+) -> tuple[
+    tuple[jax.Array],
+    SplashResidualsType,
+]:
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported")
+
+  out, (logsumexp,) = _splash_attention_forward(  # pytype: disable=wrong-arg-types
+      fwd_mask_info,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      is_mqa=is_mqa,
+      block_sizes=block_sizes,
+      residual_checkpoint_name=residual_checkpoint_name,
+      save_residuals=True,
+      mask_function=mask_function,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      interpret=interpret,
+  )
+  return out, (
+      q,
+      k,
+      v,
+      segment_ids,
+      out,
+      logsumexp,
+      dq_mask_info,
+      dkv_mask_info,
+  )
+
+
+def _flash_attention_dq_kernel(
+    # Prefetched inputs
+    data_next_ref,
+    block_mask_ref,
+    mask_next_ref,
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    logsumexp_ref,
+    do_ref,
+    di_ref,
+    mask_ref,
+    q_sequence_ref,
+    # Outputs
+    dq_scratch_ref,
+    dq_ref,
+    *,
+    mask_value: float,
+    grid_width: int,
+    bq: int,
+    bkv: int,
+    attn_logits_soft_cap: float | None = None,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    mask_function: MaskFunctionType | None,
+):
+  float32 = jnp.float32
+  HEAD_DIM_MINOR = QKVLayout.HEAD_DIM_MINOR
+
+  h, i, j = pl.program_id(0), pl.program_id(1), pl.program_id(2)
+  @pl.when(j == 0)
+  def init():
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+  global_kv_index, _, should_run, should_not_mask = _next_nonzero(
+      h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+  )
+  @pl.when(should_run)
+  def run():
+    q = q_ref[...] if q_layout == HEAD_DIM_MINOR else q_ref[...].T
+    # We keep k and v possibly transposed, since they are RHS of dots.
+    k = k_ref[...]
+    v = v_ref[...]
+    logsumexp = jnp.expand_dims(logsumexp_ref[0], -1)
+    do = do_ref[...]
+    di = jnp.expand_dims(di_ref[0], -1)
+
+    qk_dims = NT_DIM_NUMBERS if k_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    qk_uncapped = lax.dot_general(q, k, qk_dims, preferred_element_type=float32)
+
+    qk = _apply_mask_and_soft_cap(
+        qk_uncapped,
+        mask_value,
+        should_not_mask,
+        mask_ref,
+        q_sequence_ref,
+        q_segment_ids_ref,
+        kv_segment_ids_ref,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        k_slice=pl.ds(0, bkv),
+        # When the iteration space is shrunk (for local attention for example),
+        # the kv_index program_id does not correspond to the actual coordinates
+        # of the KV data. Make sure to use the 'unshrunk' index (coming from the
+        # data_next array) when computing the mask.
+        k_offset=global_kv_index * bkv,
+        bq=bq,
+        mask_function=mask_function,
+    )
+    p = jnp.exp(qk - logsumexp)
+    dp_dims = NT_DIM_NUMBERS if v_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    dp = lax.dot_general(
+        do.astype(v.dtype), v, dp_dims, preferred_element_type=jnp.float32,
+    )
+    ds = (dp - di) * p
+    if attn_logits_soft_cap is not None:
+      normalized = qk_uncapped / attn_logits_soft_cap
+      d = jnp.tanh(normalized)
+      g = ds * (1 - d)
+      ds = g + g * d
+
+    dq_dims = NN_DIM_NUMBERS if k_layout == HEAD_DIM_MINOR else NT_DIM_NUMBERS
+    dq_scratch_ref[...] += lax.dot_general(
+        ds.astype(k.dtype), k, dq_dims,
+        preferred_element_type=jnp.float32,
+    )
+
+  @pl.when(j == grid_width - 1)
+  def end():
+    dq_ref[...] = dq_scratch_ref[...].astype(dq_ref.dtype)
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+
+def _splash_attention_bwd_dq(
+    q,
+    k,
+    v,
+    segment_ids,
+    logsumexp,
+    do,
+    di,
+    *,
+    bq: int,
+    bkv: int,
+    is_mqa: bool,
+    mask_info: mask_info_lib.MaskInfo,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    mask_function: MaskFunctionType | None,
+    interpret: bool,
+):
+  num_q_heads, q_seq_len, head_dim_qk = q.shape
+  head_dim_v = v.shape[-1]
+  if is_mqa:
+    kv_seq_len = k.shape[0]
+    num_kv_heads = 1
+  else:
+    kv_seq_len = k.shape[1]
+    num_kv_heads = k.shape[0]
+
+  if bq > q_seq_len:
+    raise ValueError(
+        f"{bq=} should not be greater than {q_seq_len=}")
+  if bkv > kv_seq_len:
+    raise ValueError(
+        f"{bkv=} should not be greater than {kv_seq_len=}")
+
+  if not is_mqa and num_q_heads % num_kv_heads != 0:
+    raise ValueError(
+        f"In MHA, expected number of 'key' heads ({num_kv_heads}) to be a"
+        f" multiple of the number of 'query' heads ({num_q_heads})"
+    )
+
+  if k.shape[:-1] != v.shape[:-1]:
+    raise ValueError(
+        f"Expected 'key' {k.shape} and 'value' {v.shape} to have the same "
+        "leading dimensions."
+    )
+
+  if bkv % NUM_LANES:
+    raise ValueError(f"{bkv=} must be a multiple of {NUM_LANES}.")
+
+  # TODO(amagni/sharadmv): when adding block_compute, make sure that is a
+  # multiple of NUM_LANES.
+
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+
+  if mask_info.data_next is not None:
+    grid_width = mask_info.data_next.shape[-1]
+  else:
+    grid_width = kv_seq_len // bkv
+
+  grid = (num_q_heads, q_seq_len // bq, grid_width)
+
+  def o_index_map(h, i, *_):
+    return h, i, 0
+
+  o_spec = pl.BlockSpec((None, bq, head_dim_v), o_index_map)
+
+  def q_index_map(h, i, *_):
+    return from_head_minor((h, i, 0), q_layout)
+
+  q_spec = pl.BlockSpec(
+      from_head_minor((None, bq, head_dim_qk), q_layout), q_index_map
+  )
+
+  def k_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), k_layout)
+
+  k_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk), k_layout
+      ),
+      k_index_map,
+  )
+
+  def v_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), v_layout)
+
+  v_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v), v_layout
+      ),
+      v_index_map,
+  )
+
+  def mask_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_):
+    _, next_m, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    return next_m, 0, 0
+
+  mask_spec = pl.BlockSpec((None, bq, bkv), mask_index_map)
+
+  def q_segment_ids_index_map(h, i, j, *_):
+    del h, j  # Unused.
+    return i, 0
+
+  if segment_ids is not None:
+
+    def kv_segment_ids_index_map(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_
+    ):
+      next_j, *_ = _next_nonzero(
+          h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+      )
+      return 0, next_j
+
+    q_segment_spec = pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map)
+    kv_segment_spec = pl.BlockSpec(
+        (NUM_SUBLANES, bkv), kv_segment_ids_index_map
+    )
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q, (q_seq_len, NUM_LANES), (0,)
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv, (NUM_SUBLANES, kv_seq_len), (1,)
+    )
+  else:
+    q_segment_spec = kv_segment_spec = None
+    q_segment_ids = kv_segment_ids = None
+
+  do_spec = o_spec
+
+  def logsumexp_index_map(h, i, *_):
+    return h, 0, i
+
+  logsumexp = jnp.expand_dims(logsumexp, axis=-2)
+  logsumexp_spec = pl.BlockSpec((None, 1, bq), logsumexp_index_map)
+  assert logsumexp.ndim == len(logsumexp_spec.block_shape)
+
+  di = jnp.expand_dims(di, axis=-2)
+  di_spec = pl.BlockSpec((None, 1, bq), logsumexp_index_map)
+  assert di.ndim == len(di_spec.block_shape)
+
+  in_specs = [
+      q_spec,
+      k_spec,
+      v_spec,
+      q_segment_spec,
+      kv_segment_spec,
+      logsumexp_spec,
+      do_spec,
+      di_spec,
+  ]
+  if mask_info.partial_mask_blocks is not None:
+    in_specs.append(mask_spec)
+  else:
+    in_specs.append(None)
+
+  assert mask_info.partial_mask_blocks is None or mask_info.q_sequence is None
+
+  if mask_info.q_sequence is not None:
+    q_sequence = jax.lax.broadcast_in_dim(
+        mask_info.q_sequence, (q_seq_len, NUM_LANES), (0,)
+    )
+    in_specs.append(pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map))
+  else:
+    q_sequence = None
+    in_specs.append(None)
+
+  out_shapes = [
+      jax.ShapeDtypeStruct((bq, head_dim_qk), jnp.float32),
+      jax.ShapeDtypeStruct(q.shape, q.dtype),
+  ]
+  out_specs = [
+      pl.BlockSpec((bq, head_dim_qk), lambda *_: (0, 0)),
+      pl.BlockSpec((None, bq, head_dim_qk), lambda h, i, *_: (h, i, 0)),
+  ]
+
+  kernel = functools.partial(
+      _flash_attention_dq_kernel,
+      grid_width=grid_width,
+      mask_value=mask_value,
+      bq=bq,
+      bkv=bkv,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      q_layout=q_layout,
+      k_layout=k_layout,
+      v_layout=v_layout,
+      mask_function=mask_function,
+  )
+  num_scalar_prefetch = 3
+
+  kernel_name = get_kernel_name(
+      dict(
+          block_q_dq=bq,
+          block_kv_dq=bkv,
+          q_layout=q_layout,
+          k_layout=k_layout,
+          v_layout=v_layout,
+      ),
+      is_mqa=is_mqa,
+      save_residuals=False,
+      is_segmented=segment_ids is not None,
+      phase="dq",
+  )
+  with jax.named_scope(kernel_name):
+    _, dq = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=num_scalar_prefetch,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            grid=grid,
+        ),
+        out_shape=out_shapes,
+        compiler_params=pltpu.CompilerParams(
+          dimension_semantics=("arbitrary", "arbitrary", "arbitrary"),
+        ),
+        name=kernel_name,
+        interpret=interpret,
+    )(
+        mask_info.data_next,
+        mask_info.block_mask,
+        mask_info.mask_next,
+        q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
+        k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
+        v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
+        q_segment_ids,
+        kv_segment_ids,
+        logsumexp,
+        do,
+        di,
+        mask_info.partial_mask_blocks,
+        q_sequence,
+    )
+  return dq
+
+
+def _flash_attention_dkv_kernel(
+    # Prefetched inputs
+    data_next_ref,
+    block_mask_ref,
+    mask_next_ref,
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    logsumexp_ref,
+    do_ref,
+    di_ref,
+    mask_ref,
+    q_sequence_ref,
+    # Outputs
+    dq_scratch_ref,
+    dk_scratch_ref,
+    dv_scratch_ref,
+    dq_ref,
+    dk_ref,
+    dv_ref,
+    *,
+    num_q_heads: int,
+    num_kv_heads: int,
+    mask_value: float,
+    grid_width: int,
+    bq: int,
+    bkv_compute: int,
+    is_mqa: bool,
+    attn_logits_soft_cap: float | None,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    bkv: int,
+    mask_function: MaskFunctionType | None,
+):
+  HEAD_DIM_MINOR = QKVLayout.HEAD_DIM_MINOR
+  kv_index, q_head_index, q_index = (
+      pl.program_id(0),
+      pl.program_id(1),
+      pl.program_id(2),
+  )
+  should_initialize = q_index == 0
+
+  q_heads_per_kv_heads = None
+  q_head_index_per_kv_head = None
+
+  # Consider this situation:
+  # Q_heads:   0, 1, 2, 3, 4, 5, 6, 7
+  # KV_heads:  0,    1,    2,    3
+  # The gradient scratch buffers should be initialized for Q_heads 0, 2, 4, 6
+  # (first Q_heads to 'see' a new KV_head).
+  # The gradient output buffers should be written for Q_heads 1, 3, 5, 7 (last
+  # Q_heads to 'see' the current KV_head).
+
+  # We can use the same logic for both MQA and GA (grouped attention).
+  # But for MQA there is no need for the rem instruction, so we skip it.
+  if is_mqa:
+    should_initialize = jnp.logical_and(should_initialize, q_head_index == 0)
+  elif num_kv_heads < num_q_heads:
+    q_heads_per_kv_heads = num_q_heads // num_kv_heads
+    q_head_index_per_kv_head = lax.rem(q_head_index, q_heads_per_kv_heads)
+    should_initialize = jnp.logical_and(
+        should_initialize, q_head_index_per_kv_head == 0
+    )
+  @pl.when(should_initialize)
+  def init():
+    dk_scratch_ref[...] = jnp.zeros_like(dk_scratch_ref)
+    dv_scratch_ref[...] = jnp.zeros_like(dv_scratch_ref)
+
+  _, _, should_run, should_not_mask = _next_nonzero(
+      q_head_index,
+      q_index,
+      kv_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref,
+      next_i=True,
+  )
+
+  def body(i, _):
+
+    slice_k = pl.ds(i * bkv_compute, bkv_compute)
+    q = q_ref[...]  # We keep q potentially transposed, since it's always RHS
+    def _load_kv(ref, layout):
+      if layout == HEAD_DIM_MINOR:
+        return ref[slice_k, :]
+      return ref[:, slice_k].T
+    k = _load_kv(k_ref, k_layout)
+    v = _load_kv(v_ref, v_layout)
+    logsumexp = logsumexp_ref[:1, :]
+    do = do_ref[...]
+    di = di_ref[:1, :]
+
+    qk_dims = NT_DIM_NUMBERS if q_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    qk_uncapped = lax.dot_general(
+        k, q, qk_dims, preferred_element_type=jnp.float32
+    )
+
+    qk = _apply_mask_and_soft_cap(
+        qk_uncapped,
+        mask_value,
+        should_not_mask,
+        mask_ref,
+        q_sequence_ref,
+        q_segment_ids_ref,
+        kv_segment_ids_ref,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        k_slice=slice_k,
+        k_offset=kv_index * bkv + i * bkv_compute,
+        bq=bq,
+        k_in_lanes=False,
+        mask_function=mask_function,
+    )
+    p = jnp.exp(qk - logsumexp)
+    dv = lax.dot(p.astype(do.dtype), do, preferred_element_type=jnp.float32)
+    dv = dv.astype(dv_scratch_ref.dtype) + dv_scratch_ref[slice_k, :]
+    dv_scratch_ref[slice_k, :] = dv
+
+    dp = lax.dot_general(
+        v, do, NT_DIM_NUMBERS,
+        preferred_element_type=jnp.float32,
+    )
+    ds = (dp - di) * p
+    if attn_logits_soft_cap is not None:
+      normalized = qk_uncapped / attn_logits_soft_cap
+      d = jnp.tanh(normalized)
+      g = ds * (1 - d)
+      ds = g + g * d
+    dk_dims = NN_DIM_NUMBERS if q_layout == HEAD_DIM_MINOR else NT_DIM_NUMBERS
+    dk = lax.dot_general(
+        ds.astype(do.dtype), q, dk_dims, preferred_element_type=jnp.float32
+    )
+    dk = dk.astype(dk_scratch_ref.dtype) + dk_scratch_ref[slice_k, :]
+    dk_scratch_ref[slice_k, :] = dk
+    if dq_scratch_ref is not None or dq_ref is not None:
+      dq = lax.dot_general(
+          ds.T.astype(k.dtype), k, NN_DIM_NUMBERS,
+          preferred_element_type=jnp.float32,
+      )
+      if dq_scratch_ref is not None:
+        # Compute block size != memory block size
+        dq_scratch_ref[...] += dq
+      else:
+        # Compute block size == memory block size
+        assert dq_ref is not None
+        dq_ref[...] = dq.astype(dq_ref.dtype)
+
+  if dq_scratch_ref is not None:
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+  elif dq_scratch_ref is None and dq_ref is not None:
+    dq_ref[...] = jnp.zeros_like(dq_ref)
+
+  @pl.when(should_run)
+  def run():
+    num_iters = (
+        k_ref.shape[0 if k_layout is HEAD_DIM_MINOR else 1] // bkv_compute
+    )
+    lax.fori_loop(0, num_iters, body, None, unroll=True)
+  if dq_scratch_ref is not None:
+    assert dq_ref is not None
+    dq_ref[...] = dq_scratch_ref[...].astype(dq_ref.dtype)
+
+  should_write = q_index == grid_width - 1
+  if is_mqa:
+    should_write = jnp.logical_and(
+        should_write, q_head_index == num_q_heads - 1
+    )
+  elif num_kv_heads < num_q_heads:
+    should_write = jnp.logical_and(
+        should_write, q_head_index_per_kv_head == q_heads_per_kv_heads - 1
+    )
+
+  @pl.when(should_write)
+  def end():
+    dk_ref[...] = dk_scratch_ref[...].astype(dk_ref.dtype)
+    dv_ref[...] = dv_scratch_ref[...].astype(dv_ref.dtype)
+    if dq_scratch_ref is not None:
+      dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+    dk_scratch_ref[...] = jnp.zeros_like(dk_scratch_ref)
+    dv_scratch_ref[...] = jnp.zeros_like(dv_scratch_ref)
+
+
+def _splash_attention_bwd_dkv(
+    q,
+    k,
+    v,
+    segment_ids,
+    logsumexp,
+    do,
+    di,
+    *,
+    bq: int,
+    bkv: int,
+    bkv_compute: int,
+    is_mqa: bool,
+    mask_info: mask_info_lib.MaskInfo,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    use_fused_bwd_kernel: bool,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    mask_function: MaskFunctionType | None,
+    interpret: bool,
+):
+  num_q_heads, q_seq_len, head_dim_qk = q.shape
+  head_dim_v = v.shape[-1]
+  if is_mqa:
+    num_kv_heads, kv_seq_len = 1, k.shape[0]
+  else:
+    num_kv_heads, kv_seq_len, _ = k.shape
+
+  if bq > q_seq_len:
+    raise ValueError(
+        f"{bq=} should not be greater than {q_seq_len=}")
+  if bkv > kv_seq_len:
+    raise ValueError(
+        f"{bkv=} should not be greater than {kv_seq_len=}")
+  if bkv_compute > bkv:
+    raise ValueError(
+        f"{bkv_compute=} should not be greater than {bkv=}")
+  if bkv % bkv_compute:
+    raise ValueError(
+        f"{bkv=} should be a multiple of {bkv_compute=}")
+
+  if not is_mqa and num_q_heads % num_kv_heads != 0:
+    raise ValueError(
+        f"In MHA, expected number of 'key' heads ({num_kv_heads}) to be a"
+        f" multiple of the number of 'query' heads ({num_q_heads})"
+    )
+
+  if k.shape[:-1] != v.shape[:-1]:
+    raise ValueError(
+        f"Expected 'key' {k.shape} and 'value' {v.shape} to have the same "
+        "leading dimensions."
+    )
+
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+
+  if mask_info.data_next is not None:
+    grid_width = mask_info.data_next.shape[-2]
+  else:
+    grid_width = q_seq_len // bq
+
+  grid = (
+      kv_seq_len // bkv,
+      num_q_heads,
+      grid_width,
+  )
+
+  def o_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return head_index, next_i, 0
+
+  o_spec = pl.BlockSpec((None, bq, head_dim_v), o_index_map)
+
+  def q_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return from_head_minor((head_index, next_i, 0), q_layout)
+
+  q_spec = pl.BlockSpec(
+      from_head_minor((None, bq, head_dim_qk), q_layout), q_index_map
+  )
+
+  def k_index_map(kv_index, head_index, *_):
+    prefix = () if is_mqa else (_div(head_index, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, kv_index, 0), k_layout)
+
+  k_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk),
+          k_layout,
+      ),
+      k_index_map,
+  )
+
+  def v_index_map(kv_index, head_index, *_):
+    prefix = () if is_mqa else (_div(head_index, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, kv_index, 0), v_layout)
+
+  v_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v),
+          v_layout,
+      ),
+      v_index_map,
+  )
+
+  if use_fused_bwd_kernel:
+    def dq_index_map(kv_index, head_index, q_index, *_):
+      return (kv_index, head_index, q_index, 0)
+    dq_spec = pl.BlockSpec((None, None, bq, head_dim_qk), dq_index_map)
+    dq_shape = jax.ShapeDtypeStruct((kv_seq_len // bkv, *q.shape), q.dtype)
+    if bkv == bkv_compute:
+      dq_scratch_spec = dq_scratch_shape = None
+    else:
+      dq_scratch_spec = pl.BlockSpec((bq, head_dim_qk), lambda *_: (0, 0))
+      dq_scratch_shape = jax.ShapeDtypeStruct((bq, head_dim_qk), jnp.float32)
+  else:
+    dq_spec = dq_shape = dq_scratch_spec = dq_scratch_shape = None
+
+  def dkv_index_map(kv_index, head_index, *_):
+    prefix = () if is_mqa else (_div(head_index, q_heads_per_kv_head),)
+    return (*prefix, kv_index, 0)
+
+  dk_spec = pl.BlockSpec(
+      (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk),
+      dkv_index_map,
+  )
+
+  dv_spec = pl.BlockSpec(
+      (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v),
+      dkv_index_map,
+  )
+
+  def mask_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref,
+  ):
+    _, next_m, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return next_m, 0, 0
+
+  mask_spec = pl.BlockSpec((None, bkv, bq), mask_index_map)
+
+  def q_segment_ids_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return 0, next_i
+
+  if segment_ids is not None:
+    def kv_segment_ids_index_map(kv_index, *_):
+      return kv_index, 0
+
+    q_segment_spec = pl.BlockSpec((NUM_SUBLANES, bq), q_segment_ids_index_map)
+    kv_segment_spec = pl.BlockSpec((bkv, NUM_LANES), kv_segment_ids_index_map)
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q, (NUM_SUBLANES, q_seq_len), (1,)
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv, (kv_seq_len, NUM_LANES), (0,)
+    )
+  else:
+    q_segment_spec = kv_segment_spec = None
+    q_segment_ids = kv_segment_ids = None
+
+  do_spec = o_spec
+
+  def logsumexp_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return head_index, 0, next_i
+
+  assert logsumexp.shape == di.shape == (num_q_heads, q_seq_len)
+  # TODO(apaszke): Remove the sublane expansion once Mosaic has all retilings
+  logsumexp_shape = (num_q_heads, NUM_SUBLANES, q_seq_len)
+  logsumexp = jnp.broadcast_to(jnp.expand_dims(logsumexp, -2), logsumexp_shape)
+  logsumexp_spec = pl.BlockSpec((None, NUM_SUBLANES, bq), logsumexp_index_map)
+  assert logsumexp.ndim == len(logsumexp_spec.block_shape)
+
+  # TODO(apaszke): Remove the sublane expansion once Mosaic has all retilings
+  di = jnp.broadcast_to(jnp.expand_dims(di, -2), logsumexp_shape)
+  di_spec = pl.BlockSpec((None, NUM_SUBLANES, bq), logsumexp_index_map)
+  assert di.ndim == len(di_spec.block_shape)
+
+  in_specs = [
+      q_spec,
+      k_spec,
+      v_spec,
+      q_segment_spec,
+      kv_segment_spec,
+      logsumexp_spec,
+      do_spec,
+      di_spec,
+  ]
+  if mask_info.partial_mask_blocks is not None:
+    in_specs.append(mask_spec)
+  else:
+    in_specs.append(None)
+
+  if mask_info.q_sequence is not None:
+    in_specs.append(pl.BlockSpec((NUM_SUBLANES, bq), q_segment_ids_index_map))
+    q_sequence = jax.lax.broadcast_in_dim(
+        mask_info.q_sequence, (NUM_SUBLANES, q_seq_len), (1,)
+    )
+  else:
+    q_sequence = None
+    in_specs.append(None)
+
+  out_shapes = [
+      dq_scratch_shape,
+      jax.ShapeDtypeStruct((bkv, head_dim_qk), jnp.float32),
+      jax.ShapeDtypeStruct((bkv, head_dim_v), jnp.float32),
+      dq_shape,
+      jax.ShapeDtypeStruct(k.shape, k.dtype),
+      jax.ShapeDtypeStruct(v.shape, v.dtype),
+  ]
+  out_specs = [
+      dq_scratch_spec,
+      pl.BlockSpec((bkv, head_dim_qk), lambda *_: (0, 0)),
+      pl.BlockSpec((bkv, head_dim_v), lambda *_: (0, 0)),
+      dq_spec,
+      dk_spec,
+      dv_spec,
+  ]
+
+  kernel = functools.partial(
+      _flash_attention_dkv_kernel,
+      mask_value=mask_value,
+      num_q_heads=num_q_heads,
+      num_kv_heads=num_kv_heads,
+      is_mqa=is_mqa,
+      grid_width=grid_width,
+      bq=bq,
+      bkv_compute=bkv_compute,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      q_layout=q_layout,
+      k_layout=k_layout,
+      v_layout=v_layout,
+      bkv=bkv,
+      mask_function=mask_function,
+  )
+  num_scalar_prefetch = 3
+
+  kernel_name = get_kernel_name(
+      dict(
+          block_q_dkv=bq,
+          block_kv_dkv=bkv,
+          block_kv_dkv_compute=bkv_compute,
+          q_layout=q_layout,
+          k_layout=k_layout,
+          v_layout=v_layout,
+      ),
+      is_mqa=is_mqa,
+      save_residuals=False,
+      is_segmented=segment_ids is not None,
+      phase="dkv",
+  )
+  with jax.named_scope(kernel_name):
+    _, _, _, dq_unreduced, dk, dv = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=num_scalar_prefetch,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            grid=grid,
+        ),
+        out_shape=out_shapes,
+        # We set all dimensions to arbitrary because:
+        # 1) for kv_seq_len, the splash attention prefetch schedule assumes no
+        #    megacore
+        # 2) for heads, we are reducing over heads
+        # 3) for q_seq_len, we are reducing over it to compute dkv
+        compiler_params=pltpu.CompilerParams(
+          dimension_semantics=("arbitrary", "arbitrary", "arbitrary"),
+        ),
+        name=kernel_name,
+        interpret=interpret,
+    )(
+        mask_info.data_next,
+        mask_info.block_mask,
+        mask_info.mask_next,
+        q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
+        k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
+        v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
+        q_segment_ids,
+        kv_segment_ids,
+        logsumexp,
+        do,
+        di,
+        mask_info.partial_mask_blocks,
+        q_sequence,
+    )
+  if use_fused_bwd_kernel:
+    assert dq_unreduced is not None
+    dq = dq_unreduced.sum(axis=0)
+  else:
+    assert dq_unreduced is None
+    dq = None
+  return dq, dk, dv
+
+
+def _splash_attention_bwd(
+    save_residuals: bool,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None,
+    interpret: bool,
+    res: SplashResidualsType,
+    do: jax.Array,
+) -> tuple[
+    mask_info_lib.MaskInfo | None,  # fwd_mask_info
+    mask_info_lib.MaskInfo | None,  # dq_mask_info
+    mask_info_lib.MaskInfo | None,  # dvk_mask_info
+    jax.Array,  # q
+    jax.Array,  # k
+    jax.Array,  # v
+    SegmentIds | None,  # segmend_ids
+]:
+  del save_residuals, residual_checkpoint_name
+  if not block_sizes.has_backward_blocks:
+    raise ValueError("Need to specify backward blocks.")
+  bq_dq, bkv_dq = block_sizes.block_q_dq, block_sizes.block_kv_dq
+  bq_dkv, bkv_dkv_memory, bkv_dkv_compute = (
+      block_sizes.block_q_dkv,
+      block_sizes.block_kv_dkv,
+      block_sizes.block_kv_dkv_compute,
+  )
+  use_fused_bwd_kernel = block_sizes.use_fused_bwd_kernel
+  (
+      q,
+      k,
+      v,
+      segment_ids,
+      o,
+      logsumexp,
+      dq_mask_info,
+      dkv_mask_info,
+  ) = res
+
+  # di: [num_heads, q_seq_len]
+  di = jnp.einsum("hsd,hsd->hs", o.astype(jnp.float32), do.astype(jnp.float32))  # pytype: disable=attribute-error
+  dq, dk, dv = _splash_attention_bwd_dkv(
+      q,
+      k,
+      v,
+      segment_ids,
+      logsumexp,
+      do,
+      di,
+      bq=bq_dkv,
+      bkv=bkv_dkv_memory,
+      bkv_compute=bkv_dkv_compute,
+      is_mqa=is_mqa,
+      mask_info=dkv_mask_info,
+      mask_value=mask_value,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      use_fused_bwd_kernel=use_fused_bwd_kernel,
+      q_layout=block_sizes.q_layout,
+      k_layout=block_sizes.k_layout,
+      v_layout=block_sizes.v_layout,
+      mask_function=mask_function,
+      interpret=interpret,
+  )
+  if not use_fused_bwd_kernel:
+    assert dq is None
+    dq = _splash_attention_bwd_dq(
+        q,
+        k,
+        v,
+        segment_ids,
+        logsumexp,
+        do,
+        di,
+        bq=bq_dq,
+        bkv=bkv_dq,
+        is_mqa=is_mqa,
+        mask_info=dq_mask_info,
+        mask_value=mask_value,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        q_layout=block_sizes.q_layout,
+        k_layout=block_sizes.k_layout,
+        v_layout=block_sizes.v_layout,
+        mask_function=mask_function,
+        interpret=interpret,
+    )
+  # Match the signature of the fwd function.
+  assert dq is not None
+  return (
+      None,  # fwd_mask_info
+      None,  # dq_mask_info
+      None,  # dvk_mak_info
+      dq,  # q
+      dk,  # k
+      dv,  # v
+      None,  # segment_ids
+  )
+
+
+_splash_attention_custom.defvjp(_splash_attention_fwd, _splash_attention_bwd)
+
+
+@partial(
+    jax.jit,
+    static_argnames=[
+        "is_mqa",
+        "block_sizes",
+        "save_residuals",
+        "mask_value",
+        "attn_logits_soft_cap",
+        "residual_checkpoint_name",
+        "mask_function",
+        "interpret",
+    ],
+)
+def _splash_attention(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    dq_mask_info: mask_info_lib.MaskInfo | None,
+    dkv_mask_info: mask_info_lib.MaskInfo | None,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None = None,
+    *,
+    is_mqa: bool,
+    block_sizes: BlockSizes | None,
+    save_residuals: bool,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    interpret: bool,
+) -> SplashCustomReturnType:
+  """
+  For dynamic masks, `partial_mask_blocks` has shape (head_count, q_blocks, kv_blocks, block_q, block_kv).
+  This shape allows sharding across both head count and query sequence dimensions.
+
+  Note: The leading dimensions (head_count, q_blocks, kv_blocks) must be
+  collapsed into a single dimension before being passed to the kernel.
+  """
+  def _collapse_partial_mask_blocks(mask_info: mask_info_lib.MaskInfo | None):
+    if mask_info is None or mask_info.partial_mask_blocks is None:
+        return mask_info
+
+    return mask_info._replace(
+        partial_mask_blocks=mask_info.partial_mask_blocks.reshape(
+            -1, *mask_info.partial_mask_blocks.shape[-2:]
+        )
+    )
+
+  fwd_mask_info = _collapse_partial_mask_blocks(fwd_mask_info)
+  dq_mask_info = _collapse_partial_mask_blocks(dq_mask_info)
+  dkv_mask_info = _collapse_partial_mask_blocks(dkv_mask_info)
+  return _splash_attention_custom(
+      fwd_mask_info,
+      dq_mask_info,
+      dkv_mask_info,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      is_mqa=is_mqa,
+      block_sizes=block_sizes,
+      save_residuals=save_residuals,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      residual_checkpoint_name=residual_checkpoint_name,
+      mask_function=mask_function,
+      interpret=interpret,
+  )
+
+
+@jax.tree_util.register_pytree_node_class
+class SplashAttentionKernel:
+
+  def __init__(
+      self,
+      fwd_mask_info: mask_info_lib.MaskInfo,
+      dq_mask_info: mask_info_lib.MaskInfo | None,
+      dkv_mask_info: mask_info_lib.MaskInfo | None,
+      **kwargs,
+  ):
+    self.kwargs = kwargs
+    self.fwd_mask_info = fwd_mask_info
+    self.dq_mask_info = dq_mask_info
+    self.dkv_mask_info = dkv_mask_info
+
+  def __call__(self, *args, **kwargs) -> SplashCustomReturnType:
+    return _splash_attention(
+        self.fwd_mask_info,
+        self.dq_mask_info,
+        self.dkv_mask_info,
+        *args,
+        **kwargs,
+        **self.kwargs,
+    )
+
+  def manual_sharding_spec(self, sharding: jax.sharding.NamedSharding):
+    """Returns a value that can be used as a shard_map partition spec for the kernel."""
+    if self.fwd_mask_info.data_next is not None:
+      block_mask_shape = self.fwd_mask_info.data_next.shape
+      try:
+        shard_shape = sharding.shard_shape(block_mask_shape)
+      except ValueError as exc:
+        raise ValueError(
+            "The sharding must divide the mask blocks evenly between devices"
+        ) from exc
+      if block_mask_shape[-1] != shard_shape[-1]:
+        raise ValueError("Sharding the kv sequence dimension is not supported")
+    spec = sharding.spec
+    assert len(spec) == 2
+    replicated = jax.sharding.PartitionSpec()
+    partial_mask_blocks_spec = (
+        spec if self.fwd_mask_info.is_dynamic_mask else replicated
+    )
+    # Shard q_sequence over the sequence dimension only.
+    q_sequence_spec = jax.sharding.PartitionSpec(spec[1])
+    mask_info_specs = mask_info_lib.MaskInfo(  # pytype: disable=wrong-arg-types
+        data_next=spec if self.fwd_mask_info.data_next is not None else None,
+        mask_next=spec if self.fwd_mask_info.mask_next is not None else None,
+        block_mask=spec if self.fwd_mask_info.block_mask is not None else None,
+        partial_mask_blocks=partial_mask_blocks_spec
+        if self.fwd_mask_info.partial_mask_blocks is not None
+        else None,
+        q_sequence=q_sequence_spec
+        if self.fwd_mask_info.q_sequence is not None
+        else None,
+    )
+    return SplashAttentionKernel(
+        mask_info_specs,
+        mask_info_specs if self.dq_mask_info is not None else None,
+        mask_info_specs if self.dkv_mask_info is not None else None,
+        **self.kwargs,
+    )
+
+  def tree_flatten(self):
+    return (
+        (self.fwd_mask_info, self.dq_mask_info, self.dkv_mask_info),
+        self.kwargs,
+    )
+
+  @classmethod
+  def tree_unflatten(cls, kwargs, values):
+    fwd_mask_info, dq_mask_info, dkv_mask_info = values
+    # NamedTuples are not preserved during pytree serialization.
+    dq_mask_info = (
+        mask_info_lib.MaskInfo(*dq_mask_info)
+        if dq_mask_info is not None
+        else None
+    )
+    dkv_mask_info = (
+        mask_info_lib.MaskInfo(*dkv_mask_info)
+        if dkv_mask_info is not None
+        else None
+    )
+    return SplashAttentionKernel(
+        mask_info_lib.MaskInfo(*fwd_mask_info),
+        dq_mask_info,
+        dkv_mask_info,
+        **kwargs,
+    )
+
+
+def _make_splash_attention(
+    mask: np.ndarray | jax.Array | mask_lib.MultiHeadMask,
+    *,
+    block_sizes: BlockSizes | None = None,
+    is_mqa: bool,
+    save_residuals: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    attn_logits_soft_cap: float | None = None,
+    downcast_smem_data: bool = True,
+    head_shards: int,
+    q_seq_shards: int,
+    residual_checkpoint_name: str | None = None,
+    interpret: bool = False,
+):
+  if len(mask.shape) != 3:
+    raise ValueError(f'Unexpected mask shape: {mask.shape}')
+
+  if isinstance(mask, np.ndarray):
+    mask = mask_lib.MultiHeadMask(
+        [mask_lib.NumpyMask(head_mask) for head_mask in mask]
+    )
+
+  if block_sizes is None:
+    block_sizes = BlockSizes.get_default()
+
+  process_mask_fn = (
+      mask_info_lib.process_dynamic_mask
+      if isinstance(mask, jax.Array)
+      else mask_info_lib.process_mask
+  )
+
+  process_mask_dvk_fn = (
+      mask_info_lib.process_dynamic_mask_dkv
+      if isinstance(mask, jax.Array)
+      else mask_info_lib.process_mask_dkv
+  )
+
+  fwd_mask_info, mask_function_fwd = process_mask_fn(
+      mask,
+      (block_sizes.block_q, block_sizes.block_kv),
+      downcast_smem_data=downcast_smem_data,
+      head_shards=head_shards,
+      q_seq_shards=q_seq_shards,
+  )
+  fwd_mask_info = tree_util.tree_map(jnp.array, fwd_mask_info)
+
+  dq_mask_info = None
+  dkv_mask_info = None
+  if block_sizes.has_backward_blocks:
+    if block_sizes.use_fused_bwd_kernel:
+      dq_mask_info = None
+    else:
+      bq_dq, bkv_dq = block_sizes.block_q_dq, block_sizes.block_kv_dq
+      dq_mask_info, mask_function_dq = process_mask_fn(
+          mask,
+          (bq_dq, bkv_dq),
+          downcast_smem_data=downcast_smem_data,
+          head_shards=head_shards,
+          q_seq_shards=q_seq_shards,
+      )
+      assert (mask_function_fwd is None) == (mask_function_dq is None)
+      dq_mask_info = tree_util.tree_map(jnp.array, dq_mask_info)
+    bq_dkv, bkv_dkv = block_sizes.block_q_dkv, block_sizes.block_kv_dkv
+    dkv_mask_info, mask_function_dkv = process_mask_dvk_fn(
+        mask,
+        (bq_dkv, bkv_dkv),
+        downcast_smem_data=downcast_smem_data,
+        head_shards=head_shards,
+        q_seq_shards=q_seq_shards,
+        shrink_grid=not block_sizes.use_fused_bwd_kernel,
+    )
+    assert (mask_function_fwd is None) == (mask_function_dkv is None)
+
+    dkv_mask_info = tree_util.tree_map(jnp.array, dkv_mask_info)
+
+  return SplashAttentionKernel(
+      fwd_mask_info,
+      dq_mask_info,
+      dkv_mask_info,
+      block_sizes=block_sizes,
+      is_mqa=is_mqa,
+      save_residuals=save_residuals,
+      mask_value=mask_value,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      residual_checkpoint_name=residual_checkpoint_name,
+      mask_function=mask_function_fwd,
+      interpret=interpret,
+  )
+
+
+make_splash_mha = partial(_make_splash_attention, is_mqa=False)
+make_splash_mqa = partial(_make_splash_attention, is_mqa=True)
+
+make_splash_mha_single_device = partial(
+    make_splash_mha, is_mqa=False, head_shards=1, q_seq_shards=1
+)
+
+make_splash_mqa_single_device = partial(
+    make_splash_mha, is_mqa=True, head_shards=1, q_seq_shards=1
+)
+
+
+CONFIG = {
+    'name': 'llama3_405b_gqa_optimized',
+    'model': 'Llama-3.1-405B',
+    'operator': 'gqa_attention',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_query_heads': 128,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+    'emb_dim': 16384,
+}
+
+# Tuned by autotune_block_sizes.py. Re-run to update.
+TUNED_PARAMS = {
+    # Autotuned for 128 query heads / 8 KV heads.
+    'block_q': 2048,
+    'block_kv': 2048,
+    'block_kv_compute': 1024,
+    'q_layout': 1,  # QKVLayout.HEAD_DIM_MINOR=1, SEQ_MINOR=2
+    'k_layout': 1,
+    'v_layout': 1,
+    'head_shards': 1,
+    'q_seq_shards': 1,
+    # Not autotuned (backward-only).
+    'block_q_dkv': None,
+    'block_kv_dkv': None,
+    'block_kv_dkv_compute': None,
+    'block_q_dq': None,
+    'block_kv_dq': None,
+}
+
+
+def get_flops():
+    B, S = CONFIG['batch'], CONFIG['seq_len']
+    Hq, D = CONFIG['num_query_heads'], CONFIG['head_dim']
+    return 4 * B * Hq * S * S * D
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (query, key, value) matching GQA baseline: (B, S, H, D) layout."""
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    B, S = CONFIG['batch'], CONFIG['seq_len']
+    Hq, Hkv, D = CONFIG['num_query_heads'], CONFIG['num_kv_heads'], CONFIG['head_dim']
+    query = jax.random.normal(k1, (B, S, Hq, D), dtype=dtype)
+    key_t = jax.random.normal(k2, (B, S, Hkv, D), dtype=dtype)
+    value = jax.random.normal(k3, (B, S, Hkv, D), dtype=dtype)
+    return query, key_t, value
+
+
+def workload(query, key, value):
+    """GQA with Pallas splash attention (autotuned block sizes)."""
+    # Transpose from BSHD to BHSD for splash attention
+    q = query.transpose(0, 2, 1, 3)   # (B, H_q, S, D)
+    k = key.transpose(0, 2, 1, 3)     # (B, H_kv, S, D)
+    v = value.transpose(0, 2, 1, 3)   # (B, H_kv, S, D)
+
+    B, H_q, S, D = q.shape
+    H_kv = v.shape[1]
+    heads_per_group = H_q // H_kv
+    mask = mask_lib.CausalMask(shape=(S, S))
+    multi_head_mask = mask_lib.MultiHeadMask([mask] * H_q)
+    block_sizes = BlockSizes(
+        block_q=TUNED_PARAMS['block_q'],
+        block_kv=TUNED_PARAMS['block_kv'],
+        block_kv_compute=TUNED_PARAMS['block_kv_compute'],
+        q_layout=QKVLayout(TUNED_PARAMS['q_layout']),
+        k_layout=QKVLayout(TUNED_PARAMS['k_layout']),
+        v_layout=QKVLayout(TUNED_PARAMS['v_layout']),
+        block_q_dkv=TUNED_PARAMS['block_q_dkv'],
+        block_kv_dkv=TUNED_PARAMS['block_kv_dkv'],
+        block_kv_dkv_compute=TUNED_PARAMS['block_kv_dkv_compute'],
+        block_q_dq=TUNED_PARAMS['block_q_dq'],
+        block_kv_dq=TUNED_PARAMS['block_kv_dq'],
+    )
+    splash_kernel = _make_splash_attention(
+        multi_head_mask, block_sizes=block_sizes,
+        is_mqa=False,
+        head_shards=TUNED_PARAMS['head_shards'],
+        q_seq_shards=TUNED_PARAMS['q_seq_shards'],
+    )
+    @jax.vmap
+    def _attend(q_batch, k_batch, v_batch):
+        k_repeated = jnp.repeat(k_batch, heads_per_group, axis=0)
+        v_repeated = jnp.repeat(v_batch, heads_per_group, axis=0)
+        return splash_kernel(q_batch, k_repeated, v_repeated)
+    out = _attend(q, k, v)  # (B, H_q, S, D)
+    return out.transpose(0, 2, 1, 3)  # (B, S, H_q, D) to match baseline
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator', 'atol', 'rtol')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/30k_Matmul_Scaling_ResidualAdd/baseline.py
+++ b/JAXBench/benchmark/30k_Matmul_Scaling_ResidualAdd/baseline.py
@@ -1,0 +1,62 @@
+"""40_Matmul_Scaling_ResidualAdd — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '40_Matmul_Scaling_ResidualAdd',
+    'batch_size': 16384,
+    'in_features': 4096,
+    'out_features': 4096,
+    'scaling_factor': 0.5,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (16384, 4096), dtype=dtype)
+    weight = jnp.zeros((4096, 4096), dtype=dtype)
+    bias = jnp.zeros(4096, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Scaling + ResidualAdd."""
+    x = jnp.matmul(x, weight) + bias
+    original_x = x
+    x = x * 0.5
+    x = x + original_x
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/31k_Gemm_BatchNorm_GELU_ReLU/baseline.py
+++ b/JAXBench/benchmark/31k_Gemm_BatchNorm_GELU_ReLU/baseline.py
@@ -1,0 +1,71 @@
+"""41_Gemm_BatchNorm_GELU_ReLU — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '41_Gemm_BatchNorm_GELU_ReLU',
+    'batch_size': 16384,
+    'in_features': 8192,
+    'out_features': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    k1, k2, k3 = jax.random.split(key, 3)
+    batch_size, in_features, out_features = 16384, 8192, 8192
+    x = jax.random.uniform(k1, (batch_size, in_features), dtype=dtype)
+    gemm_weight = jax.random.normal(k2, (out_features, in_features), dtype=dtype)
+    gemm_bias = jax.random.normal(k3, (out_features,), dtype=dtype)
+    bn_weight = jnp.ones(out_features, dtype=dtype)
+    bn_bias = jnp.zeros(out_features, dtype=dtype)
+    return x, gemm_weight, gemm_bias, bn_weight, bn_bias
+
+
+def workload(x, gemm_weight, gemm_bias, bn_weight, bn_bias):
+    """Gemm + BatchNorm + GELU + ReLU."""
+    eps = 1e-5
+    # Linear
+    x = jnp.matmul(x, gemm_weight.T) + gemm_bias
+    # BatchNorm1d (training mode)
+    mean = jnp.mean(x, axis=0, keepdims=True)
+    var = jnp.mean((x - mean) ** 2, axis=0, keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + eps) * bn_weight + bn_bias
+    # GELU + ReLU
+    x = jax.nn.gelu(x)
+    x = jax.nn.relu(x)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/32k_Gemm_Sigmoid_LogSumExp/baseline.py
+++ b/JAXBench/benchmark/32k_Gemm_Sigmoid_LogSumExp/baseline.py
@@ -1,0 +1,65 @@
+"""45_Gemm_Sigmoid_LogSumExp — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '45_Gemm_Sigmoid_LogSumExp',
+    'batch_size': 16384,
+    'input_size': 2048,
+    'hidden_size': 4096,
+    'output_size': 1024,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, input_size, hidden_size, output_size = 16384, 2048, 4096, 1024
+    x = jax.random.uniform(key, (batch_size, input_size), dtype=dtype)
+    w1 = jnp.zeros((hidden_size, input_size), dtype=dtype)
+    b1 = jnp.zeros(hidden_size, dtype=dtype)
+    w2 = jnp.zeros((output_size, hidden_size), dtype=dtype)
+    b2 = jnp.zeros(output_size, dtype=dtype)
+    return x, w1, b1, w2, b2
+
+
+def workload(x, w1, b1, w2, b2):
+    """Gemm + Sigmoid + Gemm + LogSumExp."""
+    x = jnp.matmul(x, w1.T) + b1
+    x = jax.nn.sigmoid(x)
+    x = jnp.matmul(x, w2.T) + b2
+    x = jax.scipy.special.logsumexp(x, axis=1)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/33k_Conv3d_Mish_Tanh/baseline.py
+++ b/JAXBench/benchmark/33k_Conv3d_Mish_Tanh/baseline.py
@@ -1,0 +1,76 @@
+"""47_Conv3d_Mish_Tanh — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '47_Conv3d_Mish_Tanh',
+    'batch_size': 16,
+    'in_channels': 32,
+    'out_channels': 64,
+    'kernel_size': 3,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_channels, out_channels, kernel_size = 16, 32, 64, 3
+    D, H, W = 32, 64, 64
+    x = jax.random.uniform(key, (batch_size, in_channels, D, H, W), dtype=dtype)
+    weight = jnp.zeros((out_channels, in_channels, kernel_size, kernel_size, kernel_size), dtype=dtype)
+    bias = jnp.zeros(out_channels, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Conv3d + Mish + Tanh."""
+    # NCDHW -> NDHWC
+    x = jnp.transpose(x, (0, 2, 3, 4, 1))
+    kernel = jnp.transpose(weight, (2, 3, 4, 1, 0))
+    x = jax.lax.conv_general_dilated(
+        x, kernel,
+        window_strides=(1, 1, 1),
+        padding=((0, 0), (0, 0), (0, 0)),
+        dimension_numbers=('NDHWC', 'DHWIO', 'NDHWC')
+    )
+    x = x + bias.reshape(1, 1, 1, 1, -1)
+    # Mish
+    x = x * jnp.tanh(jnp.log(1 + jnp.exp(x)))
+    # Tanh
+    x = jnp.tanh(x)
+    # NDHWC -> NCDHW
+    x = jnp.transpose(x, (0, 4, 1, 2, 3))
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/34k_Conv2d_Activation_BatchNorm/baseline.py
+++ b/JAXBench/benchmark/34k_Conv2d_Activation_BatchNorm/baseline.py
@@ -1,0 +1,87 @@
+"""52_Conv2d_Activation_BatchNorm — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+import jax.lax as lax
+
+CONFIG = {
+    'name': '52_Conv2d_Activation_BatchNorm',
+    'batch_size': 64,
+    'in_channels': 64,
+    'out_channels': 128,
+    'kernel_size': 3,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    k1, k2, k3 = jax.random.split(key, 3)
+    batch_size, in_channels, out_channels, kernel_size = 64, 64, 128, 3
+    height, width = 128, 128
+    x = jax.random.uniform(k1, (batch_size, in_channels, height, width), dtype=dtype)
+    conv_weight = jax.random.normal(k2, (out_channels, in_channels, kernel_size, kernel_size), dtype=dtype)
+    conv_bias = jax.random.normal(k3, (out_channels,), dtype=dtype)
+    bn_weight = jnp.ones(out_channels, dtype=dtype)
+    bn_bias = jnp.zeros(out_channels, dtype=dtype)
+    return x, conv_weight, conv_bias, bn_weight, bn_bias
+
+
+def workload(x, conv_weight, conv_bias, bn_weight, bn_bias):
+    """Conv2d + Mish activation + BatchNorm."""
+    eps = 1e-5
+    # Conv2d NCHW -> NHWC
+    x = jnp.transpose(x, (0, 2, 3, 1))
+    weight = jnp.transpose(conv_weight, (2, 3, 1, 0))
+    x = lax.conv_general_dilated(
+        x, weight,
+        window_strides=(1, 1),
+        padding='VALID',
+        dimension_numbers=('NHWC', 'HWIO', 'NHWC')
+    )
+    x = x + conv_bias.reshape(1, 1, 1, -1)
+    x = jnp.transpose(x, (0, 3, 1, 2))  # NHWC -> NCHW
+
+    # Mish activation: multiply(tanh(softplus(x)), x)
+    softplus_x = jax.nn.softplus(x)
+    x = jnp.multiply(jnp.tanh(softplus_x), x)
+
+    # BatchNorm2d (training mode)
+    mean = jnp.mean(x, axis=(0, 2, 3), keepdims=True)
+    var = jnp.mean((x - mean) ** 2, axis=(0, 2, 3), keepdims=True)
+    w = bn_weight.reshape(1, -1, 1, 1)
+    b = bn_bias.reshape(1, -1, 1, 1)
+    x = (x - mean) / jnp.sqrt(var + eps) * w + b
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/35k_Gemm_Scaling_Hardtanh_GELU/baseline.py
+++ b/JAXBench/benchmark/35k_Gemm_Scaling_Hardtanh_GELU/baseline.py
@@ -1,0 +1,64 @@
+"""53_Gemm_Scaling_Hardtanh_GELU — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '53_Gemm_Scaling_Hardtanh_GELU',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'scaling_factor': 0.5,
+    'hardtanh_min': -2,
+    'hardtanh_max': 2,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Gemm + Scaling + Hardtanh + GELU."""
+    x = jnp.matmul(x, weight) + bias
+    x = x * 0.5
+    x = jnp.clip(x, -2, 2)
+    x = x * 0.5 * (1.0 + jnp.tanh(jnp.sqrt(2.0 / jnp.pi) * (x + 0.044715 * x**3)))
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/36k_Matmul_Sigmoid_Sum/baseline.py
+++ b/JAXBench/benchmark/36k_Matmul_Sigmoid_Sum/baseline.py
@@ -1,0 +1,60 @@
+"""56_Matmul_Sigmoid_Sum — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '56_Matmul_Sigmoid_Sum',
+    'batch_size': 4096,
+    'input_size': 8192,
+    'hidden_size': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Sigmoid + Sum."""
+    x = jnp.matmul(x, weight) + bias
+    x = jax.nn.sigmoid(x)
+    x = jnp.sum(x, axis=1, keepdims=True)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/37k_Matmul_Swish_Scaling/baseline.py
+++ b/JAXBench/benchmark/37k_Matmul_Swish_Scaling/baseline.py
@@ -1,0 +1,61 @@
+"""59_Matmul_Swish_Scaling — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '59_Matmul_Swish_Scaling',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'scaling_factor': 2.0,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Swish + Scaling."""
+    x = jnp.matmul(x, weight) + bias
+    x = x * jax.nn.sigmoid(x)
+    x = x * 2.0
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/38k_Matmul_Dropout_Softmax/baseline.py
+++ b/JAXBench/benchmark/38k_Matmul_Dropout_Softmax/baseline.py
@@ -1,0 +1,61 @@
+"""66_Matmul_Dropout_Softmax — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '66_Matmul_Dropout_Softmax',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'dropout_p': 0.2,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + (Dropout skipped in inference) + Softmax."""
+    x = x @ weight.T + bias
+    # Dropout skipped in inference mode
+    x = jax.nn.softmax(x, axis=1)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/39k_Conv2d_GELU_GlobalAvgPool/baseline.py
+++ b/JAXBench/benchmark/39k_Conv2d_GELU_GlobalAvgPool/baseline.py
@@ -1,0 +1,73 @@
+"""67_Conv2d_GELU_GlobalAvgPool — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '67_Conv2d_GELU_GlobalAvgPool',
+    'batch_size': 128,
+    'in_channels': 8,
+    'out_channels': 64,
+    'kernel_size': 3,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_channels, out_channels, kernel_size = 128, 8, 64, 3
+    height, width = 256, 256
+    x = jax.random.uniform(key, (batch_size, in_channels, height, width), dtype=dtype)
+    weight = jnp.zeros((out_channels, in_channels, kernel_size, kernel_size), dtype=dtype)
+    bias = jnp.zeros(out_channels, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Conv2d + GELU + GlobalAvgPool."""
+    # NCHW -> NHWC
+    x = jnp.transpose(x, (0, 2, 3, 1))
+    kernel = jnp.transpose(weight, (2, 3, 1, 0))
+    x = jax.lax.conv_general_dilated(
+        x, kernel,
+        window_strides=(1, 1),
+        padding='VALID',
+        dimension_numbers=('NHWC', 'HWIO', 'NHWC')
+    )
+    x = x + bias.reshape(1, 1, 1, -1)
+    x = jax.nn.gelu(x)
+    # Global average pooling over H, W
+    x = jnp.mean(x, axis=(1, 2))
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/3p_MLA_Attention/baseline.py
+++ b/JAXBench/benchmark/3p_MLA_Attention/baseline.py
@@ -1,0 +1,139 @@
+"""Multi-head Latent Attention (MLA) — DeepSeek V3 671B. Extracted from MaxText."""
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+CONFIG = {
+    'name': 'deepseek_v3_mla',
+    'model': 'DeepSeek-V3-671B',
+    'operator': 'mla_attention',
+    'batch': 4,
+    'seq_len': 2048,
+    'emb_dim': 7168,
+    'num_heads': 128,
+    'q_lora_rank': 1536,
+    'kv_lora_rank': 512,
+    'qk_nope_head_dim': 128,
+    'qk_rope_head_dim': 64,
+    'v_head_dim': 128,
+    'rope_theta': 10000,
+}
+
+
+def _compute_rope(head_dim, seq_len, theta, dtype):
+    freqs = 1.0 / (theta ** (jnp.arange(0, head_dim, 2, dtype=jnp.float32) / head_dim))
+    pos = jnp.arange(seq_len, dtype=jnp.float32)
+    angles = jnp.outer(pos, freqs)
+    return jnp.cos(angles).astype(dtype), jnp.sin(angles).astype(dtype)
+
+
+def _apply_rope(x, cos, sin):
+    x1, x2 = x[..., ::2], x[..., 1::2]
+    cos = cos[None, :, None, :]
+    sin = sin[None, :, None, :]
+    rotated = jnp.stack([x1 * cos - x2 * sin, x1 * sin + x2 * cos], axis=-1)
+    return rotated.reshape(x.shape)
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (x, q_down, q_up, kv_down, k_up, v_up, o_proj)."""
+    key = jax.random.key(42)
+    keys = jax.random.split(key, 8)
+    C = CONFIG
+    B, S, E = C['batch'], C['seq_len'], C['emb_dim']
+    H = C['num_heads']
+    ql, kvl = C['q_lora_rank'], C['kv_lora_rank']
+    nope, rope, vd = C['qk_nope_head_dim'], C['qk_rope_head_dim'], C['v_head_dim']
+    x = jax.random.normal(keys[0], (B, S, E), dtype=dtype)
+    q_down = jax.random.normal(keys[1], (E, ql), dtype=dtype) * 0.02
+    q_up = jax.random.normal(keys[2], (ql, H * (nope + rope)), dtype=dtype) * 0.02
+    kv_down = jax.random.normal(keys[3], (E, kvl + rope), dtype=dtype) * 0.02
+    k_up = jax.random.normal(keys[4], (kvl, H * nope), dtype=dtype) * 0.02
+    v_up = jax.random.normal(keys[5], (kvl, H * vd), dtype=dtype) * 0.02
+    o_proj = jax.random.normal(keys[6], (H * vd, E), dtype=dtype) * 0.02
+    return x, q_down, q_up, kv_down, k_up, v_up, o_proj
+
+
+def workload(x, q_down_proj, q_up_proj, kv_down_proj, k_up_proj, v_up_proj, o_proj):
+    """MLA: low-rank KV compression with separated position/content attention."""
+    C = CONFIG
+    B, S, E = x.shape
+    H = C['num_heads']
+    nope, rope, vd = C['qk_nope_head_dim'], C['qk_rope_head_dim'], C['v_head_dim']
+    kvl = C['kv_lora_rank']
+    # Query
+    q = jnp.dot(jnp.dot(x, q_down_proj), q_up_proj)
+    q = q.reshape(B, S, H, nope + rope)
+    q_nope, q_rope = q[..., :nope], q[..., nope:]
+    # KV compression
+    kv = jnp.dot(x, kv_down_proj)
+    k_latent, k_rope_raw = kv[..., :kvl], kv[..., kvl:]
+    k_nope = jnp.dot(k_latent, k_up_proj).reshape(B, S, H, nope)
+    # RoPE
+    cos, sin = _compute_rope(rope, S, C['rope_theta'], x.dtype)
+    k_rope = jnp.broadcast_to(k_rope_raw[:, :, None, :], (B, S, H, rope))
+    q_rope = _apply_rope(q_rope, cos, sin)
+    k_rope = _apply_rope(k_rope, cos, sin)
+    # Value
+    v = jnp.dot(k_latent, v_up_proj).reshape(B, S, H, vd)
+    # Attention
+    q_full = jnp.concatenate([q_nope, q_rope], axis=-1).transpose(0, 2, 1, 3)
+    k_full = jnp.concatenate([k_nope, k_rope], axis=-1).transpose(0, 2, 1, 3)
+    v = v.transpose(0, 2, 1, 3)
+    hd = nope + rope
+    attn = jnp.einsum('bhqd,bhkd->bhqk', q_full, k_full) * (hd ** -0.5)
+    mask = jnp.tril(jnp.ones((S, S)))
+    attn = jnp.where(mask, attn, -1e9)
+    attn = jax.nn.softmax(attn, axis=-1)
+    out = jnp.einsum('bhqk,bhkd->bhqd', attn, v)
+    out = out.transpose(0, 2, 1, 3).reshape(B, S, H * vd)
+    return jnp.dot(out, o_proj)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    C = CONFIG
+    B, S, E, H = C['batch'], C['seq_len'], C['emb_dim'], C['num_heads']
+    ql, kvl = C['q_lora_rank'], C['kv_lora_rank']
+    hd = C['qk_nope_head_dim'] + C['qk_rope_head_dim']
+    proj_flops = (
+        B * S * E * ql * 2 +
+        B * S * ql * (H * hd) * 2 +
+        B * S * E * (kvl + C['qk_rope_head_dim']) * 2 +
+        B * S * kvl * (H * C['qk_nope_head_dim']) * 2 +
+        B * S * kvl * (H * C['v_head_dim']) * 2 +
+        B * S * (H * C['v_head_dim']) * E * 2
+    )
+    attn_flops = B * H * S * S * hd * 4
+    flops = proj_flops + attn_flops
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/3p_MLA_Attention/optimized.py
+++ b/JAXBench/benchmark/3p_MLA_Attention/optimized.py
@@ -1,0 +1,1887 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flash Attention TPU kernel."""
+from __future__ import annotations
+
+import dataclasses
+import functools
+import math
+from typing import Any, NamedTuple
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
+
+DEFAULT_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.dtype("float32")).max)
+NUM_LANES = 128
+NUM_SUBLANES = 8
+
+
+class SegmentIds(NamedTuple):
+  """SegmentIds for Q and KV sequences.
+
+  SegmentIds are used to generate segment mask, which prevents attention between
+  different segments in the input sequence. Each array is a list of ids
+  (integers).
+  Only the token with the same id can attend to each other.
+
+  Attributes:
+    q: segment ids along the Q sequence.
+    kv: segment ids along the KV sequence.
+  """
+
+  q: jax.Array  # [batch_size, q_seq_len]
+  kv: jax.Array  # [batch_size, kv_seq_len]
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockSizes:
+  """Tile sizes parameterizing FlashAttention kernels.
+
+  Those parameters have negligible effect on numerics, but affect performance
+  greatly.
+  """
+  block_q: int
+  block_k_major: int
+  block_k: int
+  block_b: int
+
+  block_q_major_dkv: int | None = None
+  block_k_major_dkv: int | None = None
+  block_k_dkv: int | None = None
+  block_q_dkv: int | None = None
+
+  block_k_major_dq: int | None = None
+  block_k_dq: int | None = None
+  block_q_dq: int | None = None
+
+  def __post_init__(self):
+    def verify_major_minor(prefix, suffix, major, minor):
+      if minor > major:
+        raise ValueError(
+            f"{prefix}{suffix}={minor} should be smaller than"
+            f" {prefix}_major{suffix}={major}"
+        )
+      if major % minor != 0:
+        raise ValueError(
+            f"{prefix}{suffix}={minor} should divide"
+            f" {prefix}_major{suffix}={major}"
+        )
+
+    verify_major_minor("block_k", "", self.block_k_major, self.block_k)
+    if self.block_q_major_dkv is not None and self.block_q_dkv is not None:
+      verify_major_minor(
+          "block_q", "_dkv", self.block_q_major_dkv, self.block_q_dkv
+      )
+    if self.block_k_major_dkv is not None and self.block_k_dkv is not None:
+      verify_major_minor(
+          "block_k", "_dkv", self.block_k_major_dkv, self.block_k_dkv
+      )
+    if self.block_k_major_dq is not None and self.block_k_dq is not None:
+      verify_major_minor(
+          "block_k", "_dq", self.block_k_major_dq, self.block_k_dq
+      )
+
+  @property
+  def has_backward_blocks(self) -> bool:
+    backward_blocks = (
+        self.block_q_major_dkv,
+        self.block_k_major_dkv,
+        self.block_q_dkv,
+        self.block_k_dkv,
+        self.block_k_major_dq,
+        self.block_k_dq,
+        self.block_q_dq,
+    )
+    return all(b is not None for b in backward_blocks)
+
+  @classmethod
+  def get_default(cls, batch_size, num_heads, q_seq_len, kv_len, d_model):
+    # TODO(apaszke,sharadmv): Select better parameters based on a heuristic.
+    del batch_size, num_heads, q_seq_len, kv_len, d_model  # Unused.
+    return BlockSizes(
+        block_q=128,
+        block_k_major=128,
+        block_k=128,
+        block_b=1,
+        block_q_major_dkv=128,
+        block_k_major_dkv=128,
+        block_k_dkv=128,
+        block_q_dkv=128,
+        block_k_major_dq=128,
+        block_k_dq=128,
+        block_q_dq=128,
+    )
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "causal",
+        "sm_scale",
+        "block_sizes",
+        "debug",
+    ],
+)
+def flash_attention(
+    q,  # [batch_size, num_heads, q_seq_len, d_model]
+    k,  # [batch_size, num_heads, kv_seq_len, d_model]
+    v,  # [batch_size, num_heads, kv_seq_len, d_model]
+    ab=None,  # [batch_size, num_heads, q_seq_len, kv_seq_len]
+    segment_ids=None,  # q of [batch_size, q_seq_len] and kv of [batch_size, kv_seq_len]
+    *,
+    causal: bool = False,
+    sm_scale: float = 1.0,
+    block_sizes: BlockSizes | None = None,
+    debug: bool = False,
+):
+  batch_size, num_heads, q_seq_len, d_model = q.shape
+  batch_size_k, num_heads_k, kv_seq_len, d_model_k = k.shape
+  batch_size_v, num_heads_v, kv_seq_len_v, d_model_v = v.shape
+  if batch_size != batch_size_k or batch_size != batch_size_v:
+    raise ValueError(
+        f"Batch size mismatch: got {batch_size}, {batch_size_k} and"
+        f" {batch_size_v} (for q, k, v respectively)"
+    )
+  if num_heads != num_heads_k or num_heads != num_heads_v:
+    raise ValueError(
+        f"Head count mismatch: got {num_heads}, {num_heads_k},"
+        f" {num_heads_v} (for q, k, v respectively)"
+    )
+  if d_model != d_model_k:
+    raise ValueError(
+        f"Model dimension mismatch: got {d_model} and {d_model_k} (for q and k"
+        " respectively)"
+    )
+  if d_model != d_model_v:
+    raise NotImplementedError(
+        "V model dimension unequal to KV model dimension unsupported"
+    )
+  if kv_seq_len != kv_seq_len_v:
+    raise ValueError(
+        f"KV sequence length mismatch: got {kv_seq_len} and {kv_seq_len_v}"
+    )
+  if ab is not None:
+    if ab.shape != (batch_size, num_heads, q_seq_len, kv_seq_len):
+      raise ValueError(
+          f"Attention bias shape mismatch: expected ({batch_size=},"
+          f" {num_heads=}, {q_seq_len=}, {kv_seq_len=}), got {ab.shape}"
+      )
+  if segment_ids is not None:
+    if segment_ids.q.shape != (batch_size, q_seq_len):
+      raise ValueError(
+          f"Q segment ids shape mismatch: expected ({batch_size=},"
+          f" {q_seq_len=},), got {segment_ids.q.shape}"
+      )
+    if segment_ids.kv.shape != (batch_size, kv_seq_len):
+      raise ValueError(
+          f"KV segment ids shape mismatch: expected ({batch_size=},"
+          f" {kv_seq_len=},), got {segment_ids.kv.shape}"
+      )
+  if block_sizes is None:
+    block_sizes = BlockSizes.get_default(
+        batch_size, num_heads, q_seq_len, kv_seq_len, d_model
+    )
+  return _flash_attention(
+      q, k, v, ab, segment_ids, False, causal, sm_scale, block_sizes, debug
+  )
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnames=("save_residuals", "causal", "sm_scale", "block_sizes", "debug"))
+def _flash_attention(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+):
+  return _flash_attention_impl(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      save_residuals,
+      causal,
+      sm_scale,
+      block_sizes.block_b,
+      block_sizes.block_q,
+      block_sizes.block_k_major,
+      block_sizes.block_k,
+      debug,
+  )
+
+
+def _flash_attention_fwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_sizes,
+    debug,
+):
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported")
+  o, l, m = _flash_attention(
+      q, k, v, ab, segment_ids, True, causal, sm_scale, block_sizes, debug
+  )
+  return o, (q, k, v, ab, segment_ids, o, l, m)
+
+
+def _flash_attention_bwd(
+    save_residuals: bool,
+    causal: bool,
+    sm_scale: float,
+    block_sizes: BlockSizes,
+    debug: bool,
+    residuals,
+    do,
+):
+  """VJP rule for FlashAttention."""
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported")
+  (q, k, v, ab, segment_ids, o, l, m) = residuals
+  if not block_sizes.has_backward_blocks:
+    raise ValueError(
+        "Program is being differentiated, but not all backward blocks are"
+        " specified"
+    )
+
+  di = jnp.sum(
+      o.astype(jnp.float32) * do.astype(jnp.float32), axis=-1
+  )  # [batch_size, num_heads, q_seq_len]
+
+  dk, dv = _flash_attention_bwd_dkv(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      l,
+      m,
+      do,
+      di,
+      block_q_major=block_sizes.block_q_major_dkv,
+      block_k_major=block_sizes.block_k_major_dkv,
+      block_k=block_sizes.block_k_dkv,
+      block_q=block_sizes.block_q_dkv,
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=DEFAULT_MASK_VALUE,
+      debug=debug,
+  )
+
+  dq, ds = _flash_attention_bwd_dq(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      l,
+      m,
+      do,
+      di,
+      block_q_major=block_sizes.block_q_dq,
+      block_k_major=block_sizes.block_k_major_dq,
+      block_k=block_sizes.block_k_dq,
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=DEFAULT_MASK_VALUE,
+      debug=debug,
+  )
+  return dq, dk, dv, ds, None
+
+
+_flash_attention.defvjp(fwd=_flash_attention_fwd, bwd=_flash_attention_bwd)
+
+
+MIN_BLOCK_SIZE = 128
+TRANS_B_DIM_NUMBERS = (((1,), (1,)), ((), ()))
+
+
+def below_or_on_diag(r, r_blk_size, c, c_blk_size):
+  # A block is considered below or on diagonal as long as the bottom left
+  # corner of the block is below or on diagonal.
+  return ((r + 1) * r_blk_size - 1) > (c * c_blk_size)
+
+
+def _flash_attention_kernel(q_tile_ref, *args, **kwargs):
+  block_b = q_tile_ref.shape[0]
+  # If we're not going to tile the softmax, then we can avoid a bunch of VPU ops.
+  if kwargs["block_k"] == kwargs["kv_seq_len"]:
+    kernel = _flash_attention_kernel_single_batch_single_step
+  else:
+    kernel = _flash_attention_kernel_single_batch
+  for batch_idx in range(block_b):
+    kernel((batch_idx, 0), q_tile_ref, *args, **kwargs)
+
+
+def _flash_attention_kernel_single_batch(
+    batch_idx: tuple[int, ...],
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,  # Input arrays
+    o_tile_ref,  # Output arrays
+    l_ref,
+    m_ref,
+    m_scratch_ref,
+    l_scratch_ref,
+    acc_scratch_ref,
+    *,
+    causal,
+    sm_scale,
+    block_k,
+    kv_seq_len,
+    mask_value,
+):
+  block_k_major = k_tile_ref.shape[2]
+  block_q = q_tile_ref.shape[2]
+  head_dim = q_tile_ref.shape[-1]
+
+  kv_seq_idx = pl.program_id(3)
+  @pl.when(kv_seq_idx == 0)
+  def start_new_sequence():
+    m_scratch_ref[batch_idx] = jnp.full(
+        m_scratch_ref.shape[2:], -jnp.inf, jnp.float32
+    )
+    l_scratch_ref[batch_idx] = jnp.zeros(l_scratch_ref.shape[2:], jnp.float32)
+    acc_scratch_ref[batch_idx] = jnp.zeros(
+        acc_scratch_ref.shape[2:], jnp.float32
+    )
+
+  q_seq_idx = pl.program_id(2)
+  if causal:
+    should_run = below_or_on_diag(q_seq_idx, block_q, kv_seq_idx, block_k_major)
+  else:
+    should_run = True
+
+  @pl.when(should_run)
+  def run():
+    @pl.loop(0, block_k_major, step=block_k, unroll=True)
+    def _body(start_k):
+      m_prev = m_scratch_ref[batch_idx]
+      l_prev = l_scratch_ref[batch_idx]
+      q = q_tile_ref[batch_idx]  # [block_q, head_dim]
+      k = k_tile_ref[
+          (*batch_idx, pl.dslice(start_k, block_k), slice(None))
+      ]  # [block_k, head_dim]
+
+      s = jax.lax.dot_general(
+          q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+      )  # [block_q, block_k]
+
+      # Add attention bias if needed.
+      # TODO(tanburn) Should the attention bias be added before or after
+      # multiplication by sm_scale?
+      if ab_tile_ref is not None:
+        ab = ab_tile_ref[
+            (*batch_idx, pl.dslice(None), pl.dslice(start_k, block_k))
+        ].astype(jnp.float32)
+        s += ab
+
+      if sm_scale != 1.0:
+        s *= sm_scale
+
+      mask = None
+      if q_segment_ids_tile_ref is not None:
+        repeats, rem = divmod(block_k, NUM_LANES)
+        if rem:
+          raise NotImplementedError(
+              f"kv block size must be a multiple of {NUM_LANES}"
+          )
+        q_segment_ids = jnp.tile(
+            q_segment_ids_tile_ref[batch_idx[0]], (1, repeats)
+        )  # [block_q, block_k].
+        kv_segment_ids = kv_segment_ids_tile_ref[
+            batch_idx[0], :1, pl.dslice(start_k, block_k)
+        ]  # [1, block_k].
+        mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+      if causal:
+        mask_shape = (block_q, block_k)
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        row_ids += q_seq_idx * block_q
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        col_ids += kv_seq_idx * block_k_major + start_k
+        causal_mask = col_ids <= row_ids
+        mask = (
+            causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+        )
+
+      s = s if mask is None else s + jnp.where(mask, 0.0, mask_value)
+
+      m_curr = jnp.max(s, axis=1)[:, None]  # Row max, shape [block_q, 1].
+      m_next = jnp.maximum(m_prev, m_curr)  # Shape [block_q, 128].
+
+      block_k_repeats, rem = divmod(block_k, MIN_BLOCK_SIZE)
+      if rem:
+        raise NotImplementedError(
+            f"{block_k=} should be a multiple of {MIN_BLOCK_SIZE}"
+        )
+      p = jnp.exp(s - jnp.tile(m_next, (1, block_k_repeats)))
+
+      alpha = jnp.exp(m_prev - m_next)  # Shape [block_q, 128].
+
+      l_corr = alpha * l_prev
+
+      l_next = jnp.sum(p, axis=1)[:, None] + l_corr  # Shape [block_q, 128]
+
+      head_dim_repeats, rem = divmod(head_dim, MIN_BLOCK_SIZE)
+      l_broadcast = lambda l: jnp.tile(l, (1, head_dim_repeats))
+      if rem:
+        if head_dim_repeats == 0:
+          l_broadcast = lambda l: l[:, :head_dim]
+        else:
+          raise NotImplementedError(
+              f"{head_dim=} should be a multiple of {MIN_BLOCK_SIZE} if larger"
+          )
+      l_scratch_ref[batch_idx] = l_next
+      m_scratch_ref[batch_idx] = m_next
+
+      l_next_inv_safe = jnp.where(l_next == 0.0, 1.0, 1.0 / l_next)
+      acc_scratch_ref[batch_idx] *= l_broadcast(l_corr * l_next_inv_safe)
+      v = v_tile_ref[(*batch_idx, pl.dslice(start_k, block_k), slice(None))]
+      o_curr = jax.lax.dot(
+          p.astype(v.dtype), v, preferred_element_type=jnp.float32
+      )
+      acc_scratch_ref[batch_idx] += o_curr * l_broadcast(l_next_inv_safe)
+
+  @pl.when(kv_seq_idx == (kv_seq_len // block_k_major) - 1)
+  def store_output():
+    o_tile_ref[batch_idx] = acc_scratch_ref[batch_idx].astype(o_tile_ref.dtype)
+    if l_ref is not None:
+      l_ref[batch_idx] = l_scratch_ref[batch_idx].astype(l_ref.dtype)
+    if m_ref is not None:
+      m_ref[batch_idx] = m_scratch_ref[batch_idx].astype(m_ref.dtype)
+
+
+def _flash_attention_kernel_single_batch_single_step(
+    batch_idx: tuple[int, ...],
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,  # Input arrays
+    o_tile_ref,  # Output arrays
+    l_ref: Any | None = None,
+    m_ref: Any | None = None,
+    *,
+    causal,
+    sm_scale,
+    block_k,
+    kv_seq_len,
+    mask_value,
+):
+  block_k_major = k_tile_ref.shape[2]
+  block_q = q_tile_ref.shape[2]
+
+  assert kv_seq_len == block_k_major == block_k
+
+  q = q_tile_ref[batch_idx]  # [block_q, head_dim]
+  k = k_tile_ref[batch_idx]  # [block_k, head_dim]
+  s = jax.lax.dot_general(
+      q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+  )  # [block_q, block_k]
+
+  if ab_tile_ref is not None:
+    s += ab_tile_ref[batch_idx].astype(jnp.float32)
+  if sm_scale != 1.0:
+    s *= sm_scale
+
+  mask = None
+  if q_segment_ids_tile_ref is not None:
+    repeats, rem = divmod(block_k, NUM_LANES)
+    if rem:
+      raise NotImplementedError(
+          f"kv block size must be a multiple of {NUM_LANES}"
+      )
+    q_segment_ids = q_segment_ids_tile_ref[
+        batch_idx[0]
+    ]  # [block_q, NUM_LANES].
+    q_segment_ids = jnp.tile(
+        q_segment_ids, (1, repeats)
+    )  # [block_q, block_k].
+    kv_segment_ids = kv_segment_ids_tile_ref[batch_idx[0], :1]  # [1, block_k].
+    mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+  if causal:
+    q_seq_idx = pl.program_id(2)
+    mask_shape = (block_q, block_k)
+    row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+    row_ids += q_seq_idx * block_q
+    col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+    causal_mask = col_ids <= row_ids
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+  s = s if mask is None else s + jnp.where(mask, 0.0, mask_value)
+
+  m = jnp.max(s, axis=1)[:, None]
+  p = jnp.exp(s - m)
+  l = jnp.sum(p, axis=1)[:, None]
+  p /= l
+
+  if m_ref is not None:
+    m_ref[batch_idx] = lax.broadcast_in_dim(m, m_ref.shape[2:], range(2))
+  if l_ref is not None:
+    l_ref[batch_idx] = lax.broadcast_in_dim(l, l_ref.shape[2:], range(2))
+
+  v = v_tile_ref[batch_idx]
+  o_tile_ref[batch_idx] = jax.lax.dot(
+      p.astype(v.dtype), v, preferred_element_type=jnp.float32
+  ).astype(o_tile_ref.dtype)
+
+
+def _bytes(x: jax.Array | jax.ShapeDtypeStruct) -> int:
+  return math.prod(x.shape) * x.dtype.itemsize
+
+
+def _fwd_cost_estimate(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    ab: jax.Array | None,
+    segment_ids: SegmentIds | None,
+    *,
+    causal: bool,
+    sm_scale: jax.Array | None,
+    kernel_inputs_specs,
+    kernel_outputs_specs,
+) -> pl.CostEstimate | None:
+  body_cost = pl.estimate_cost(
+    mha_reference,
+    q, k, v, ab, segment_ids, causal=causal, sm_scale=sm_scale
+  )
+  input_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_inputs_specs))
+  output_bytes = sum(_bytes(x) for x in jax.tree.leaves(kernel_outputs_specs))
+  return pl.CostEstimate(
+      flops=body_cost.flops,
+      transcendentals=body_cost.transcendentals,
+      bytes_accessed=input_bytes + output_bytes,
+  )
+
+
+def _flash_attention_impl(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    save_residuals,
+    causal,
+    sm_scale,
+    block_b,
+    block_q,
+    block_k_major,
+    block_k,
+    debug,
+):
+  batch_size, num_heads, q_seq_len, head_dim = q.shape
+  _, _, kv_seq_len, _ = k.shape
+  _verify_block("block_q", "q_seq_len", block_q, q_seq_len, should_divide=False)
+  _verify_block("block_k_major", "kv_seq_len", block_k_major, kv_seq_len)
+  _verify_block("block_k", "kv_seq_len", block_k, kv_seq_len)
+  _verify_block("block_b", "batch", block_b, batch_size, should_divide=False)
+
+  # TODO(apaszke): Tile over heads as well.
+  grid = (
+      pl.cdiv(batch_size, block_b),
+      num_heads,
+      pl.cdiv(q_seq_len, block_q),
+      kv_seq_len // block_k_major,
+  )
+
+  def q_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  def kv_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    if causal:
+      # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+      # 0th one to be used for the next block_q rows.
+      next_kv_index = lax.select(
+          below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+          kv_seq_index,
+          0,
+      )
+    else:
+      next_kv_index = kv_seq_index
+    return (batch_index, head_index, next_kv_index, 0)
+
+  def ab_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    if causal:
+      should_run = below_or_on_diag(
+          q_seq_index, block_q, kv_seq_index, block_k_major
+      )
+      # If the ab block is skipped, prefetch the next valid ab block, i.e. the
+      # 0th kv to be used for the next block_q rows.
+      next_q_index = lax.select(
+          should_run,
+          q_seq_index,
+          lax.select(
+              q_seq_index == (q_seq_len // block_q) - 1, 0, q_seq_index + 1
+          ),
+      )
+      next_kv_index = lax.select(should_run, kv_seq_index, 0)
+    else:
+      next_q_index = q_seq_index
+      next_kv_index = kv_seq_index
+
+    return (batch_index, head_index, next_q_index, next_kv_index)
+
+  def o_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  def lm_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  kernel = functools.partial(
+      _flash_attention_kernel,
+      causal=causal,
+      mask_value=DEFAULT_MASK_VALUE,
+      sm_scale=sm_scale,
+      block_k=block_k,
+      kv_seq_len=kv_seq_len,
+  )
+  out_shape = jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype)
+  out_shape = [out_shape]
+  out_specs = [pl.BlockSpec((block_b, 1, block_q, head_dim), o_index_map)]
+
+  if block_k != kv_seq_len:
+    m_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+    l_scratch = pltpu.VMEM((block_b, 1, block_q, MIN_BLOCK_SIZE), jnp.float32)
+    acc_scratch = pltpu.VMEM((block_b, 1, block_q, head_dim), jnp.float32)
+    scratch_shapes = [m_scratch, l_scratch, acc_scratch]
+  else:
+    scratch_shapes = []
+
+  if save_residuals:
+    out_specs = [
+        *out_specs,
+        pl.BlockSpec((block_b, 1, block_q, MIN_BLOCK_SIZE), lm_index_map),
+        pl.BlockSpec((block_b, 1, block_q, MIN_BLOCK_SIZE), lm_index_map),
+    ]
+    l = jax.ShapeDtypeStruct(
+        (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+    )
+    m = jax.ShapeDtypeStruct(
+        (batch_size, num_heads, q_seq_len, MIN_BLOCK_SIZE), dtype=jnp.float32
+    )
+    out_shape = (*out_shape, l, m)
+  else:
+    out_specs = [*out_specs, None, None]
+    out_shape = (*out_shape, None, None)
+
+  ab_block_spec = (
+      pl.BlockSpec((block_b, 1, block_q, block_k_major), ab_index_map)
+      if ab is not None else None)
+
+  q_segment_ids_spec = kv_segment_ids_spec = None
+  q_segment_ids = kv_segment_ids = None
+  if segment_ids is not None:
+
+    def q_segment_ids_index_map(batch_index, head_index, q_seq_index, _):
+      del head_index
+      return (batch_index, q_seq_index, 0)
+
+    def kv_segment_ids_index_map(
+        batch_index, head_index, q_seq_index, kv_seq_index
+    ):
+      del head_index
+      if causal:
+        next_kv_index = lax.select(
+            below_or_on_diag(q_seq_index, block_q, kv_seq_index, block_k_major),
+            kv_seq_index,
+            0,
+        )
+      else:
+        next_kv_index = kv_seq_index
+      return (batch_index, 0, next_kv_index)
+
+    q_segment_ids_spec = pl.BlockSpec(
+        (block_b, block_q, NUM_LANES), q_segment_ids_index_map
+    )
+    kv_segment_ids_spec = pl.BlockSpec(
+        (block_b, NUM_SUBLANES, block_k_major), kv_segment_ids_index_map
+    )
+
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q,
+        (batch_size, q_seq_len, NUM_LANES),
+        (
+            0,
+            1,
+        ),
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv,
+        (batch_size, NUM_SUBLANES, kv_seq_len),
+        (
+            0,
+            2,
+        ),
+    )
+
+  in_specs = [
+      pl.BlockSpec((block_b, 1, block_q, head_dim), q_index_map),
+      pl.BlockSpec((block_b, 1, block_k_major, head_dim), kv_index_map),
+      pl.BlockSpec((block_b, 1, block_k_major, head_dim), kv_index_map),
+      ab_block_spec,
+      q_segment_ids_spec,
+      kv_segment_ids_spec,
+  ]
+
+  o, *aux = pl.pallas_call(
+      kernel,
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          num_scalar_prefetch=0,
+          grid=grid,
+          in_specs=in_specs,
+          out_specs=out_specs,
+          scratch_shapes=scratch_shapes,
+      ),
+      out_shape=out_shape,
+      debug=debug,
+      compiler_params=pltpu.CompilerParams(
+          dimension_semantics=(
+              "parallel",
+              "parallel",
+              "parallel",
+              "arbitrary",
+          )
+      ),
+      cost_estimate=_fwd_cost_estimate(
+          q,
+          k,
+          v,
+          ab,
+          segment_ids,
+          causal=causal,
+          sm_scale=sm_scale,
+          kernel_inputs_specs=(q, k, v, ab, q_segment_ids, kv_segment_ids),
+          kernel_outputs_specs=out_shape,
+      ),
+  )(q, k, v, ab, q_segment_ids, kv_segment_ids)
+  if save_residuals:
+    l, m = (v[..., 0] for v in aux[-2:])
+    return (o, l, m)
+  else:
+    return o
+
+
+def _flash_attention_dkv_kernel(
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,
+    l_tile_ref,
+    m_tile_ref,
+    do_tile_ref,
+    di_tile_ref,
+    dk_tile_ref,
+    dv_tile_ref,
+    dk_scratch_ref,
+    dv_scratch_ref,
+    *,
+    sm_scale: float,
+    causal: bool,
+    mask_value: float,
+    q_seq_len: int,
+    block_q: int,
+    block_k: int,
+):
+  _, _, block_q_major, _ = q_tile_ref.shape
+  _, _, block_k_major, _ = k_tile_ref.shape
+
+  q_seq_index = pl.program_id(axis=3)
+  kv_seq_index = pl.program_id(axis=2)
+
+  @pl.when(q_seq_index == 0)
+  def start_new_sequence():
+    dk_scratch_ref[:, :] = jnp.zeros(dk_scratch_ref.shape, dk_scratch_ref.dtype)
+    dv_scratch_ref[:, :] = jnp.zeros(dv_scratch_ref.shape, dv_scratch_ref.dtype)
+
+  def q_body(j, _):
+    start_q = j * block_q
+    def k_body(i, _):
+      start_k = i * block_k
+      k = k_tile_ref[0, 0, pl.ds(start_k, block_k), :]
+      v = v_tile_ref[0, 0, pl.ds(start_k, block_k), :]
+      q = q_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, head_dim]
+      l = l_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, 128]
+      m = m_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, 128]
+      do = do_tile_ref[0, 0, pl.ds(start_q, block_q), :]  # [block_q, 128]
+      di = di_tile_ref[0, 0, pl.ds(start_q, block_q), :].astype(
+          jnp.float32
+      )  # [block_q, 128]
+
+      capped_logits = lax.dot_general(
+          q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+      )  # [block_q_major, block_k]
+
+      if ab_tile_ref is not None:
+        ab = ab_tile_ref[
+            0,
+            0,
+            pl.dslice(j * block_q, block_q),
+            pl.dslice(i * block_k, block_k),
+        ].astype(jnp.float32)
+        capped_logits += ab
+
+      if sm_scale != 1.0:
+        capped_logits *= sm_scale
+
+      mask = None
+      if q_segment_ids_tile_ref is not None:
+        repeats, rem = divmod(block_k, NUM_LANES)
+        if rem:
+          raise NotImplementedError(
+          )
+        q_segment_ids = q_segment_ids_tile_ref[
+            0, pl.ds(start_q, block_q), :
+        ]  # [block_q, NUM_LANES].
+        q_segment_ids = jnp.tile(
+            q_segment_ids, (1, repeats)
+        )  # [block_q, block_k].
+        kv_segment_ids = kv_segment_ids_tile_ref[
+            :, 0, pl.ds(start_k, block_k)
+        ]  # [1, block_k].
+        mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+      if causal:
+        mask_shape = (block_q, block_k)
+        row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+        row_ids += q_seq_index * block_q_major + start_q
+        col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+        col_ids += kv_seq_index * block_k_major + start_k
+        causal_mask = col_ids <= row_ids
+        mask = (
+            causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+        )
+
+      capped_logits = (
+          capped_logits
+          if mask is None
+          else capped_logits + jnp.where(mask, 0.0, mask_value)
+      )
+
+      p = jnp.exp(
+          capped_logits - jnp.tile(m, (1, block_k // MIN_BLOCK_SIZE))
+      )
+      p = p * jnp.tile(
+          1 / l, (1, block_k // MIN_BLOCK_SIZE)
+      )  # [block_q_major, block_k_major]
+      dv = lax.dot(p.T.astype(do.dtype), do, preferred_element_type=jnp.float32)
+      dv_scratch_ref[pl.ds(start_k, block_k), :] += dv.astype(
+          dv_scratch_ref.dtype
+      )
+
+      # di: [block_q, 128]
+      # do: [block_q, head_dim]
+      # v: [block_k_major, head_dim]
+      dp = lax.dot_general(
+          do, v, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+      )
+      ds = (dp - jnp.tile(di, (1, block_k // MIN_BLOCK_SIZE))) * p
+
+      if sm_scale != 1.0:
+        ds = ds * sm_scale
+
+      # ds: [block_q_major, block_k_major]
+      # q: [block_q_major, head_dim]
+      dk = lax.dot(ds.T.astype(do.dtype), q, preferred_element_type=jnp.float32)
+      dk_scratch_ref[pl.ds(start_k, block_k), :] += dk.astype(
+          dk_scratch_ref.dtype
+      )
+    lax.fori_loop(0, block_k_major // block_k, k_body, None, unroll=True)
+
+  if causal:
+    should_run = below_or_on_diag(
+        q_seq_index, block_q_major, kv_seq_index, block_k_major
+    )
+  else:
+    should_run = True
+
+  @pl.when(should_run)
+  def run():
+    lax.fori_loop(0, block_q_major // block_q, q_body, None, unroll=True)
+
+  @pl.when(q_seq_index == q_seq_len // block_q_major - 1)
+  def end_of_q_sequence():
+    dv_tile_ref[0, 0, :, :] = dv_scratch_ref[...].astype(dv_tile_ref.dtype)
+    dk_tile_ref[0, 0, :, :] = dk_scratch_ref[...].astype(dk_tile_ref.dtype)
+
+
+def _flash_attention_bwd_dkv(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    l,
+    m,
+    do,
+    di,
+    *,
+    block_q_major: int | None,
+    block_q: int | None,
+    block_k_major: int | None,
+    block_k: int | None,
+    sm_scale: float,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    debug: bool = False,
+):
+  batch_size, num_heads, q_seq_len, head_dim = q.shape
+  _, _, kv_seq_len, _ = k.shape
+  _verify_block("block_q_major_dkv", "q_seq_len", block_q_major, q_seq_len)
+  _verify_block("block_q_dkv", "q_seq_len", block_q, q_seq_len)
+  _verify_block("block_k_major_dkv", "kv_seq_len", block_k_major, kv_seq_len)
+  _verify_block("block_k_dkv", "kv_seq_len", block_k, kv_seq_len)
+
+  # Broadcast out scalar values
+  m = jnp.broadcast_to(m[..., None], (*m.shape, MIN_BLOCK_SIZE))
+  l = jnp.broadcast_to(l[..., None], (*l.shape, MIN_BLOCK_SIZE))
+  # Preprocess contraction for bwd pass
+  di = jnp.broadcast_to(di[..., None], (*di.shape, MIN_BLOCK_SIZE))
+
+  # kv index needs to be before q index since q index is the contractng
+  # dimension.
+  grid = (
+      batch_size,
+      num_heads,
+      kv_seq_len // block_k_major,
+      q_seq_len // block_q_major,
+  )
+
+  def qo_index_map(batch_index, head_index, kv_seq_index, q_seq_index):
+    if causal:
+      # If the q block is skipped, stay at the 0th q block.
+      next_q_index = lax.select(
+          below_or_on_diag(
+              q_seq_index, block_q_major, kv_seq_index, block_k_major
+          ),
+          q_seq_index,
+          0,
+      )
+    else:
+      next_q_index = q_seq_index
+
+    return (batch_index, head_index, next_q_index, 0)
+
+  qo_spec = pl.BlockSpec((1, 1, block_q_major, head_dim), qo_index_map)
+  assert qo_spec.block_shape is not None
+  assert q.ndim == len(qo_spec.block_shape)
+  do_spec = qo_spec
+  assert do.ndim == len(qo_spec.block_shape)
+
+  def kv_index_map(batch_index, head_index, kv_seq_index, _):
+    return (batch_index, head_index, kv_seq_index, 0)
+
+  kv_spec = pl.BlockSpec((1, 1, block_k_major, head_dim), kv_index_map)
+  assert kv_spec.block_shape is not None
+  assert k.ndim == len(kv_spec.block_shape)
+  assert v.ndim == len(kv_spec.block_shape)
+
+  def lm_index_map(batch_index, head_index, _, q_seq_index):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  lm_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), lm_index_map)
+  assert lm_spec.block_shape is not None
+  assert l.ndim == len(lm_spec.block_shape)
+  assert m.ndim == len(lm_spec.block_shape)
+
+  di_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), qo_index_map)
+  assert di_spec.block_shape is not None
+  assert di.ndim == len(di_spec.block_shape)
+
+  def ab_index_map(batch_index, head_index, kv_seq_index, q_seq_index):
+    return (batch_index, head_index, q_seq_index, kv_seq_index)
+
+  dab_spec = (
+      pl.BlockSpec((1, 1, block_q_major, block_k_major), ab_index_map)
+      if ab is not None
+      else None
+  )
+
+  q_segment_ids_spec = kv_segment_ids_spec = None
+  q_segment_ids = kv_segment_ids = None
+  if segment_ids is not None:
+
+    def q_segment_ids_index_map(
+        batch_index, head_index, kv_seq_index, q_seq_index
+    ):
+      del head_index
+      if causal:
+        next_q_index = lax.select(
+            below_or_on_diag(
+                q_seq_index, block_q_major, kv_seq_index, block_k_major
+            ),
+            q_seq_index,
+            0,
+        )
+      else:
+        next_q_index = q_seq_index
+      return (batch_index, next_q_index, 0)
+
+    def kv_segment_ids_index_map(batch_index, head_index, kv_seq_index, _):
+      del head_index
+      return (batch_index, 0, kv_seq_index)
+
+    q_segment_ids_spec = pl.BlockSpec(
+        (1, block_q_major, NUM_LANES), q_segment_ids_index_map
+    )
+    kv_segment_ids_spec = pl.BlockSpec(
+        (1, NUM_SUBLANES, block_k_major), kv_segment_ids_index_map
+    )
+
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q,
+        (batch_size, q_seq_len, NUM_LANES),
+        (
+            0,
+            1,
+        ),
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv,
+        (batch_size, NUM_SUBLANES, kv_seq_len),
+        (
+            0,
+            2,
+        ),
+    )
+
+  in_specs = [
+      qo_spec,
+      kv_spec,
+      kv_spec,
+      dab_spec,
+      q_segment_ids_spec,
+      kv_segment_ids_spec,
+      lm_spec,
+      lm_spec,
+      do_spec,
+      di_spec,
+  ]
+
+  out_shapes = [
+      jax.ShapeDtypeStruct((batch_size, num_heads, kv_seq_len, head_dim),
+                           k.dtype),
+      jax.ShapeDtypeStruct((batch_size, num_heads, kv_seq_len, head_dim),
+                           v.dtype),
+  ]
+  def dkv_index_map(batch_index, head_index, kv_seq_index, _):
+    return (batch_index, head_index, kv_seq_index, 0)
+
+  dkv_spec = pl.BlockSpec((1, 1, block_k_major, head_dim), dkv_index_map)
+  out_specs = [dkv_spec, dkv_spec]
+  scratch_shapes = [
+      pltpu.VMEM((block_k_major, head_dim), jnp.float32),  # type: ignore
+      pltpu.VMEM((block_k_major, head_dim), jnp.float32),  # type: ignore
+  ]
+
+  kernel = functools.partial(
+      _flash_attention_dkv_kernel,
+      block_q=block_q,  # type: ignore
+      block_k=block_k,  # type: ignore
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=mask_value,
+      q_seq_len=q_seq_len,
+  )
+  name_scope = f"flash_mha_bwd_dkv_{block_q_major=}_{block_q=}_{block_k_major=}_{block_k=}"
+  with jax.named_scope(name_scope):
+    dk, dv = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            grid=grid,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            scratch_shapes=scratch_shapes,
+        ),
+        out_shape=out_shapes,
+        debug=debug,
+        compiler_params=pltpu.CompilerParams(
+                dimension_semantics=(
+                    "parallel",
+                    "parallel",
+                    "parallel",
+                    "arbitrary",
+                )
+        ),
+    )(q, k, v, ab, q_segment_ids, kv_segment_ids, l, m, do, di)
+    assert dk.shape == k.shape
+    assert dv.shape == v.shape
+  return dk, dv
+
+
+def _flash_attention_dq_kernel(
+    q_tile_ref,
+    k_tile_ref,
+    v_tile_ref,
+    ab_tile_ref,
+    q_segment_ids_tile_ref,
+    kv_segment_ids_tile_ref,
+    l_tile_ref,
+    m_tile_ref,
+    do_tile_ref,
+    di_tile_ref,
+    dq_tile_ref,
+    ds_tile_ref,
+    dq_scratch_ref,
+    *,
+    sm_scale: float,
+    causal: bool,
+    mask_value: float,
+    kv_seq_len: int,
+    block_k: int,
+):
+  _, _, block_k_major, _ = k_tile_ref.shape
+  _, _, block_q_major, _ = q_tile_ref.shape
+
+  kv_seq_index = pl.program_id(axis=3)
+  q_seq_index = pl.program_id(axis=2)
+
+  @pl.when(kv_seq_index == 0)
+  def start_new_sequence():
+    dq_scratch_ref[:, :] = jnp.zeros(dq_scratch_ref.shape, dq_scratch_ref.dtype)
+
+  def body(i, _):
+    k_slice = pl.ds(i * block_k, block_k)
+    q = q_tile_ref[0, 0, :, :]
+    k = k_tile_ref[0, 0, k_slice, :]  # [block_k, head_dim]
+    v = v_tile_ref[0, 0, k_slice, :]  # [block_k, head_dim]
+    l = l_tile_ref[0, 0, :, :]  # [block_q_major, 128]
+    m = m_tile_ref[0, 0, :, :]  # [block_q_major, 128]
+    do = do_tile_ref[0, 0, :, :]  # [block_q_major, head_dim]
+    di = di_tile_ref[0, 0, :].astype(jnp.float32)  # [block_q_major, 128]
+
+    capped_logits = jax.lax.dot_general(
+        q, k, TRANS_B_DIM_NUMBERS, preferred_element_type=jnp.float32
+    )
+
+    if ab_tile_ref is not None:
+      ab = ab_tile_ref[0, 0, :, pl.dslice(i * block_k, block_k)].astype(
+          jnp.float32
+      )
+      capped_logits += ab
+
+    if sm_scale != 1.0:
+      capped_logits *= sm_scale
+
+    mask = None
+    if q_segment_ids_tile_ref is not None:
+      repeats, rem = divmod(block_k, NUM_LANES)
+      if rem:
+        raise NotImplementedError(
+            f"kv block size must be a multiple of {NUM_LANES}"
+        )
+      q_segment_ids = jnp.tile(
+          q_segment_ids_tile_ref[0], (1, repeats)
+      )  # [block_q, block_k].
+      kv_segment_ids = kv_segment_ids_tile_ref[:, 0, k_slice]  # [1, block_k].
+      mask = jnp.equal(q_segment_ids, kv_segment_ids).astype(jnp.bool_)
+
+    if causal:
+      mask_shape = (block_q_major, block_k)
+      row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+      row_ids += q_seq_index * block_q_major
+      col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+      col_ids += kv_seq_index * block_k_major + i * block_k
+      causal_mask = col_ids <= row_ids
+      mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+    capped_logits = (
+        capped_logits
+        if mask is None
+        else capped_logits + jnp.where(mask, 0.0, mask_value)
+    )
+
+    p = jnp.exp(
+        capped_logits - jnp.tile(m, (1, block_k // MIN_BLOCK_SIZE))
+    )
+    p = p * jnp.tile(
+        1 / l, (1, block_k // MIN_BLOCK_SIZE)
+    )  # [block_q_major, block_k]
+
+    # di: [block_q_major, 128]
+    # do: [block_q_major, head_dim]
+    # v: [block_k_major, head_dim]
+    dp = jax.lax.dot_general(
+        do,
+        v,
+        TRANS_B_DIM_NUMBERS,
+        preferred_element_type=jnp.float32,
+    )
+    ds = (dp - jnp.tile(di, (1, block_k // MIN_BLOCK_SIZE))) * p
+    # dp = jnp.dot(do, v.T)
+    # ds = (dp - (dp * p).sum(axis=1)[:, None]) * p
+
+    if sm_scale != 1.0:
+      ds = ds * sm_scale
+
+    if ds_tile_ref is not None:
+      ds_tile_ref[0, 0, :, pl.dslice(i * block_k, block_k)] = ds.astype(
+          ds_tile_ref.dtype
+      )
+
+    # dp: [block_q_major, block_k]
+    # k: [block_k, head_dim]
+    dq_scratch_ref[:, :] += lax.dot(
+        ds.astype(k.dtype),
+        k,
+        preferred_element_type=jnp.float32,
+    ).astype(dq_scratch_ref.dtype)
+
+  if causal:
+    should_run = below_or_on_diag(
+        q_seq_index, block_q_major, kv_seq_index, block_k_major
+    )
+    should_not_run = lax.select(should_run, False, True)
+  else:
+    should_run = True
+    should_not_run = False  # type: ignore
+
+  @pl.when(should_run)
+  def run():
+    lax.fori_loop(0, block_k_major // block_k, body, None, unroll=True)
+
+  @pl.when(should_not_run)
+  def zero_out_ds():
+    if ds_tile_ref is not None:
+      ds_tile_ref[...] = jnp.zeros_like(ds_tile_ref)
+
+  @pl.when(kv_seq_index == kv_seq_len // block_k_major - 1)
+  def end_of_kv_sequence():
+    dq_tile_ref[0, 0, :, :] = dq_scratch_ref[...].astype(dq_tile_ref.dtype)
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+
+def _flash_attention_bwd_dq(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids,
+    l,
+    m,
+    do,
+    di,
+    *,
+    block_q_major: int | None,
+    block_k_major: int | None,
+    block_k: int | None,
+    sm_scale: float,
+    causal: bool,
+    mask_value: float,
+    debug: bool,
+):
+  batch_size, num_heads, q_seq_len, head_dim = q.shape
+  _, _, kv_seq_len, _ = k.shape
+  _verify_block("block_q_dq", "q_seq_len", block_q_major, q_seq_len)
+  _verify_block("block_k_major_dq", "kv_seq_len", block_k_major, kv_seq_len)
+  _verify_block("block_k_dq", "block_k", block_k, kv_seq_len)
+
+  # Broadcast out scalar values
+  m = jnp.broadcast_to(m[..., None], (*m.shape, MIN_BLOCK_SIZE))
+  l = jnp.broadcast_to(l[..., None], (*l.shape, MIN_BLOCK_SIZE))
+  # Preprocess contraction for bwd pass
+  di = jnp.broadcast_to(di[..., None], (*di.shape, block_k_major))
+
+  grid = (
+      batch_size,
+      num_heads,
+      q_seq_len // block_q_major,
+      kv_seq_len // block_k_major,
+  )
+
+  def qo_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  qo_spec = pl.BlockSpec((1, 1, block_q_major, head_dim), qo_index_map)
+  do_spec = qo_spec
+
+  def kv_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    if causal:
+      # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+      # 0th one to be used for the next block_q rows.
+      next_kv_index = lax.select(
+          below_or_on_diag(
+              q_seq_index, block_q_major, kv_seq_index, block_k_major
+          ),
+          kv_seq_index,
+          0,
+      )
+    else:
+      next_kv_index = kv_seq_index
+    return (batch_index, head_index, next_kv_index, 0)
+
+  kv_spec = pl.BlockSpec((1, 1, block_k_major, head_dim), kv_index_map)
+  assert kv_spec.block_shape is not None
+  assert k.ndim == len(kv_spec.block_shape)
+  assert v.ndim == len(kv_spec.block_shape)
+
+  def lm_index_map(batch_index, head_index, q_seq_index, _):
+    return (batch_index, head_index, q_seq_index, 0)
+
+  lm_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), lm_index_map)
+  assert lm_spec.block_shape is not None
+  assert l.ndim == len(lm_spec.block_shape)
+  assert m.ndim == len(lm_spec.block_shape)
+
+  di_spec = pl.BlockSpec((1, 1, block_q_major, MIN_BLOCK_SIZE), qo_index_map)
+  assert di_spec.block_shape is not None
+  assert di.ndim == len(di_spec.block_shape)
+
+  def ab_index_map(batch_index, head_index, q_seq_index, kv_seq_index):
+    return (batch_index, head_index, q_seq_index, kv_seq_index)
+
+  dab_spec = (
+      pl.BlockSpec((1, 1, block_q_major, block_k_major), ab_index_map)
+      if ab is not None
+      else None
+  )
+
+  q_segment_ids_spec = kv_segment_ids_spec = None
+  q_segment_ids = kv_segment_ids = None
+  if segment_ids is not None:
+
+    def q_segment_ids_index_map(batch_index, head_index, q_seq_index, _):
+      del head_index
+      return (batch_index, q_seq_index, 0)
+
+    def kv_segment_ids_index_map(
+        batch_index, head_index, q_seq_index, kv_seq_index
+    ):
+      del head_index
+      if causal:
+        # If the kv block is skipped, prefetch the next valid kv block, i.e. the
+        # 0th one to be used for the next block_q rows.
+        next_kv_index = lax.select(
+            below_or_on_diag(
+                q_seq_index, block_q_major, kv_seq_index, block_k_major
+            ),
+            kv_seq_index,
+            0,
+        )
+      else:
+        next_kv_index = kv_seq_index
+      return (batch_index, 0, next_kv_index)
+
+    q_segment_ids_spec = pl.BlockSpec(
+        (1, block_q_major, NUM_LANES), q_segment_ids_index_map
+    )
+    kv_segment_ids_spec = pl.BlockSpec(
+        (1, NUM_SUBLANES, block_k_major), kv_segment_ids_index_map
+    )
+
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q,
+        (batch_size, q_seq_len, NUM_LANES),
+        (
+            0,
+            1,
+        ),
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv,
+        (batch_size, NUM_SUBLANES, kv_seq_len),
+        (
+            0,
+            2,
+        ),
+    )
+
+  in_specs = [
+      qo_spec,
+      kv_spec,
+      kv_spec,
+      dab_spec,
+      q_segment_ids_spec,
+      kv_segment_ids_spec,
+      lm_spec,
+      lm_spec,
+      do_spec,
+      di_spec,
+  ]
+
+  out_shapes = [
+      jax.ShapeDtypeStruct(q.shape, q.dtype),
+      jax.ShapeDtypeStruct(ab.shape, ab.dtype) if ab is not None else None,
+  ]
+  dq_spec = pl.BlockSpec((1, 1, block_q_major, head_dim), qo_index_map)
+  out_specs = [
+      dq_spec,
+      dab_spec,
+  ]
+  scratch_shapes = [pltpu.VMEM((block_q_major, head_dim), jnp.float32)]  # type: ignore
+
+  kernel = functools.partial(
+      _flash_attention_dq_kernel,
+      sm_scale=sm_scale,
+      causal=causal,
+      mask_value=mask_value,
+      block_k=block_k,  # type: ignore
+      kv_seq_len=kv_seq_len,
+  )
+  name_scope = f"flash_mha_bwd_dq_{block_q_major=}_{block_k_major=}_{block_k=}"
+  with jax.named_scope(name_scope):
+    dq, ds = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=0,
+            grid=grid,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            scratch_shapes=scratch_shapes,
+        ),
+        out_shape=out_shapes,
+        debug=debug,
+        compiler_params=pltpu.CompilerParams(
+                dimension_semantics=(
+                    "parallel",
+                    "parallel",
+                    "parallel",
+                    "arbitrary",
+                )
+        ),
+    )(q, k, v, ab, q_segment_ids, kv_segment_ids, l, m, do, di)
+
+  # dab is just ds
+  return dq, ds
+
+
+# For autograd testing.
+def mha_reference_no_custom_vjp(
+    q,
+    k,
+    v,
+    ab: jax.Array | None = None,
+    segment_ids: SegmentIds | None = None,
+    *,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale: float = 1.0,
+    save_residuals: bool = False,
+):
+  logits = jnp.einsum("bhqc,bhkc->bhqk", q, k)
+  if ab is not None:
+    logits += ab
+  if sm_scale != 1.0:
+    logits *= sm_scale
+
+  mask = None
+  if segment_ids is not None:
+    mask = segment_ids.q[:, :, None] == segment_ids.kv[:, None, :]
+    mask = mask[:, None, :, :]
+
+  if causal:
+    _, _, q_seq_len, _ = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    mask_shape = (q_seq_len, kv_seq_len)
+    row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+    col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+    causal_mask = (col_ids <= row_ids)[None, None, :, :]
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+
+  logits = logits if mask is None else logits + jnp.where(mask, 0.0, mask_value)
+
+  m = logits.max(axis=-1)
+  unnormalized = jnp.exp(logits - m[..., None])
+  l = unnormalized.sum(axis=-1)
+  weights = unnormalized / l[..., None]
+  out = jnp.einsum("bhqk,bhkc->bhqc", weights, v)
+  if save_residuals:
+    return out, l, m
+  return out
+
+
+@functools.partial(
+    jax.jit, static_argnames=["causal", "mask_value", "sm_scale"]
+)
+@jax.default_matmul_precision("bfloat16")
+def mha_reference(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None = None,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale=1.0,
+):
+  return _mha_reference(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+      save_residuals=False,
+  )
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnames=("causal", "mask_value", "sm_scale", "save_residuals"))
+def _mha_reference(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+):
+  return mha_reference_no_custom_vjp(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+      save_residuals=save_residuals,
+  )
+
+
+def _mha_reference_fwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+):
+  if save_residuals:
+    raise NotImplementedError
+  res = _mha_reference(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+      save_residuals=True,
+  )
+  assert isinstance(res, tuple)
+  out, l, m = res
+  return out, (q, k, v, ab, segment_ids, out, l, m)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "causal",
+        "mask_value",
+        "sm_scale",
+    ],
+)
+def mha_reference_bwd(
+    q,
+    k,
+    v,
+    ab,
+    segment_ids: SegmentIds | None,
+    o,
+    l,
+    m,
+    do,
+    causal: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    sm_scale: float = 1.0,
+):
+  if sm_scale != 1.0:
+    raise NotImplementedError
+
+  logits = jnp.einsum(
+      "bhqc,bhkc->bhqk",
+      q.astype(jnp.float32),
+      k.astype(jnp.float32),
+  )
+  if ab is not None:
+    logits += ab
+
+  mask = None
+  if segment_ids is not None:
+    mask = segment_ids.q[:, :, None] == segment_ids.kv[:, None, :]
+    mask = mask[:, None, :, :]
+
+  if causal:
+    _, _, q_seq_len, _ = q.shape
+    _, _, kv_seq_len, _ = k.shape
+    mask_shape = (q_seq_len, kv_seq_len)
+    row_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 0)
+    col_ids = jax.lax.broadcasted_iota(jnp.int32, mask_shape, 1)
+    causal_mask = (col_ids <= row_ids)[None, None, :, :]
+    mask = causal_mask if mask is None else jnp.logical_and(mask, causal_mask)
+
+  logits = logits if mask is None else logits + jnp.where(mask, 0.0, mask_value)
+
+  unnormalized = jnp.exp(logits - m[..., None])
+  p = unnormalized / l[..., None]
+  dv = jnp.einsum("bhpt,bhpd->bhtd", p, do.astype(jnp.float32)).astype(v.dtype)
+
+  dp = jnp.einsum(
+      "bhpd,bhtd->bhpt", do.astype(jnp.float32), v.astype(jnp.float32)
+  )
+
+  di = jnp.sum(o.astype(jnp.float32) * do.astype(jnp.float32), axis=-1)[
+      ..., None
+  ]  # [batch_size, num_heads, q_seq_len]
+
+  ds = (dp - di) * p
+  dk = jnp.einsum("bhsd,bhst->bhtd", q.astype(jnp.float32), ds).astype(k.dtype)
+  dq = jnp.einsum("bhst,bhtd->bhsd", ds, k.astype(jnp.float32)).astype(q.dtype)
+
+  # dab is just ds
+  dab = ds if ab is not None else None
+  return dq, dk, dv, dab
+
+
+def _mha_reference_bwd(
+    causal: bool,
+    mask_value: float,
+    sm_scale: float,
+    save_residuals: bool,
+    residuals,
+    do,
+):
+  del save_residuals
+  q, k, v, ab, segment_ids, o, l, m = residuals
+  dq, dk, dv, dab = mha_reference_bwd(
+      q,
+      k,
+      v,
+      ab,
+      segment_ids,
+      o,
+      l,
+      m,
+      do,
+      causal=causal,
+      mask_value=mask_value,
+      sm_scale=sm_scale,
+  )
+  return dq, dk, dv, dab, None
+
+
+_mha_reference.defvjp(fwd=_mha_reference_fwd, bwd=_mha_reference_bwd)
+
+
+def _verify_block(block_name, dim_name, block, dim, should_divide=True):
+  if block > dim:
+    raise ValueError(
+        f"{block_name}={block} should be smaller or equal to {dim_name}={dim}"
+    )
+  if should_divide and dim % block != 0:
+    raise ValueError(
+        f"{dim_name}={dim} should be divisible by {block_name}={block}"
+    )
+
+
+CONFIG = {
+    'name': 'deepseek_v3_mla_optimized',
+    'model': 'DeepSeek-V3-671B',
+    'operator': 'mla_attention',
+    'batch': 4,
+    'seq_len': 2048,
+    'emb_dim': 7168,
+    'num_heads': 128,
+    'q_lora_rank': 1536,
+    'kv_lora_rank': 512,
+    'qk_nope_head_dim': 128,
+    'qk_rope_head_dim': 64,
+    'v_head_dim': 128,
+    'rope_theta': 10000,
+}
+
+# Flash attention requires head_dim to be a multiple of 128.
+# d_qk = 192 (128 nope + 64 rope) -> pad to 256
+_PAD_HEAD_DIM = 256
+
+# Tuned by autotune_block_sizes.py for head_dim=128. Re-run for 256.
+TUNED_PARAMS = {
+    'block_q': 2048,
+    'block_k_major': 2048,
+    'block_k': 1024,
+    'block_b': 1,
+    'block_q_major_dkv': 128,
+    'block_k_major_dkv': 128,
+    'block_k_dkv': 128,
+    'block_q_dkv': 128,
+    'block_k_major_dq': 128,
+    'block_k_dq': 128,
+    'block_q_dq': 128,
+}
+
+
+def _apply_rope(x, cos, sin):
+    d = x.shape[-1]
+    x1, x2 = x[..., :d // 2], x[..., d // 2:]
+    return jnp.concatenate([x1 * cos - x2 * sin, x2 * cos + x1 * sin], axis=-1)
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns MLA inputs matching the baseline."""
+    key = jax.random.key(42)
+    keys = jax.random.split(key, 9)
+    C = CONFIG
+    B, S, E = C['batch'], C['seq_len'], C['emb_dim']
+    H = C['num_heads']
+    ql, kvl = C['q_lora_rank'], C['kv_lora_rank']
+    nope, rope, vd = C['qk_nope_head_dim'], C['qk_rope_head_dim'], C['v_head_dim']
+    x = jax.random.normal(keys[0], (B, S, E), dtype=dtype)
+    q_down = jax.random.normal(keys[1], (E, ql), dtype=dtype) * 0.02
+    q_up = jax.random.normal(keys[2], (ql, H * (nope + rope)), dtype=dtype) * 0.02
+    kv_down = jax.random.normal(keys[3], (E, kvl + rope), dtype=dtype) * 0.02
+    k_up = jax.random.normal(keys[4], (kvl, H * nope), dtype=dtype) * 0.02
+    v_up = jax.random.normal(keys[5], (kvl, H * vd), dtype=dtype) * 0.02
+    o_proj = jax.random.normal(keys[6], (H * vd, E), dtype=dtype) * 0.02
+    return x, q_down, q_up, kv_down, k_up, v_up, o_proj
+
+
+def workload(x, q_down, q_up, kv_down, k_up, v_up, o_proj):
+    """MLA with Pallas flash attention (padded head_dim=256)."""
+    C = CONFIG
+    B, S, E, H = C['batch'], C['seq_len'], C['emb_dim'], C['num_heads']
+    nope, rope, vd = C['qk_nope_head_dim'], C['qk_rope_head_dim'], C['v_head_dim']
+    d_qk = nope + rope  # 192
+    kvl = C['kv_lora_rank']
+
+    # LoRA projections
+    q_compressed = jnp.dot(x, q_down)
+    q_full = jnp.dot(q_compressed, q_up).reshape(B, S, H, d_qk)
+    q_nope, q_rope_part = q_full[..., :nope], q_full[..., nope:]
+
+    kv_compressed = jnp.dot(x, kv_down)  # (B, S, kvl + rope)
+    k_nope = jnp.dot(kv_compressed[:, :, :kvl], k_up).reshape(B, S, H, nope)
+    v = jnp.dot(kv_compressed[:, :, :kvl], v_up).reshape(B, S, H, vd)
+
+    # RoPE
+    pos = jnp.arange(S)
+    freqs = 1.0 / (C['rope_theta'] ** (jnp.arange(0, rope, 2, dtype=jnp.float32) / rope))
+    angles = jnp.outer(pos, freqs)
+    cos, sin = jnp.cos(angles), jnp.sin(angles)
+    q_rope_part = _apply_rope(q_rope_part, cos[None, :, None, :], sin[None, :, None, :])
+    rope_input = kv_compressed[:, :, kvl:]  # (B, S, rope)
+    rope_input = jnp.broadcast_to(rope_input[:, :, None, :], (B, S, H, rope))
+    k_rope_part = _apply_rope(
+        rope_input,
+        cos[None, :, None, :], sin[None, :, None, :]
+    )
+
+    # Concatenate Q/K, pad V to match
+    q = jnp.concatenate([q_nope, q_rope_part], axis=-1)  # (B, S, H, 192)
+    k = jnp.concatenate([k_nope, k_rope_part], axis=-1)  # (B, S, H, 192)
+
+    # Pad to 256 for flash attention
+    pad_size = _PAD_HEAD_DIM - d_qk  # 64
+    q = jnp.pad(q, ((0,0), (0,0), (0,0), (0, pad_size)))  # (B, S, H, 256)
+    k = jnp.pad(k, ((0,0), (0,0), (0,0), (0, pad_size)))
+    v_padded = jnp.pad(v, ((0,0), (0,0), (0,0), (0, _PAD_HEAD_DIM - vd)))  # (B, S, H, 256)
+
+    # Transpose to BHSD for flash_attention
+    q = q.transpose(0, 2, 1, 3)  # (B, H, S, 256)
+    k = k.transpose(0, 2, 1, 3)
+    v_padded = v_padded.transpose(0, 2, 1, 3)
+
+    # Pallas flash attention
+    sm_scale = d_qk ** -0.5
+    block_sizes = BlockSizes(
+        block_q=TUNED_PARAMS['block_q'],
+        block_k_major=TUNED_PARAMS['block_k_major'],
+        block_k=TUNED_PARAMS['block_k'],
+        block_b=TUNED_PARAMS['block_b'],
+        block_q_major_dkv=TUNED_PARAMS['block_q_major_dkv'],
+        block_k_major_dkv=TUNED_PARAMS['block_k_major_dkv'],
+        block_k_dkv=TUNED_PARAMS['block_k_dkv'],
+        block_q_dkv=TUNED_PARAMS['block_q_dkv'],
+        block_k_major_dq=TUNED_PARAMS['block_k_major_dq'],
+        block_k_dq=TUNED_PARAMS['block_k_dq'],
+        block_q_dq=TUNED_PARAMS['block_q_dq'],
+    )
+    attn_out = flash_attention(q, k, v_padded, causal=True, sm_scale=sm_scale, block_sizes=block_sizes)
+
+    # Slice back to d_v and output projection
+    attn_out = attn_out[..., :vd]  # (B, H, S, d_v=128)
+    attn_out = attn_out.transpose(0, 2, 1, 3).reshape(B, S, H * vd)
+    return jnp.dot(attn_out, o_proj)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, D, H = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim'], CONFIG['num_heads']
+    d_qk = CONFIG['qk_nope_head_dim'] + CONFIG['qk_rope_head_dim']
+    d_v = CONFIG['v_head_dim']
+    proj_flops = 2 * B * S * (D * CONFIG['q_lora_rank'] + CONFIG['q_lora_rank'] * H * d_qk +
+                                D * CONFIG['kv_lora_rank'] + CONFIG['kv_lora_rank'] * H * CONFIG['qk_nope_head_dim'] +
+                                CONFIG['kv_lora_rank'] * H * d_v + H * d_v * D)
+    attn_flops = B * H * (2 * S * S * d_qk + 2 * S * S * d_v)
+    flops = proj_flops + attn_flops
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/40k_Gemm_GroupNorm_Min_BiasAdd/baseline.py
+++ b/JAXBench/benchmark/40k_Gemm_GroupNorm_Min_BiasAdd/baseline.py
@@ -1,0 +1,80 @@
+"""75_Gemm_GroupNorm_Min_BiasAdd — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '75_Gemm_GroupNorm_Min_BiasAdd',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'num_groups': 512,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_features, out_features, num_groups = 4096, 8192, 8192, 512
+    x = jax.random.uniform(key, (batch_size, in_features), dtype=dtype)
+    weight = jnp.zeros((out_features, in_features), dtype=dtype)
+    linear_bias = jnp.zeros(out_features, dtype=dtype)
+    gn_weight = jnp.ones(out_features, dtype=dtype)
+    gn_bias = jnp.zeros(out_features, dtype=dtype)
+    bias = jnp.zeros((1, out_features, 1, 1), dtype=dtype)
+    return x, weight, linear_bias, gn_weight, gn_bias, bias
+
+
+def workload(x, weight, linear_bias, gn_weight, gn_bias, bias):
+    """Gemm + GroupNorm + Min + BiasAdd."""
+    num_groups = 512
+    eps = 1e-5
+    # Linear
+    x = jnp.matmul(x, weight.T) + linear_bias
+    # GroupNorm
+    N, C = x.shape
+    G = num_groups
+    x = x.reshape(N, G, C // G)
+    mean = jnp.mean(x, axis=2, keepdims=True)
+    var = jnp.var(x, axis=2, keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + eps)
+    x = x.reshape(N, C)
+    x = x * gn_weight + gn_bias
+    # Min along features
+    x = jnp.min(x, axis=1, keepdims=True)
+    # Reshape and bias add
+    x = x.reshape(1, 1, N, 1)
+    x = x + bias
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/41k_Gemm_Add_ReLU/baseline.py
+++ b/JAXBench/benchmark/41k_Gemm_Add_ReLU/baseline.py
@@ -1,0 +1,60 @@
+"""76_Gemm_Add_ReLU — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '76_Gemm_Add_ReLU',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Gemm + Add(bias) + ReLU."""
+    x = jnp.matmul(x, weight)
+    x = x + bias
+    x = jax.nn.relu(x)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/42k_Gemm_Max_Subtract_GELU/baseline.py
+++ b/JAXBench/benchmark/42k_Gemm_Max_Subtract_GELU/baseline.py
@@ -1,0 +1,62 @@
+"""80_Gemm_Max_Subtract_GELU — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '80_Gemm_Max_Subtract_GELU',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'max_dim': 1,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Gemm + Max + Subtract(mean) + GELU."""
+    x = jnp.matmul(x, weight) + bias
+    x = jnp.max(x, axis=1, keepdims=True)
+    x = x - jnp.mean(x, axis=1, keepdims=True)
+    x = jax.nn.gelu(x)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/43k_Gemm_BatchNorm_Scaling_Softmax/baseline.py
+++ b/JAXBench/benchmark/43k_Gemm_BatchNorm_Scaling_Softmax/baseline.py
@@ -1,0 +1,75 @@
+"""84_Gemm_BatchNorm_Scaling_Softmax — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '84_Gemm_BatchNorm_Scaling_Softmax',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'bn_eps': 1e-05,
+    'bn_momentum': 0.1,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_features, out_features = 4096, 8192, 8192
+    x = jax.random.uniform(key, (batch_size, in_features), dtype=dtype)
+    weight = jnp.zeros((in_features, out_features), dtype=dtype)
+    bias = jnp.zeros(out_features, dtype=dtype)
+    bn_scale = jnp.ones(out_features, dtype=dtype)
+    bn_bias = jnp.zeros(out_features, dtype=dtype)
+    bn_mean = jnp.zeros(out_features, dtype=dtype)
+    bn_var = jnp.ones(out_features, dtype=dtype)
+    scale = jnp.ones((1,), dtype=dtype)
+    return x, weight, bias, bn_scale, bn_bias, bn_mean, bn_var, scale
+
+
+def workload(x, weight, bias, bn_scale, bn_bias, bn_mean, bn_var, scale):
+    """Gemm + BatchNorm + Scaling + Softmax."""
+    bn_eps = 1e-5
+    # Linear
+    x = jnp.matmul(x, weight) + bias
+    # BatchNorm (eval mode with running stats)
+    x_normalized = (x - bn_mean) / jnp.sqrt(bn_var + bn_eps)
+    x = bn_scale * x_normalized + bn_bias
+    # Scale
+    x = scale * x
+    # Softmax
+    x = jax.nn.softmax(x, axis=1)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/44k_Matmul_Divide_GELU/baseline.py
+++ b/JAXBench/benchmark/44k_Matmul_Divide_GELU/baseline.py
@@ -1,0 +1,61 @@
+"""86_Matmul_Divide_GELU — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '86_Matmul_Divide_GELU',
+    'batch_size': 4096,
+    'input_size': 8192,
+    'output_size': 8192,
+    'divisor': 10.0,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + Divide + GELU."""
+    x = x @ weight + bias
+    x = x / 10.0
+    x = jax.nn.gelu(x)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/45k_Gemm_GroupNorm_Swish_Multiply_Swish/baseline.py
+++ b/JAXBench/benchmark/45k_Gemm_GroupNorm_Swish_Multiply_Swish/baseline.py
@@ -1,0 +1,81 @@
+"""88_Gemm_GroupNorm_Swish_Multiply_Swish — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '88_Gemm_GroupNorm_Swish_Multiply_Swish',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'num_groups': 256,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_features, out_features, num_groups = 4096, 8192, 8192, 256
+    x = jax.random.uniform(key, (batch_size, in_features), dtype=dtype)
+    gemm_weight = jnp.zeros((out_features, in_features), dtype=dtype)
+    gemm_bias = jnp.zeros(out_features, dtype=dtype)
+    gn_weight = jnp.ones(out_features, dtype=dtype)
+    gn_bias = jnp.zeros(out_features, dtype=dtype)
+    multiply_weight = jnp.zeros(out_features, dtype=dtype)
+    return x, gemm_weight, gemm_bias, gn_weight, gn_bias, multiply_weight
+
+
+def workload(x, gemm_weight, gemm_bias, gn_weight, gn_bias, multiply_weight):
+    """Gemm + GroupNorm + Swish + Multiply + Swish."""
+    num_groups = 256
+    out_features = 8192
+    # Linear
+    x = jnp.matmul(x, gemm_weight.T) + gemm_bias
+    # GroupNorm
+    batch_size = x.shape[0]
+    group_size = out_features // num_groups
+    x_grouped = x.reshape(batch_size, num_groups, group_size)
+    mean = jnp.mean(x_grouped, axis=-1, keepdims=True)
+    var = jnp.var(x_grouped, axis=-1, keepdims=True)
+    x_normalized = (x_grouped - mean) / jnp.sqrt(var + 1e-5)
+    x = x_normalized.reshape(batch_size, out_features)
+    x = x * gn_weight + gn_bias
+    # Swish
+    x = x * jax.nn.sigmoid(x)
+    # Multiply
+    x = x * multiply_weight
+    # Swish
+    x = x * jax.nn.sigmoid(x)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/46k_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp/baseline.py
+++ b/JAXBench/benchmark/46k_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp/baseline.py
@@ -1,0 +1,93 @@
+"""92_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '92_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp',
+    'batch_size': 128,
+    'in_channels': 8,
+    'out_channels': 64,
+    'kernel_size': 3,
+    'groups': 16,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_channels, out_channels, kernel_size, groups = 128, 8, 64, 3, 16
+    height, width = 128, 128
+    x = jax.random.uniform(key, (batch_size, in_channels, height, width), dtype=dtype)
+    conv_weight = jnp.zeros((out_channels, in_channels, kernel_size, kernel_size), dtype=dtype)
+    conv_bias = jnp.zeros(out_channels, dtype=dtype)
+    gn_weight = jnp.ones(out_channels, dtype=dtype)
+    gn_bias = jnp.zeros(out_channels, dtype=dtype)
+    return x, conv_weight, conv_bias, gn_weight, gn_bias
+
+
+def workload(x, conv_weight, conv_bias, gn_weight, gn_bias):
+    """Conv2d + GroupNorm + Tanh + HardSwish + ResidualAdd + LogSumExp."""
+    groups = 16
+    eps = 1e-5
+    # Conv2d
+    x_nhwc = jnp.transpose(x, (0, 2, 3, 1))
+    kernel = jnp.transpose(conv_weight, (2, 3, 1, 0))
+    x_conv = jax.lax.conv_general_dilated(
+        x_nhwc, kernel,
+        window_strides=(1, 1),
+        padding='VALID',
+        dimension_numbers=('NHWC', 'HWIO', 'NHWC'))
+    x_conv = x_conv + conv_bias.reshape(1, 1, 1, -1)
+    x_conv = jnp.transpose(x_conv, (0, 3, 1, 2))  # NHWC -> NCHW
+
+    # GroupNorm
+    N, C, H, W = x_conv.shape
+    x = x_conv.reshape(N, groups, C // groups, H, W)
+    mean = jnp.mean(x, axis=(2, 3, 4), keepdims=True)
+    var = jnp.var(x, axis=(2, 3, 4), keepdims=True)
+    x = (x - mean) / jnp.sqrt(var + eps)
+    x = x.reshape(N, C, H, W)
+    x_norm = x * gn_weight.reshape(1, -1, 1, 1) + gn_bias.reshape(1, -1, 1, 1)
+
+    # Tanh
+    x_tanh = jnp.tanh(x_norm)
+    # HardSwish
+    x_hard_swish = x_tanh * jnp.minimum(jnp.maximum(x_tanh + 3, 0), 6) / 6
+    # Residual Add
+    x_res = x_conv + x_hard_swish
+    # LogSumExp
+    x_logsumexp = jax.scipy.special.logsumexp(x_res, axis=1, keepdims=True)
+    return x_logsumexp
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/47k_Matmul_Add_Swish_Tanh_GELU_Hardtanh/baseline.py
+++ b/JAXBench/benchmark/47k_Matmul_Add_Swish_Tanh_GELU_Hardtanh/baseline.py
@@ -1,0 +1,64 @@
+"""95_Matmul_Add_Swish_Tanh_GELU_Hardtanh — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '95_Matmul_Add_Swish_Tanh_GELU_Hardtanh',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    add_value = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias, add_value
+
+
+def workload(x, weight, bias, add_value):
+    """Matmul + Add + Swish + Tanh + GELU + Hardtanh."""
+    x = x @ weight + bias
+    x = x + add_value
+    x = jax.nn.swish(x)
+    x = jnp.tanh(x)
+    x = jax.nn.gelu(x)
+    x = jnp.clip(x, -1.0, 1.0)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/48k_Matmul_BatchNorm_BiasAdd_Divide_Swish/baseline.py
+++ b/JAXBench/benchmark/48k_Matmul_BatchNorm_BiasAdd_Divide_Swish/baseline.py
@@ -1,0 +1,78 @@
+"""97_Matmul_BatchNorm_BiasAdd_Divide_Swish — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '97_Matmul_BatchNorm_BiasAdd_Divide_Swish',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'bn_eps': 1e-05,
+    'bn_momentum': 0.1,
+    'divide_value': 1.0,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    batch_size, in_features, out_features = 4096, 8192, 8192
+    x = jax.random.uniform(key, (batch_size, in_features), dtype=dtype)
+    weight = jnp.zeros((in_features, out_features), dtype=dtype)
+    linear_bias = jnp.zeros(out_features, dtype=dtype)
+    bn_scale = jnp.ones(out_features, dtype=dtype)
+    bn_bias = jnp.zeros(out_features, dtype=dtype)
+    bn_mean = jnp.zeros(out_features, dtype=dtype)
+    bn_var = jnp.ones(out_features, dtype=dtype)
+    bias = jnp.zeros((1,), dtype=dtype)
+    return x, weight, linear_bias, bn_scale, bn_bias, bn_mean, bn_var, bias
+
+
+def workload(x, weight, linear_bias, bn_scale, bn_bias, bn_mean, bn_var, bias):
+    """Matmul + BatchNorm + BiasAdd + Divide + Swish."""
+    bn_eps = 1e-5
+    divide_value = 1.0
+    # Linear
+    x = jnp.matmul(x, weight) + linear_bias
+    # BatchNorm (eval mode)
+    x_normalized = (x - bn_mean) / jnp.sqrt(bn_var + bn_eps)
+    x = bn_scale * x_normalized + bn_bias
+    # Bias + divide
+    x = x + bias
+    x = x / divide_value
+    # Swish
+    x = x * jax.nn.sigmoid(x)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/49k_Matmul_AvgPool_GELU_Scale_Max/baseline.py
+++ b/JAXBench/benchmark/49k_Matmul_AvgPool_GELU_Scale_Max/baseline.py
@@ -1,0 +1,80 @@
+"""98_Matmul_AvgPool_GELU_Scale_Max — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '98_Matmul_AvgPool_GELU_Scale_Max',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+    'pool_kernel_size': 16,
+    'scale_factor': 2.0,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + AvgPool1d + GELU + Scale + Max."""
+    pool_kernel_size = 16
+    scale_factor = 2.0
+    # Linear
+    x = jnp.matmul(x, weight) + bias
+    # AvgPool1d
+    x = jnp.expand_dims(x, axis=1)
+    x = jax.lax.reduce_window(
+        x,
+        init_value=0.0,
+        computation=jax.lax.add,
+        window_dimensions=(1, 1, pool_kernel_size),
+        window_strides=(1, 1, pool_kernel_size),
+        padding='VALID'
+    ) / pool_kernel_size
+    x = jnp.squeeze(x, axis=1)
+    # GELU
+    x = jax.nn.gelu(x)
+    # Scale
+    x = x * scale_factor
+    # Max
+    x = jnp.max(x, axis=1)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/4p_Sparse_Attention/baseline.py
+++ b/JAXBench/benchmark/4p_Sparse_Attention/baseline.py
@@ -1,0 +1,98 @@
+"""Sparse (Splash) Attention — Llama-3.1-70B GQA with causal mask.
+
+Vanilla JAX baseline for sparse/splash attention: standard dot-product
+attention with causal masking and grouped-query attention (GQA).
+From MaxText kernels/attention/splash_attention_kernel.py.
+"""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'llama3_70b_sparse_attention',
+    'model': 'Llama-3.1-70B',
+    'operator': 'sparse_attention',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_query_heads': 64,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (q, k, v) tensors in [num_heads, seq_len, head_dim] layout."""
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    S = CONFIG['seq_len']
+    H_q = CONFIG['num_query_heads']
+    H_kv = CONFIG['num_kv_heads']
+    D = CONFIG['head_dim']
+    q = jax.random.normal(k1, (H_q, S, D), dtype=dtype) * (D ** -0.5)
+    k = jax.random.normal(k2, (H_kv, S, D), dtype=dtype) * 0.02
+    v = jax.random.normal(k3, (H_kv, S, D), dtype=dtype) * 0.02
+    return q, k, v
+
+
+def workload(q, k, v):
+    """Causal GQA attention: splash attention baseline."""
+    S = CONFIG['seq_len']
+    H_q = CONFIG['num_query_heads']
+    H_kv = CONFIG['num_kv_heads']
+    num_q_per_kv = H_q // H_kv
+
+    # Repeat KV heads for GQA
+    k = jnp.repeat(k, num_q_per_kv, axis=0)  # (H_q, S, D)
+    v = jnp.repeat(v, num_q_per_kv, axis=0)  # (H_q, S, D)
+
+    # Attention scores: (H_q, S, D) x (H_q, S, D) -> (H_q, S, S)
+    attn = jnp.einsum('hqd,hkd->hqk', q, k)
+
+    # Causal mask
+    causal = jnp.tril(jnp.ones((S, S), dtype=jnp.bool_))
+    attn = jnp.where(causal[None, :, :], attn, -1e30)
+
+    attn = jax.nn.softmax(attn, axis=-1)
+
+    # Output: (H_q, S, S) x (H_q, S, D) -> (H_q, S, D)
+    out = jnp.einsum('hqk,hkd->hqd', attn, v)
+    return out
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    H_q = CONFIG['num_query_heads']
+    S = CONFIG['seq_len']
+    D = CONFIG['head_dim']
+    # QK dot: 2*H*S*S*D, AV dot: 2*H*S*S*D
+    flops = 4 * H_q * S * S * D
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/4p_Sparse_Attention/optimized.py
+++ b/JAXBench/benchmark/4p_Sparse_Attention/optimized.py
@@ -1,0 +1,2648 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of Sparse Flash Attention, a.k.a. "Splash" attention."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+import dataclasses
+import enum
+import functools
+from typing import Any, Literal, NamedTuple, Optional, Union, overload
+
+import jax
+from jax import ad_checkpoint
+from jax import lax
+from jax import tree_util
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask as mask_lib
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask_info as mask_info_lib
+import jax.numpy as jnp
+import numpy as np
+
+partial = functools.partial
+DEFAULT_MASK_VALUE = -0.7 * float(np.finfo(np.dtype("float32")).max)
+NUM_LANES = 128
+NUM_SUBLANES = 8
+# We predefine some useful dimension numbers for dot_general
+NN_DIM_NUMBERS = (((1,), (0,)), ((), ()))  # standard matmul
+NT_DIM_NUMBERS = (((1,), (1,)), ((), ()))  # RHS transposed
+
+# mypy: ignore-errors
+
+class SegmentIds(NamedTuple):
+  """SegmentIds for Q and KV sequences.
+
+  SegmentIds are a mechanism to ensure that there is no cross-attention between
+  segments (fraction of a sequence) that have been concatenated together into a
+  sequence. Each array is a list of ids (integers). Only tokens with the same
+  id are allowed to attend to each other.
+
+  The static mask (e.g. causal) is "and-ed" with the segment id mask to form
+  the actual attention mask. It is important that the latter does not have any
+  all-zero rows (along dimension kv). Otherwise it would result in a invalid
+  softmax (the denominator would be 0).
+  This condition holds for causal self-attention because in this case segment
+  ids form a block diagonal matrix so at least one element in each row is set.
+  It is easy to break this condition with non-self-attention configurations.
+  Attributes:
+    q: segment ids along the Q sequence
+    kv: segment ids along the KV sequence
+  """
+
+  q: jax.Array  # [q_seq_len]
+  kv: jax.Array  # [kv_seq_len]
+
+
+# Return type of SplashAttention function that implements the custom vjp rule.
+SplashCustomReturnType = Union[
+    # out, no residuals
+    jax.Array,
+    # out, residuals:
+    tuple[jax.Array, tuple[jax.Array,]]
+]
+
+SplashResidualsType = tuple[
+    jax.Array,  # q
+    jax.Array,  # k
+    jax.Array,  # v
+    Optional[SegmentIds],  # segment_ids
+    jax.Array,  # out
+    jax.Array,  # logsumexp
+    Optional[mask_info_lib.MaskInfo],  # dq_mask_info
+    Optional[mask_info_lib.MaskInfo],  # dkv_mask_info
+]
+
+MaskFunctionType = Callable[..., jax.Array]
+
+
+def get_kernel_name(
+    block_metadata: Mapping[str, Any],
+    is_mqa: bool,
+    save_residuals: bool,
+    is_segmented: bool,
+    phase: str,
+) -> str:
+  """Returns a unique name for all SplashAttention kernel variants."""
+  assert phase == "dq" or phase == "dkv" or phase == "fwd"
+  # Saving residuals is supported only for the fwd phase.
+  assert not save_residuals or phase == "fwd"
+  residuals = ""
+  if save_residuals:
+    residuals = "_residuals"
+  elif phase == "fwd":
+    residuals = "_no_residuals"
+  attention_type = "mqa" if is_mqa else "mha"
+  segments = "_segmented" if is_segmented else ""
+  return f"splash_{attention_type}_{phase}{segments}{residuals}_" + "_".join(
+      f"{k}={v}" for k, v in sorted(block_metadata.items())
+  )
+
+
+# Reference attention implementations
+
+
+@overload
+def _attention_reference(
+    mask: jax.Array,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: Literal[False],
+    mask_value: float,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+) -> jax.Array:
+  ...
+
+
+@overload
+def _attention_reference(
+    mask: jax.Array,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: Literal[True],
+    mask_value: float,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+) -> tuple[jax.Array, tuple[jax.Array]]:
+  ...
+
+
+def _attention_reference(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+):
+  return _attention_reference_default(  # pytype: disable=bad-return-type
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value,
+      save_residuals,
+      custom_type,
+      attn_logits_soft_cap,
+  )
+
+
+def _attention_reference_default(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+):
+  del custom_type
+  logits = jnp.einsum("sd,td->st", q.astype(jnp.float32), k.astype(jnp.float32))
+
+  if segment_ids is not None:
+    mask = jnp.logical_and(
+        mask, segment_ids.q[:, None] == segment_ids.kv[None, :]
+    )
+
+  if attn_logits_soft_cap is not None:
+    logits = jnp.tanh(logits / attn_logits_soft_cap)
+    logits = logits * attn_logits_soft_cap
+
+  logits = jnp.where(mask, logits, mask_value)
+  m = logits.max(axis=-1)
+  s = jnp.exp(logits - m[..., None])
+  l = s.sum(axis=-1)
+  s = s / l[..., None]
+
+  o = jnp.einsum("st,td->sd", s, v.astype(jnp.float32))
+
+  logsumexp = m + jnp.log(l)
+  if save_residuals:
+    return o, (logsumexp,)
+  return o
+
+
+def attention_reference(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    *,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    save_residuals: bool = False,
+    custom_type: str = "flash",
+    attn_logits_soft_cap: float | None = None,
+) -> SplashCustomReturnType:
+  return _attention_reference(  # pytype: disable=wrong-arg-types
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      save_residuals=save_residuals,
+      custom_type=custom_type,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+  )
+
+
+def _attention_reference_custom_fwd(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+):
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported.")
+
+  o, (logsumexp,) = _attention_reference(
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      save_residuals=True,
+      custom_type=custom_type,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+  )
+  return o, (mask, q, k, v, segment_ids, o, logsumexp)
+
+
+def _attention_reference_custom_bwd(
+    mask_value: float,
+    save_residuals: bool,
+    custom_type: str,
+    attn_logits_soft_cap: float | None,
+    res,
+    do: jax.Array,
+) -> tuple[None, jax.Array, jax.Array, jax.Array, None]:
+  del save_residuals
+  mask, q, k, v, segment_ids, o, logsumexp = res
+
+  uncapped_logits = jnp.einsum(
+      "qc,kc->qk", q, k, preferred_element_type=jnp.float32)
+
+  if attn_logits_soft_cap is not None:
+    logits = jnp.tanh(uncapped_logits / attn_logits_soft_cap)
+    logits = logits * attn_logits_soft_cap
+  else:
+    logits = uncapped_logits
+
+  if segment_ids is not None:
+    mask = jnp.logical_and(
+        mask, segment_ids.q[:, None] == segment_ids.kv[None, :]
+    )
+  logits = jnp.where(mask, logits, mask_value)
+
+  p = jnp.exp(logits - logsumexp[..., None])
+  do = do.astype(jnp.float32)  # pytype: disable=attribute-error
+  dv = jnp.einsum("pt,pd->td", p, do).astype(v.dtype)
+  dp = jnp.einsum("pd,td->pt", do, v.astype(jnp.float32))
+
+  # These two ways of computing ds are mathematically equivalent. The first
+  # involves reducing over the head_dim dimension and the second involves
+  # reducing over a sequence dimension. They tend to produce slightly different
+  # numerics.
+  if custom_type == "flash":
+    di = jnp.sum(o.astype(jnp.float32) * do, axis=-1)[..., None]
+  else:
+    di = jnp.einsum("st,st->s", dp, p)[:, None]
+  ds = (dp - di) * p
+  if attn_logits_soft_cap is not None:
+    normalized = uncapped_logits / attn_logits_soft_cap
+    d = jnp.tanh(normalized)
+    g = ds * (1 - d)
+    ds = g + g * d
+  dk = jnp.einsum("sd,st->td", q.astype(jnp.float32), ds).astype(k.dtype)
+  dq = jnp.einsum("st,td->sd", ds, k.astype(jnp.float32)).astype(q.dtype)
+  return None, dq, dk, dv, None
+
+
+_attention_reference_custom = jax.custom_vjp(
+    _attention_reference, nondiff_argnames=(
+    "mask_value", "save_residuals", "custom_type", "attn_logits_soft_cap")
+)
+_attention_reference_custom.defvjp(_attention_reference_custom_fwd,
+                                   _attention_reference_custom_bwd)
+
+
+def attention_reference_custom(
+    mask: jax.Array,  # [q_seq_len, kv_seq_len]
+    q: jax.Array,  # [q_seq_len, head_dim]
+    k: jax.Array,  # [kv_seq_len, head_dim]
+    v: jax.Array,  # [kv_seq_len, head_dim]
+    segment_ids: SegmentIds | None,
+    *,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    save_residuals: bool = False,
+    custom_type: str = "flash",
+    attn_logits_soft_cap: float | None = None,
+):
+  return _attention_reference_custom(
+      mask,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value,
+      save_residuals,
+      custom_type=custom_type,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+  )
+
+
+def make_attention_reference(
+    mask: mask_lib.Mask | np.ndarray,
+    is_mqa: bool,
+    backward_impl: str = "vanilla",
+    **params: Any,
+) -> Callable:
+  @partial(
+      jax.jit,
+      static_argnames=[
+          "mask_value",
+          "save_residuals",
+          "attn_logits_soft_cap",
+      ],
+  )
+  def _wrapped(
+      mask: jax.Array,
+      q: jax.Array,
+      k: jax.Array,
+      v: jax.Array,
+      segment_ids: SegmentIds | None = None,
+      *,
+      mask_value: float = DEFAULT_MASK_VALUE,
+      save_residuals: bool = False,
+      attn_logits_soft_cap: float | None = None,
+  ):
+    if backward_impl == "custom":
+      attn_impl = partial(
+          attention_reference_custom, custom_type="flash",
+      )
+    elif backward_impl == "custom_vanilla":
+      attn_impl = partial(
+          attention_reference_custom, custom_type="vanilla",
+      )
+    else:
+      attn_impl = attention_reference
+    func = partial(
+        attn_impl,
+        mask_value=mask_value,
+        save_residuals=save_residuals,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        **params,
+    )
+
+    if is_mqa:
+      func = jax.vmap(func, in_axes=(0, 0, None, None, None))
+      is_grouped = False
+    else:
+      # In grouped attention (1 < num_kv_heads && num_kv_heads < num_q_heads).
+      # We interleave the KV heads across the Q heads.
+      # For example: for 8 Q heads and 4 KV heads:
+      # Q head [0, 1] see KV head 0
+      # Q head [2, 3] see KV head 1
+      # Q head [4, 5] see KV head 2
+      # Q head [6, 7] see KV head 3
+      #
+      # The following implementation reshapes Q to expose KV heads and vmaps
+      # Across the Q heads so it is similar to MQA.
+      # Alternatively we can replicate K/V to match Q like so:
+      # k = jnp.repeat(k, q_heads_per_kv_head, axis=0)
+      # v = jnp.repeat(v, q_heads_per_kv_head, axis=0)
+
+      kv_heads = k.shape[0]
+      assert kv_heads == v.shape[0]
+      q_heads, q_seq_len, head_dim = q.shape
+      is_grouped = kv_heads < q_heads
+      if is_grouped:
+        assert q_heads % kv_heads == 0
+        assert mask.shape[0] == q_heads
+        q_heads_per_kv_head = q_heads // kv_heads
+        q = q.reshape((kv_heads, q_heads_per_kv_head, q_seq_len, head_dim))
+        mask = mask.reshape((kv_heads, q_heads_per_kv_head, *mask.shape[1:]))
+
+        # Inner-most vmap: iterate over the q heads.
+        func = jax.vmap(func, in_axes=(0, 0, None, None, None))
+
+      # Outer-most vmap: iterate over the kv heads.
+      func = jax.vmap(func, in_axes=(0, 0, 0, 0, None))
+
+    out = func(mask, q, k, v, segment_ids)
+
+    if is_grouped:
+
+      def reshape_activations(activations):
+        if activations.ndim == 4:  # pytype: disable=attribute-error
+          kv_heads, q_heads_per_kv_head, q_seq_len, head_dim = activations.shape  # pytype: disable=attribute-error
+          return activations.reshape(  # pytype: disable=attribute-error
+              kv_heads * q_heads_per_kv_head, q_seq_len, head_dim
+          )
+        return activations
+
+      def reshape_residuals(residuals):
+        if residuals.ndim == 3:
+          kv_heads, q_heads_per_kv_head, q_seq_len = residuals.shape
+          return residuals.reshape(kv_heads * q_heads_per_kv_head, q_seq_len)
+        return residuals
+
+      if save_residuals:
+        assert isinstance(out, tuple)
+        assert isinstance(out[1], tuple)
+
+        return (reshape_activations(out[0]), (reshape_residuals(out[1][0]),))
+      else:
+        return reshape_activations(out)
+    else:
+      return out
+
+  return functools.partial(_wrapped, jnp.array(mask[:, :, :]))
+
+
+make_masked_mha_reference = partial(make_attention_reference, is_mqa=False)
+make_masked_mqa_reference = partial(make_attention_reference, is_mqa=True)
+
+
+# Splash attention implementation
+
+# We use an IntEnum to make it JSON serializable as regen metadata.
+class QKVLayout(enum.IntEnum):
+  HEAD_DIM_MINOR = enum.auto()  # [..., seq_len, head_dim]
+  SEQ_MINOR = enum.auto()  # [..., head_dim, seq_len]
+
+
+def from_head_minor(vals: tuple[Any, ...], layout: QKVLayout):
+  if layout == QKVLayout.HEAD_DIM_MINOR:
+    return vals
+  return (*vals[:-2], vals[-1], vals[-2])
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BlockSizes:
+  """Tile sizes parameterizing SplashAttention kernels.
+
+  Those parameters have negligible effect on numerics, but affect performance
+  greatly.
+
+  Note that changing the layouts only influences the physical layout that the
+  kernel will enforce. The logical interface to splash attention always takes
+  the head dimension as the minormost one.
+  """
+  block_q: int
+  block_kv: int
+  block_kv_compute: int | None = None
+
+  block_q_dkv: int | None = None
+  block_kv_dkv: int | None = None
+  block_kv_dkv_compute: int | None = None
+
+  block_q_dq: int | None = None
+  block_kv_dq: int | None = None
+
+  use_fused_bwd_kernel: bool = False
+
+  q_layout: QKVLayout = QKVLayout.HEAD_DIM_MINOR
+  k_layout: QKVLayout = QKVLayout.HEAD_DIM_MINOR
+  v_layout: QKVLayout = QKVLayout.HEAD_DIM_MINOR
+
+  def __post_init__(self):
+    if self.block_kv_compute is None:
+      object.__setattr__(self, "block_kv_compute", self.block_kv)
+    if self.block_kv_dkv_compute is None:
+      object.__setattr__(self, "block_kv_dkv_compute", self.block_kv_dkv)
+    if self.use_fused_bwd_kernel:
+      if self.block_q_dq is not None or self.block_kv_dq is not None:
+        raise ValueError(
+            "Block sizes for dq kernel are not needed with a fused kernel."
+        )
+
+  @property
+  def has_backward_blocks(self) -> bool:
+    backward_blocks = (
+        self.block_q_dkv, self.block_kv_dkv, self.block_kv_dkv_compute,
+    )
+    if not self.use_fused_bwd_kernel:
+      backward_blocks += (self.block_q_dq, self.block_kv_dq)
+    return all(b is not None for b in backward_blocks)
+
+  @classmethod
+  def get_default(cls):
+    # TODO(apaszke,sharadmv): Select better parameters based on a heuristic.
+    return BlockSizes(
+        block_q=128,
+        block_kv=128,
+        block_kv_compute=128,
+        block_q_dkv=128,
+        block_kv_dkv=128,
+        block_kv_dkv_compute=128,
+        block_q_dq=128,
+        block_kv_dq=128,
+    )
+
+
+def _next_nonzero(
+    h,
+    i,
+    j,
+    data_next_ref,
+    block_mask_ref,
+    m_next_ref,
+    next_i=False,
+):
+  assert (data_next_ref is None) == (block_mask_ref is None)
+
+  if data_next_ref is None and block_mask_ref is None:
+    # Handle the case in which we have no masking nor next data information.
+    # Simply fetch the next data and apply the mask for every block.
+    assert m_next_ref is None
+    next_data = i if next_i else j
+    return (
+        next_data,
+        None,  # next mask
+        True,  # should run
+        False,  # should not mask
+    )
+
+  assert data_next_ref.shape == block_mask_ref.shape
+  assert m_next_ref is None or data_next_ref.shape[0] == m_next_ref.shape[0]
+
+  # We are working with one head only. Force the head index to 0.
+  if data_next_ref.shape[0] == 1:
+    h = 0
+
+  # When scalar-memory data is of types smaller than int32, then we have to
+  # upcast it back to use it in the kernel.
+
+  to_i32 = lambda x: x.astype(jnp.int32)
+
+  is_nonzero = to_i32(block_mask_ref[h, i, j]) > 0
+  if m_next_ref is None:
+    should_not_mask = True
+    next_m = None
+  else:
+    should_not_mask = to_i32(block_mask_ref[h, i, j]) != 1
+    next_m = to_i32(m_next_ref[h, i, j])
+  next_j = to_i32(data_next_ref[h, i, j])
+  return next_j, next_m, is_nonzero, should_not_mask
+
+
+def _apply_mask_and_soft_cap(
+    qk: jax.Array,
+    mask_value: float,
+    should_not_mask,
+    mask_ref,
+    q_sequence_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    *,
+    attn_logits_soft_cap: float,
+    k_slice: pl.Slice,
+    k_offset: int | jax.Array,
+    bq: int,
+    k_in_lanes=True,
+    mask_function=None,
+) -> jax.Array | tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+  assert mask_ref is None or q_sequence_ref is None
+  assert (q_sequence_ref is None) == (mask_function is None)
+
+  masks = []
+  if mask_ref is not None:
+    if k_in_lanes:
+      mask = mask_ref[:, k_slice]
+    else:
+      mask = mask_ref[k_slice, :]
+
+    masks.append(
+        jnp.bitwise_or(mask, jnp.broadcast_to(should_not_mask, mask.shape))
+    )
+  if mask_function is not None:
+    # Compute the mask using the given q_sequence indices.
+    # KV indices are computed on the fly. This works because we only support Q
+    # sequence sharding. If we wanted to compute Q indices too, then we would
+    # need to keep into account the current shard along Q sequence.
+
+    if k_in_lanes:
+      assert q_sequence_ref.shape == (bq, NUM_LANES)
+
+      k_sequence = k_offset + jax.lax.broadcasted_iota(
+          jnp.int32, (bq, k_slice.size), 1
+      )
+
+      repeats, rem = divmod(k_slice.size, NUM_LANES)
+      assert rem == 0
+      q_sequence = jnp.tile(
+          q_sequence_ref[...], (1, repeats)
+      )  # [bq, k_slice.size]
+    else:
+      assert q_sequence_ref.shape == (NUM_SUBLANES, bq)
+
+      k_sequence = k_offset + jax.lax.broadcasted_iota(
+          jnp.int32, (k_slice.size, bq), 0
+      )
+      q_sequence = q_sequence_ref[:1, :]  # [1, bq]
+      q_sequence = jnp.broadcast_to(q_sequence, (k_slice.size, bq))
+
+    assert q_sequence.shape == k_sequence.shape
+    computed_mask = mask_function(q_sequence, k_sequence)  # pytype: disable=wrong-arg-count
+    if computed_mask.dtype != jnp.dtype(jnp.bool_):
+      raise ValueError(
+          "Mask function must return a boolean-valued array, but got:"
+          f" {computed_mask.dtype}"
+      )
+    masks.append(computed_mask)
+
+  if q_segment_ids_ref is not None:
+    if k_in_lanes:
+      kv_ids = kv_segment_ids_ref[:1, k_slice]  # [1, k_slice]
+      repeats, rem = divmod(kv_ids.shape[1], NUM_LANES)
+      if rem:
+        raise NotImplementedError(f"block_kv must be a multiple of {NUM_LANES}")
+      q_ids = jnp.tile(q_segment_ids_ref[:], (1, repeats))  # [bq, bkv]
+    else:
+      assert bq == q_segment_ids_ref.shape[-1]
+      repeats, rem = divmod(bq, NUM_LANES)
+      if rem:
+        raise NotImplementedError(f"block_q must be a multiple of {NUM_LANES}")
+      kv_ids = jnp.tile(
+          kv_segment_ids_ref[k_slice, :], (1, repeats)
+      )  # [k_slice, bq]
+      q_ids = q_segment_ids_ref[:1, :]  # [1, bq]
+    masks.append(q_ids == kv_ids)
+
+  def cap_logits(logits):
+    if attn_logits_soft_cap is not None:
+      logits = jnp.tanh(qk / attn_logits_soft_cap)
+      return logits * attn_logits_soft_cap
+    else:
+      return logits
+
+  if masks:
+    mask = functools.reduce(jnp.logical_and, masks)
+    qk = cap_logits(qk)
+    qk = jnp.where(mask, qk, mask_value)
+  else:
+    qk = cap_logits(qk)
+  return qk
+
+
+def flash_attention_kernel(
+    # Prefetched inputs
+    data_next_ref,
+    block_mask_ref,
+    mask_next_ref,
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    mask_ref,
+    q_sequence_ref,
+    # Outputs
+    m_scratch_ref,
+    l_scratch_ref,
+    o_scratch_ref,
+    o_ref,
+    logsumexp_ref=None,
+    *,
+    mask_value: float,
+    grid_width: int,
+    bq: int,
+    bkv: int,
+    bkv_compute: int,
+    head_dim_v: int,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    attn_logits_soft_cap: float | None,
+    mask_function: MaskFunctionType | None,
+):
+  float32 = jnp.float32
+  HEAD_DIM_MINOR = QKVLayout.HEAD_DIM_MINOR
+
+  head_dim_v_repeats, rem = divmod(head_dim_v, NUM_LANES)
+  if rem != 0:
+    raise NotImplementedError(
+        f"{head_dim_v=} should be a multiple of {NUM_LANES}"
+    )
+
+  h, i, j = pl.program_id(0), pl.program_id(1), pl.program_id(2)
+
+  @pl.when(j == 0)
+  def init():
+    o_scratch_ref[...] = jnp.zeros_like(o_scratch_ref)
+    m_scratch_ref[...] = jnp.full_like(m_scratch_ref, mask_value)
+    l_scratch_ref[...] = jnp.zeros_like(l_scratch_ref)
+
+  global_kv_index, _, should_run, should_not_mask = _next_nonzero(
+      h,
+      i,
+      j,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref,
+  )
+
+  def body(kv_compute_index, _):
+    slice_k = pl.ds(kv_compute_index * bkv_compute, bkv_compute)
+    m_prev, l_prev = m_scratch_ref[...], l_scratch_ref[...]
+    assert m_prev.shape == (bq, NUM_LANES)
+    assert l_prev.shape == (bq, NUM_LANES)
+
+    q = q_ref[...] if q_layout == HEAD_DIM_MINOR else q_ref[...].T
+    qk_dims = NT_DIM_NUMBERS if k_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    if k_layout == HEAD_DIM_MINOR:
+      k = k_ref[slice_k, :]
+    else:
+      k = k_ref[:, slice_k]
+    qk = lax.dot_general(q, k, qk_dims, preferred_element_type=float32)
+
+    assert qk.shape == (bq, bkv_compute)
+    apply_mask_and_soft_cap = functools.partial(
+        _apply_mask_and_soft_cap,
+        qk,
+        mask_value,
+        should_not_mask,
+        mask_ref,
+        q_sequence_ref,
+        q_segment_ids_ref,
+        kv_segment_ids_ref,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        k_slice=slice_k,
+        # When the iteration space is shrunk (for local attention for example),
+        # the kv_index program_id does not correspond to the actual coordinates
+        # of the KV data. Make sure to use the 'unshrunk' index (coming from the
+        # data_next array) when computing the mask.
+        k_offset=global_kv_index * bkv + kv_compute_index * bkv_compute,
+        bq=bq,
+        mask_function=mask_function,
+    )
+
+    qk = apply_mask_and_soft_cap()
+
+    m_curr = qk.max(axis=-1)[:, None]  # pytype: disable=attribute-error
+    assert m_curr.shape == (bq, 1)
+    m_next = jnp.maximum(m_prev, m_curr)
+    assert m_next.shape == (bq, NUM_LANES)
+
+    bkv_repeats, rem = divmod(bkv_compute, NUM_LANES)
+    if rem != 0:
+      raise NotImplementedError(
+          f"{bkv_compute=} should be a multiple of {NUM_LANES}"
+      )
+
+    s_curr = jnp.exp(qk - jnp.tile(m_next, (1, bkv_repeats)))
+    assert s_curr.shape == (bq, bkv_compute)
+
+    l_curr = jax.lax.broadcast_in_dim(s_curr.sum(axis=-1), l_prev.shape, (0,))
+    assert l_curr.shape == (bq, NUM_LANES)
+
+    alpha = jnp.exp(m_prev - m_next)
+    l_next = l_curr + alpha * l_prev
+    m_scratch_ref[...], l_scratch_ref[...] = m_next, l_next
+
+    sv_dims = NN_DIM_NUMBERS if v_layout == HEAD_DIM_MINOR else NT_DIM_NUMBERS
+    if v_layout == HEAD_DIM_MINOR:
+      v = v_ref[slice_k, :]
+    else:
+      v = v_ref[:, slice_k]
+    v = v.astype(float32)
+    o_curr = lax.dot_general(s_curr, v, sv_dims)
+
+    alpha_o = jnp.tile(alpha, (1, head_dim_v_repeats))
+    o_scratch_ref[:] = alpha_o * o_scratch_ref[:] + o_curr
+
+  @pl.when(should_run)
+  def run():
+    assert bkv % bkv_compute == 0
+    num_iters = (
+        k_ref.shape[0 if k_layout == HEAD_DIM_MINOR else 1] // bkv_compute
+    )
+    lax.fori_loop(0, num_iters, body, None, unroll=True)
+
+  @pl.when(j == grid_width - 1)
+  def end():
+    l = l_scratch_ref[...]
+    l_inv = jnp.tile(1.0 / l, (1, head_dim_v_repeats))
+    o_ref[...] = (o_scratch_ref[...] * l_inv).astype(o_ref.dtype)
+    if logsumexp_ref is not None:
+      assert logsumexp_ref.shape == (bq, NUM_LANES)
+      logsumexp_ref[...] = (jnp.log(l) + m_scratch_ref[...]).astype(
+          logsumexp_ref.dtype
+      )
+
+    m_scratch_ref[...] = jnp.zeros_like(m_scratch_ref)
+    l_scratch_ref[...] = jnp.zeros_like(l_scratch_ref)
+    o_scratch_ref[...] = jnp.zeros_like(o_scratch_ref)
+
+
+@overload
+def _splash_attention_forward(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    save_residuals: Literal[False] = False,
+    attn_logits_soft_cap: float | None = None,
+) -> jax.Array:
+  ...
+
+
+@overload
+def _splash_attention_forward(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    save_residuals: Literal[True],
+    attn_logits_soft_cap: float | None = None,
+) -> SplashCustomReturnType:
+  ...
+
+
+def _div(dividend: int, divisor: int):
+  if divisor == 1:
+    return dividend
+
+  return lax.div(dividend, divisor)
+
+
+def _splash_attention_forward(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    save_residuals: bool,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None = None,
+    interpret: bool = False
+) -> SplashCustomReturnType:
+  num_q_heads, q_seq_len, head_dim_qk = q.shape
+  head_dim_v = v.shape[-1]
+  bq, bkv = block_sizes.block_q, block_sizes.block_kv
+  bkv_compute = block_sizes.block_kv_compute
+
+  if is_mqa:
+    expected_kv_rank = 2
+    kv_head_dimension = 1
+    kv_seq_len_dimension = 0
+    num_kv_heads = 1
+  else:
+    expected_kv_rank = 3
+    kv_head_dimension = 2
+    kv_seq_len_dimension = 1
+    num_kv_heads = k.shape[0]
+
+  partial_mask_blocks = fwd_mask_info.partial_mask_blocks
+  if (
+      partial_mask_blocks is not None
+      and jnp.dtype(partial_mask_blocks.dtype) != np.bool_
+  ):
+    raise ValueError(
+        "partial_mask_blocks must be of type np.bool_ but got"
+        f" {partial_mask_blocks.dtype}"
+    )
+
+  if len(k.shape) != expected_kv_rank:
+    raise ValueError(
+        f"Expected {expected_kv_rank}-dim 'key' tensor for MQA. Instead got a"
+        f" {len(k.shape)}-dim one."
+    )
+
+  if k.shape[kv_head_dimension] != head_dim_qk:
+    raise ValueError(
+        f"Expected 'key' head dimension to be: {head_dim_qk}. Instead got:"
+        f" {k.shape[kv_head_dimension]}."
+    )
+
+  if not is_mqa and num_q_heads % num_kv_heads != 0:
+    raise ValueError(
+        f"In MHA, expected number of 'key' heads ({num_kv_heads}) to be a"
+        f" multiple of the number of 'query' heads ({num_q_heads})"
+    )
+
+  if k.shape[:-1] != v.shape[:-1]:
+    raise ValueError(
+        f"Expected 'key' {k.shape} and 'value' {v.shape} to have the same "
+        "leading dimensions."
+    )
+
+  if bkv % bkv_compute:
+    raise ValueError(f"{bkv=} must be a multiple of {bkv_compute=}.")
+  if bkv_compute % NUM_LANES:
+    raise ValueError(f"{bkv_compute=} must be a multiple of {NUM_LANES}.")
+
+  kv_seq_len = k.shape[kv_seq_len_dimension]
+
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+
+  if segment_ids is not None:
+    if segment_ids.q.shape != (q_seq_len,):
+      raise ValueError(
+          "Invalid shape for q segment_ids: "
+          f"{segment_ids.q.shape}. Expected: {(q_seq_len,)}"
+      )
+    if segment_ids.kv.shape != (kv_seq_len,):
+      raise ValueError(
+          "Invalid shape for kv segment_ids: "
+          f"{segment_ids.kv.shape}. Expected: {(kv_seq_len,)}"
+      )
+
+  q_layout = block_sizes.q_layout
+  def q_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    del j, data_next_ref, mask_next_ref, block_mask_ref
+    return from_head_minor((h, i, 0), q_layout)
+  def out_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    del j, data_next_ref, mask_next_ref, block_mask_ref
+    return h, i, 0
+
+  k_layout = block_sizes.k_layout
+  def k_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), k_layout)
+
+  v_layout = block_sizes.v_layout
+  def v_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref=None):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), v_layout)
+
+  def mask_index_map(h, i, j, data_next_ref, block_mask_ref,
+                     mask_next_ref=None):
+    _, next_m, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    return next_m, 0, 0
+
+  def q_segment_ids_index_map(h, i, j, *_):
+    del h, j  # Unused.
+    return i, 0
+
+  def kv_segment_ids_index_map(h, i, j, data_next_ref, block_mask_ref,
+                               mask_next_ref=None):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    return 0, next_j
+
+  # Convert the logical shape from head-minor to sequence-minor.
+  in_specs = [
+      pl.BlockSpec(
+          from_head_minor((None, bq, head_dim_qk), q_layout), q_index_map
+      ),
+      pl.BlockSpec(
+          from_head_minor(
+              (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk), k_layout
+          ),
+          k_index_map,
+      ),
+      pl.BlockSpec(
+          from_head_minor(
+              (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v), v_layout
+          ),
+          v_index_map,
+      ),
+  ]
+  if segment_ids is not None:
+    in_specs += [
+        pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map),
+        pl.BlockSpec((NUM_SUBLANES, bkv), kv_segment_ids_index_map),
+    ]
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q, (q_seq_len, NUM_LANES), (0,)
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv, (NUM_SUBLANES, kv_seq_len), (1,)
+    )
+  else:
+    in_specs += [None, None]
+    q_segment_ids = kv_segment_ids = None
+
+  if fwd_mask_info.partial_mask_blocks is not None:
+    in_specs.append(pl.BlockSpec((None, bq, bkv), mask_index_map))
+  else:
+    in_specs.append(None)
+
+  assert (
+      fwd_mask_info.partial_mask_blocks is None
+      or fwd_mask_info.q_sequence is None
+  )
+
+  if fwd_mask_info.q_sequence is not None:
+    q_sequence = jax.lax.broadcast_in_dim(
+        fwd_mask_info.q_sequence, (q_seq_len, NUM_LANES), (0,)
+    )
+    in_specs.append(pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map))
+  else:
+    q_sequence = None
+    in_specs.append(None)
+
+  num_scalar_prefetch = 3
+
+  out_shapes = [
+      jax.ShapeDtypeStruct((bq, NUM_LANES), jnp.float32),  # m_scratch
+      jax.ShapeDtypeStruct((bq, NUM_LANES), jnp.float32),  # l_scratch
+      jax.ShapeDtypeStruct((bq, head_dim_v), jnp.float32),  # o_scratch
+      jax.ShapeDtypeStruct((num_q_heads, q_seq_len, head_dim_v), q.dtype),
+  ]
+  out_specs = [
+      # TODO(sharadmv): convert m/l to be scratch
+      pl.BlockSpec((bq, NUM_LANES), lambda h, i, j, *_: (0, 0)),
+      pl.BlockSpec((bq, NUM_LANES), lambda h, i, j, *_: (0, 0)),
+      pl.BlockSpec((bq, head_dim_v), lambda h, i, j, *_: (0, 0)),
+      pl.BlockSpec((None, bq, head_dim_v), out_index_map),
+  ]
+  if save_residuals:
+    out_shapes += [
+        jax.ShapeDtypeStruct(
+            (num_q_heads, q_seq_len, NUM_LANES), jnp.float32
+        ),  # logsumexp
+    ]
+
+    def logsumexp_index_map(h, i, *_):
+      return h, i, 0
+
+    out_specs += [
+        pl.BlockSpec((None, bq, NUM_LANES), logsumexp_index_map),
+    ]
+  else:
+    out_shapes += [None]
+    out_specs += [None]
+
+  kernel_name = get_kernel_name(
+      dataclasses.asdict(block_sizes),
+      is_mqa=is_mqa,
+      save_residuals=save_residuals,
+      is_segmented=segment_ids is not None,
+      phase="fwd",
+  )
+
+  if fwd_mask_info.data_next is not None:
+    grid_width = fwd_mask_info.data_next.shape[-1]
+  else:
+    grid_width = kv_seq_len // bkv
+
+  grid = (num_q_heads, q_seq_len // bq, grid_width)
+  with jax.named_scope(kernel_name):
+    all_out = pl.pallas_call(
+        partial(
+            flash_attention_kernel,
+            mask_value=mask_value,
+            grid_width=grid_width,
+            bq=bq,
+            bkv=bkv,
+            bkv_compute=bkv_compute,
+            head_dim_v=head_dim_v,
+            q_layout=q_layout,
+            k_layout=k_layout,
+            v_layout=v_layout,
+            attn_logits_soft_cap=attn_logits_soft_cap,
+            mask_function=mask_function,
+        ),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=num_scalar_prefetch,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            grid=grid,
+        ),
+        compiler_params=pltpu.CompilerParams(
+          dimension_semantics=("parallel", "arbitrary", "arbitrary"),
+        ),
+        out_shape=out_shapes,
+        name=kernel_name,
+        interpret=interpret,
+    )(
+        fwd_mask_info.data_next,
+        fwd_mask_info.block_mask,
+        fwd_mask_info.mask_next,
+        q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
+        k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
+        v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
+        q_segment_ids,
+        kv_segment_ids,
+        fwd_mask_info.partial_mask_blocks,
+        q_sequence,
+    )
+
+  (
+      _,
+      _,
+      _,
+      out,
+      logsumexp,
+  ) = all_out
+
+  if save_residuals:
+    assert logsumexp is not None
+    logsumexp = logsumexp[..., 0]
+
+  if residual_checkpoint_name is not None:
+    out = ad_checkpoint.checkpoint_name(out, name=residual_checkpoint_name)
+    if logsumexp is not None:
+      logsumexp = ad_checkpoint.checkpoint_name(
+          logsumexp, name=residual_checkpoint_name
+      )
+  if save_residuals:
+    return out, (logsumexp,)
+  return out
+
+
+@partial(jax.custom_vjp, nondiff_argnames=(
+  "save_residuals", "mask_value", "is_mqa", "block_sizes",
+  "residual_checkpoint_name", "mask_function", "attn_logits_soft_cap",
+  "interpret")
+)
+def _splash_attention_custom(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    dq_mask_info: mask_info_lib.MaskInfo | None,
+    dkv_mask_info: mask_info_lib.MaskInfo | None,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: bool,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None = None,
+    interpret: bool = False,
+) -> SplashCustomReturnType:
+  # The forward function does not use the dq and dkv MaskInfos, it just forwards
+  # them to the backward function as residuals. This is a way to communicate
+  # arbitrary Arrays to the backward function. Since the three MaskInfos are
+  # constants there is no overhead in passing them to the backward function as
+  # residuals. When sharding computation MaskInfos are partitioned so both the
+  # forward and the backward kernels need to work on the relevant slice. If we
+  # recomputed the backward MaskInfos in the backward function from the numpy
+  # mask then we would not work with the MaskInfo slice relevant to the current
+  # device.
+  del dq_mask_info, dkv_mask_info
+
+  return _splash_attention_forward(  # pytype: disable=wrong-arg-types
+      fwd_mask_info,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      is_mqa=is_mqa,
+      block_sizes=block_sizes,
+      residual_checkpoint_name=residual_checkpoint_name,
+      save_residuals=save_residuals,
+      mask_function=mask_function,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      interpret=interpret,
+  )
+
+
+def _splash_attention_fwd(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    dq_mask_info: mask_info_lib.MaskInfo | None,
+    dkv_mask_info: mask_info_lib.MaskInfo | None,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None,
+    save_residuals: bool,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None = None,
+    interpret: bool = False,
+) -> tuple[
+    tuple[jax.Array],
+    SplashResidualsType,
+]:
+  if save_residuals:
+    raise NotImplementedError("Higher-order AD not supported")
+
+  out, (logsumexp,) = _splash_attention_forward(  # pytype: disable=wrong-arg-types
+      fwd_mask_info,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      is_mqa=is_mqa,
+      block_sizes=block_sizes,
+      residual_checkpoint_name=residual_checkpoint_name,
+      save_residuals=True,
+      mask_function=mask_function,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      interpret=interpret,
+  )
+  return out, (
+      q,
+      k,
+      v,
+      segment_ids,
+      out,
+      logsumexp,
+      dq_mask_info,
+      dkv_mask_info,
+  )
+
+
+def _flash_attention_dq_kernel(
+    # Prefetched inputs
+    data_next_ref,
+    block_mask_ref,
+    mask_next_ref,
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    logsumexp_ref,
+    do_ref,
+    di_ref,
+    mask_ref,
+    q_sequence_ref,
+    # Outputs
+    dq_scratch_ref,
+    dq_ref,
+    *,
+    mask_value: float,
+    grid_width: int,
+    bq: int,
+    bkv: int,
+    attn_logits_soft_cap: float | None = None,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    mask_function: MaskFunctionType | None,
+):
+  float32 = jnp.float32
+  HEAD_DIM_MINOR = QKVLayout.HEAD_DIM_MINOR
+
+  h, i, j = pl.program_id(0), pl.program_id(1), pl.program_id(2)
+  @pl.when(j == 0)
+  def init():
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+  global_kv_index, _, should_run, should_not_mask = _next_nonzero(
+      h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+  )
+  @pl.when(should_run)
+  def run():
+    q = q_ref[...] if q_layout == HEAD_DIM_MINOR else q_ref[...].T
+    # We keep k and v possibly transposed, since they are RHS of dots.
+    k = k_ref[...]
+    v = v_ref[...]
+    logsumexp = jnp.expand_dims(logsumexp_ref[0], -1)
+    do = do_ref[...]
+    di = jnp.expand_dims(di_ref[0], -1)
+
+    qk_dims = NT_DIM_NUMBERS if k_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    qk_uncapped = lax.dot_general(q, k, qk_dims, preferred_element_type=float32)
+
+    qk = _apply_mask_and_soft_cap(
+        qk_uncapped,
+        mask_value,
+        should_not_mask,
+        mask_ref,
+        q_sequence_ref,
+        q_segment_ids_ref,
+        kv_segment_ids_ref,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        k_slice=pl.ds(0, bkv),
+        # When the iteration space is shrunk (for local attention for example),
+        # the kv_index program_id does not correspond to the actual coordinates
+        # of the KV data. Make sure to use the 'unshrunk' index (coming from the
+        # data_next array) when computing the mask.
+        k_offset=global_kv_index * bkv,
+        bq=bq,
+        mask_function=mask_function,
+    )
+    p = jnp.exp(qk - logsumexp)
+    dp_dims = NT_DIM_NUMBERS if v_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    dp = lax.dot_general(
+        do.astype(v.dtype), v, dp_dims, preferred_element_type=jnp.float32,
+    )
+    ds = (dp - di) * p
+    if attn_logits_soft_cap is not None:
+      normalized = qk_uncapped / attn_logits_soft_cap
+      d = jnp.tanh(normalized)
+      g = ds * (1 - d)
+      ds = g + g * d
+
+    dq_dims = NN_DIM_NUMBERS if k_layout == HEAD_DIM_MINOR else NT_DIM_NUMBERS
+    dq_scratch_ref[...] += lax.dot_general(
+        ds.astype(k.dtype), k, dq_dims,
+        preferred_element_type=jnp.float32,
+    )
+
+  @pl.when(j == grid_width - 1)
+  def end():
+    dq_ref[...] = dq_scratch_ref[...].astype(dq_ref.dtype)
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+
+def _splash_attention_bwd_dq(
+    q,
+    k,
+    v,
+    segment_ids,
+    logsumexp,
+    do,
+    di,
+    *,
+    bq: int,
+    bkv: int,
+    is_mqa: bool,
+    mask_info: mask_info_lib.MaskInfo,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    mask_function: MaskFunctionType | None,
+    interpret: bool,
+):
+  num_q_heads, q_seq_len, head_dim_qk = q.shape
+  head_dim_v = v.shape[-1]
+  if is_mqa:
+    kv_seq_len = k.shape[0]
+    num_kv_heads = 1
+  else:
+    kv_seq_len = k.shape[1]
+    num_kv_heads = k.shape[0]
+
+  if bq > q_seq_len:
+    raise ValueError(
+        f"{bq=} should not be greater than {q_seq_len=}")
+  if bkv > kv_seq_len:
+    raise ValueError(
+        f"{bkv=} should not be greater than {kv_seq_len=}")
+
+  if not is_mqa and num_q_heads % num_kv_heads != 0:
+    raise ValueError(
+        f"In MHA, expected number of 'key' heads ({num_kv_heads}) to be a"
+        f" multiple of the number of 'query' heads ({num_q_heads})"
+    )
+
+  if k.shape[:-1] != v.shape[:-1]:
+    raise ValueError(
+        f"Expected 'key' {k.shape} and 'value' {v.shape} to have the same "
+        "leading dimensions."
+    )
+
+  if bkv % NUM_LANES:
+    raise ValueError(f"{bkv=} must be a multiple of {NUM_LANES}.")
+
+  # TODO(amagni/sharadmv): when adding block_compute, make sure that is a
+  # multiple of NUM_LANES.
+
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+
+  if mask_info.data_next is not None:
+    grid_width = mask_info.data_next.shape[-1]
+  else:
+    grid_width = kv_seq_len // bkv
+
+  grid = (num_q_heads, q_seq_len // bq, grid_width)
+
+  def o_index_map(h, i, *_):
+    return h, i, 0
+
+  o_spec = pl.BlockSpec((None, bq, head_dim_v), o_index_map)
+
+  def q_index_map(h, i, *_):
+    return from_head_minor((h, i, 0), q_layout)
+
+  q_spec = pl.BlockSpec(
+      from_head_minor((None, bq, head_dim_qk), q_layout), q_index_map
+  )
+
+  def k_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), k_layout)
+
+  k_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk), k_layout
+      ),
+      k_index_map,
+  )
+
+  def v_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_):
+    next_j, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    prefix = () if is_mqa else (_div(h, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, next_j, 0), v_layout)
+
+  v_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v), v_layout
+      ),
+      v_index_map,
+  )
+
+  def mask_index_map(h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_):
+    _, next_m, *_ = _next_nonzero(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+    )
+    return next_m, 0, 0
+
+  mask_spec = pl.BlockSpec((None, bq, bkv), mask_index_map)
+
+  def q_segment_ids_index_map(h, i, j, *_):
+    del h, j  # Unused.
+    return i, 0
+
+  if segment_ids is not None:
+
+    def kv_segment_ids_index_map(
+        h, i, j, data_next_ref, block_mask_ref, mask_next_ref, *_
+    ):
+      next_j, *_ = _next_nonzero(
+          h, i, j, data_next_ref, block_mask_ref, mask_next_ref
+      )
+      return 0, next_j
+
+    q_segment_spec = pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map)
+    kv_segment_spec = pl.BlockSpec(
+        (NUM_SUBLANES, bkv), kv_segment_ids_index_map
+    )
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q, (q_seq_len, NUM_LANES), (0,)
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv, (NUM_SUBLANES, kv_seq_len), (1,)
+    )
+  else:
+    q_segment_spec = kv_segment_spec = None
+    q_segment_ids = kv_segment_ids = None
+
+  do_spec = o_spec
+
+  def logsumexp_index_map(h, i, *_):
+    return h, 0, i
+
+  logsumexp = jnp.expand_dims(logsumexp, axis=-2)
+  logsumexp_spec = pl.BlockSpec((None, 1, bq), logsumexp_index_map)
+  assert logsumexp.ndim == len(logsumexp_spec.block_shape)
+
+  di = jnp.expand_dims(di, axis=-2)
+  di_spec = pl.BlockSpec((None, 1, bq), logsumexp_index_map)
+  assert di.ndim == len(di_spec.block_shape)
+
+  in_specs = [
+      q_spec,
+      k_spec,
+      v_spec,
+      q_segment_spec,
+      kv_segment_spec,
+      logsumexp_spec,
+      do_spec,
+      di_spec,
+  ]
+  if mask_info.partial_mask_blocks is not None:
+    in_specs.append(mask_spec)
+  else:
+    in_specs.append(None)
+
+  assert mask_info.partial_mask_blocks is None or mask_info.q_sequence is None
+
+  if mask_info.q_sequence is not None:
+    q_sequence = jax.lax.broadcast_in_dim(
+        mask_info.q_sequence, (q_seq_len, NUM_LANES), (0,)
+    )
+    in_specs.append(pl.BlockSpec((bq, NUM_LANES), q_segment_ids_index_map))
+  else:
+    q_sequence = None
+    in_specs.append(None)
+
+  out_shapes = [
+      jax.ShapeDtypeStruct((bq, head_dim_qk), jnp.float32),
+      jax.ShapeDtypeStruct(q.shape, q.dtype),
+  ]
+  out_specs = [
+      pl.BlockSpec((bq, head_dim_qk), lambda *_: (0, 0)),
+      pl.BlockSpec((None, bq, head_dim_qk), lambda h, i, *_: (h, i, 0)),
+  ]
+
+  kernel = functools.partial(
+      _flash_attention_dq_kernel,
+      grid_width=grid_width,
+      mask_value=mask_value,
+      bq=bq,
+      bkv=bkv,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      q_layout=q_layout,
+      k_layout=k_layout,
+      v_layout=v_layout,
+      mask_function=mask_function,
+  )
+  num_scalar_prefetch = 3
+
+  kernel_name = get_kernel_name(
+      dict(
+          block_q_dq=bq,
+          block_kv_dq=bkv,
+          q_layout=q_layout,
+          k_layout=k_layout,
+          v_layout=v_layout,
+      ),
+      is_mqa=is_mqa,
+      save_residuals=False,
+      is_segmented=segment_ids is not None,
+      phase="dq",
+  )
+  with jax.named_scope(kernel_name):
+    _, dq = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=num_scalar_prefetch,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            grid=grid,
+        ),
+        out_shape=out_shapes,
+        compiler_params=pltpu.CompilerParams(
+          dimension_semantics=("arbitrary", "arbitrary", "arbitrary"),
+        ),
+        name=kernel_name,
+        interpret=interpret,
+    )(
+        mask_info.data_next,
+        mask_info.block_mask,
+        mask_info.mask_next,
+        q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
+        k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
+        v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
+        q_segment_ids,
+        kv_segment_ids,
+        logsumexp,
+        do,
+        di,
+        mask_info.partial_mask_blocks,
+        q_sequence,
+    )
+  return dq
+
+
+def _flash_attention_dkv_kernel(
+    # Prefetched inputs
+    data_next_ref,
+    block_mask_ref,
+    mask_next_ref,
+    # Inputs
+    q_ref,
+    k_ref,
+    v_ref,
+    q_segment_ids_ref,
+    kv_segment_ids_ref,
+    logsumexp_ref,
+    do_ref,
+    di_ref,
+    mask_ref,
+    q_sequence_ref,
+    # Outputs
+    dq_scratch_ref,
+    dk_scratch_ref,
+    dv_scratch_ref,
+    dq_ref,
+    dk_ref,
+    dv_ref,
+    *,
+    num_q_heads: int,
+    num_kv_heads: int,
+    mask_value: float,
+    grid_width: int,
+    bq: int,
+    bkv_compute: int,
+    is_mqa: bool,
+    attn_logits_soft_cap: float | None,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    bkv: int,
+    mask_function: MaskFunctionType | None,
+):
+  HEAD_DIM_MINOR = QKVLayout.HEAD_DIM_MINOR
+  kv_index, q_head_index, q_index = (
+      pl.program_id(0),
+      pl.program_id(1),
+      pl.program_id(2),
+  )
+  should_initialize = q_index == 0
+
+  q_heads_per_kv_heads = None
+  q_head_index_per_kv_head = None
+
+  # Consider this situation:
+  # Q_heads:   0, 1, 2, 3, 4, 5, 6, 7
+  # KV_heads:  0,    1,    2,    3
+  # The gradient scratch buffers should be initialized for Q_heads 0, 2, 4, 6
+  # (first Q_heads to 'see' a new KV_head).
+  # The gradient output buffers should be written for Q_heads 1, 3, 5, 7 (last
+  # Q_heads to 'see' the current KV_head).
+
+  # We can use the same logic for both MQA and GA (grouped attention).
+  # But for MQA there is no need for the rem instruction, so we skip it.
+  if is_mqa:
+    should_initialize = jnp.logical_and(should_initialize, q_head_index == 0)
+  elif num_kv_heads < num_q_heads:
+    q_heads_per_kv_heads = num_q_heads // num_kv_heads
+    q_head_index_per_kv_head = lax.rem(q_head_index, q_heads_per_kv_heads)
+    should_initialize = jnp.logical_and(
+        should_initialize, q_head_index_per_kv_head == 0
+    )
+  @pl.when(should_initialize)
+  def init():
+    dk_scratch_ref[...] = jnp.zeros_like(dk_scratch_ref)
+    dv_scratch_ref[...] = jnp.zeros_like(dv_scratch_ref)
+
+  _, _, should_run, should_not_mask = _next_nonzero(
+      q_head_index,
+      q_index,
+      kv_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref,
+      next_i=True,
+  )
+
+  def body(i, _):
+
+    slice_k = pl.ds(i * bkv_compute, bkv_compute)
+    q = q_ref[...]  # We keep q potentially transposed, since it's always RHS
+    def _load_kv(ref, layout):
+      if layout == HEAD_DIM_MINOR:
+        return ref[slice_k, :]
+      return ref[:, slice_k].T
+    k = _load_kv(k_ref, k_layout)
+    v = _load_kv(v_ref, v_layout)
+    logsumexp = logsumexp_ref[:1, :]
+    do = do_ref[...]
+    di = di_ref[:1, :]
+
+    qk_dims = NT_DIM_NUMBERS if q_layout == HEAD_DIM_MINOR else NN_DIM_NUMBERS
+    qk_uncapped = lax.dot_general(
+        k, q, qk_dims, preferred_element_type=jnp.float32
+    )
+
+    qk = _apply_mask_and_soft_cap(
+        qk_uncapped,
+        mask_value,
+        should_not_mask,
+        mask_ref,
+        q_sequence_ref,
+        q_segment_ids_ref,
+        kv_segment_ids_ref,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        k_slice=slice_k,
+        k_offset=kv_index * bkv + i * bkv_compute,
+        bq=bq,
+        k_in_lanes=False,
+        mask_function=mask_function,
+    )
+    p = jnp.exp(qk - logsumexp)
+    dv = lax.dot(p.astype(do.dtype), do, preferred_element_type=jnp.float32)
+    dv = dv.astype(dv_scratch_ref.dtype) + dv_scratch_ref[slice_k, :]
+    dv_scratch_ref[slice_k, :] = dv
+
+    dp = lax.dot_general(
+        v, do, NT_DIM_NUMBERS,
+        preferred_element_type=jnp.float32,
+    )
+    ds = (dp - di) * p
+    if attn_logits_soft_cap is not None:
+      normalized = qk_uncapped / attn_logits_soft_cap
+      d = jnp.tanh(normalized)
+      g = ds * (1 - d)
+      ds = g + g * d
+    dk_dims = NN_DIM_NUMBERS if q_layout == HEAD_DIM_MINOR else NT_DIM_NUMBERS
+    dk = lax.dot_general(
+        ds.astype(do.dtype), q, dk_dims, preferred_element_type=jnp.float32
+    )
+    dk = dk.astype(dk_scratch_ref.dtype) + dk_scratch_ref[slice_k, :]
+    dk_scratch_ref[slice_k, :] = dk
+    if dq_scratch_ref is not None or dq_ref is not None:
+      dq = lax.dot_general(
+          ds.T.astype(k.dtype), k, NN_DIM_NUMBERS,
+          preferred_element_type=jnp.float32,
+      )
+      if dq_scratch_ref is not None:
+        # Compute block size != memory block size
+        dq_scratch_ref[...] += dq
+      else:
+        # Compute block size == memory block size
+        assert dq_ref is not None
+        dq_ref[...] = dq.astype(dq_ref.dtype)
+
+  if dq_scratch_ref is not None:
+    dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+  elif dq_scratch_ref is None and dq_ref is not None:
+    dq_ref[...] = jnp.zeros_like(dq_ref)
+
+  @pl.when(should_run)
+  def run():
+    num_iters = (
+        k_ref.shape[0 if k_layout is HEAD_DIM_MINOR else 1] // bkv_compute
+    )
+    lax.fori_loop(0, num_iters, body, None, unroll=True)
+  if dq_scratch_ref is not None:
+    assert dq_ref is not None
+    dq_ref[...] = dq_scratch_ref[...].astype(dq_ref.dtype)
+
+  should_write = q_index == grid_width - 1
+  if is_mqa:
+    should_write = jnp.logical_and(
+        should_write, q_head_index == num_q_heads - 1
+    )
+  elif num_kv_heads < num_q_heads:
+    should_write = jnp.logical_and(
+        should_write, q_head_index_per_kv_head == q_heads_per_kv_heads - 1
+    )
+
+  @pl.when(should_write)
+  def end():
+    dk_ref[...] = dk_scratch_ref[...].astype(dk_ref.dtype)
+    dv_ref[...] = dv_scratch_ref[...].astype(dv_ref.dtype)
+    if dq_scratch_ref is not None:
+      dq_scratch_ref[...] = jnp.zeros_like(dq_scratch_ref)
+
+    dk_scratch_ref[...] = jnp.zeros_like(dk_scratch_ref)
+    dv_scratch_ref[...] = jnp.zeros_like(dv_scratch_ref)
+
+
+def _splash_attention_bwd_dkv(
+    q,
+    k,
+    v,
+    segment_ids,
+    logsumexp,
+    do,
+    di,
+    *,
+    bq: int,
+    bkv: int,
+    bkv_compute: int,
+    is_mqa: bool,
+    mask_info: mask_info_lib.MaskInfo,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    use_fused_bwd_kernel: bool,
+    q_layout: QKVLayout,
+    k_layout: QKVLayout,
+    v_layout: QKVLayout,
+    mask_function: MaskFunctionType | None,
+    interpret: bool,
+):
+  num_q_heads, q_seq_len, head_dim_qk = q.shape
+  head_dim_v = v.shape[-1]
+  if is_mqa:
+    num_kv_heads, kv_seq_len = 1, k.shape[0]
+  else:
+    num_kv_heads, kv_seq_len, _ = k.shape
+
+  if bq > q_seq_len:
+    raise ValueError(
+        f"{bq=} should not be greater than {q_seq_len=}")
+  if bkv > kv_seq_len:
+    raise ValueError(
+        f"{bkv=} should not be greater than {kv_seq_len=}")
+  if bkv_compute > bkv:
+    raise ValueError(
+        f"{bkv_compute=} should not be greater than {bkv=}")
+  if bkv % bkv_compute:
+    raise ValueError(
+        f"{bkv=} should be a multiple of {bkv_compute=}")
+
+  if not is_mqa and num_q_heads % num_kv_heads != 0:
+    raise ValueError(
+        f"In MHA, expected number of 'key' heads ({num_kv_heads}) to be a"
+        f" multiple of the number of 'query' heads ({num_q_heads})"
+    )
+
+  if k.shape[:-1] != v.shape[:-1]:
+    raise ValueError(
+        f"Expected 'key' {k.shape} and 'value' {v.shape} to have the same "
+        "leading dimensions."
+    )
+
+  q_heads_per_kv_head = num_q_heads // num_kv_heads
+
+  if mask_info.data_next is not None:
+    grid_width = mask_info.data_next.shape[-2]
+  else:
+    grid_width = q_seq_len // bq
+
+  grid = (
+      kv_seq_len // bkv,
+      num_q_heads,
+      grid_width,
+  )
+
+  def o_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return head_index, next_i, 0
+
+  o_spec = pl.BlockSpec((None, bq, head_dim_v), o_index_map)
+
+  def q_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return from_head_minor((head_index, next_i, 0), q_layout)
+
+  q_spec = pl.BlockSpec(
+      from_head_minor((None, bq, head_dim_qk), q_layout), q_index_map
+  )
+
+  def k_index_map(kv_index, head_index, *_):
+    prefix = () if is_mqa else (_div(head_index, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, kv_index, 0), k_layout)
+
+  k_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk),
+          k_layout,
+      ),
+      k_index_map,
+  )
+
+  def v_index_map(kv_index, head_index, *_):
+    prefix = () if is_mqa else (_div(head_index, q_heads_per_kv_head),)
+    return from_head_minor((*prefix, kv_index, 0), v_layout)
+
+  v_spec = pl.BlockSpec(
+      from_head_minor(
+          (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v),
+          v_layout,
+      ),
+      v_index_map,
+  )
+
+  if use_fused_bwd_kernel:
+    def dq_index_map(kv_index, head_index, q_index, *_):
+      return (kv_index, head_index, q_index, 0)
+    dq_spec = pl.BlockSpec((None, None, bq, head_dim_qk), dq_index_map)
+    dq_shape = jax.ShapeDtypeStruct((kv_seq_len // bkv, *q.shape), q.dtype)
+    if bkv == bkv_compute:
+      dq_scratch_spec = dq_scratch_shape = None
+    else:
+      dq_scratch_spec = pl.BlockSpec((bq, head_dim_qk), lambda *_: (0, 0))
+      dq_scratch_shape = jax.ShapeDtypeStruct((bq, head_dim_qk), jnp.float32)
+  else:
+    dq_spec = dq_shape = dq_scratch_spec = dq_scratch_shape = None
+
+  def dkv_index_map(kv_index, head_index, *_):
+    prefix = () if is_mqa else (_div(head_index, q_heads_per_kv_head),)
+    return (*prefix, kv_index, 0)
+
+  dk_spec = pl.BlockSpec(
+      (bkv, head_dim_qk) if is_mqa else (None, bkv, head_dim_qk),
+      dkv_index_map,
+  )
+
+  dv_spec = pl.BlockSpec(
+      (bkv, head_dim_v) if is_mqa else (None, bkv, head_dim_v),
+      dkv_index_map,
+  )
+
+  def mask_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref,
+  ):
+    _, next_m, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return next_m, 0, 0
+
+  mask_spec = pl.BlockSpec((None, bkv, bq), mask_index_map)
+
+  def q_segment_ids_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return 0, next_i
+
+  if segment_ids is not None:
+    def kv_segment_ids_index_map(kv_index, *_):
+      return kv_index, 0
+
+    q_segment_spec = pl.BlockSpec((NUM_SUBLANES, bq), q_segment_ids_index_map)
+    kv_segment_spec = pl.BlockSpec((bkv, NUM_LANES), kv_segment_ids_index_map)
+    q_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.q, (NUM_SUBLANES, q_seq_len), (1,)
+    )
+    kv_segment_ids = jax.lax.broadcast_in_dim(
+        segment_ids.kv, (kv_seq_len, NUM_LANES), (0,)
+    )
+  else:
+    q_segment_spec = kv_segment_spec = None
+    q_segment_ids = kv_segment_ids = None
+
+  do_spec = o_spec
+
+  def logsumexp_index_map(
+      kv_index,
+      head_index,
+      q_index,
+      data_next_ref,
+      block_mask_ref,
+      mask_next_ref=None,
+  ):
+    next_i, *_ = _next_nonzero(
+        head_index,
+        q_index,
+        kv_index,
+        data_next_ref,
+        block_mask_ref,
+        mask_next_ref,
+        next_i=True,
+    )
+    return head_index, 0, next_i
+
+  assert logsumexp.shape == di.shape == (num_q_heads, q_seq_len)
+  # TODO(apaszke): Remove the sublane expansion once Mosaic has all retilings
+  logsumexp_shape = (num_q_heads, NUM_SUBLANES, q_seq_len)
+  logsumexp = jnp.broadcast_to(jnp.expand_dims(logsumexp, -2), logsumexp_shape)
+  logsumexp_spec = pl.BlockSpec((None, NUM_SUBLANES, bq), logsumexp_index_map)
+  assert logsumexp.ndim == len(logsumexp_spec.block_shape)
+
+  # TODO(apaszke): Remove the sublane expansion once Mosaic has all retilings
+  di = jnp.broadcast_to(jnp.expand_dims(di, -2), logsumexp_shape)
+  di_spec = pl.BlockSpec((None, NUM_SUBLANES, bq), logsumexp_index_map)
+  assert di.ndim == len(di_spec.block_shape)
+
+  in_specs = [
+      q_spec,
+      k_spec,
+      v_spec,
+      q_segment_spec,
+      kv_segment_spec,
+      logsumexp_spec,
+      do_spec,
+      di_spec,
+  ]
+  if mask_info.partial_mask_blocks is not None:
+    in_specs.append(mask_spec)
+  else:
+    in_specs.append(None)
+
+  if mask_info.q_sequence is not None:
+    in_specs.append(pl.BlockSpec((NUM_SUBLANES, bq), q_segment_ids_index_map))
+    q_sequence = jax.lax.broadcast_in_dim(
+        mask_info.q_sequence, (NUM_SUBLANES, q_seq_len), (1,)
+    )
+  else:
+    q_sequence = None
+    in_specs.append(None)
+
+  out_shapes = [
+      dq_scratch_shape,
+      jax.ShapeDtypeStruct((bkv, head_dim_qk), jnp.float32),
+      jax.ShapeDtypeStruct((bkv, head_dim_v), jnp.float32),
+      dq_shape,
+      jax.ShapeDtypeStruct(k.shape, k.dtype),
+      jax.ShapeDtypeStruct(v.shape, v.dtype),
+  ]
+  out_specs = [
+      dq_scratch_spec,
+      pl.BlockSpec((bkv, head_dim_qk), lambda *_: (0, 0)),
+      pl.BlockSpec((bkv, head_dim_v), lambda *_: (0, 0)),
+      dq_spec,
+      dk_spec,
+      dv_spec,
+  ]
+
+  kernel = functools.partial(
+      _flash_attention_dkv_kernel,
+      mask_value=mask_value,
+      num_q_heads=num_q_heads,
+      num_kv_heads=num_kv_heads,
+      is_mqa=is_mqa,
+      grid_width=grid_width,
+      bq=bq,
+      bkv_compute=bkv_compute,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      q_layout=q_layout,
+      k_layout=k_layout,
+      v_layout=v_layout,
+      bkv=bkv,
+      mask_function=mask_function,
+  )
+  num_scalar_prefetch = 3
+
+  kernel_name = get_kernel_name(
+      dict(
+          block_q_dkv=bq,
+          block_kv_dkv=bkv,
+          block_kv_dkv_compute=bkv_compute,
+          q_layout=q_layout,
+          k_layout=k_layout,
+          v_layout=v_layout,
+      ),
+      is_mqa=is_mqa,
+      save_residuals=False,
+      is_segmented=segment_ids is not None,
+      phase="dkv",
+  )
+  with jax.named_scope(kernel_name):
+    _, _, _, dq_unreduced, dk, dv = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=num_scalar_prefetch,
+            in_specs=in_specs,
+            out_specs=out_specs,
+            grid=grid,
+        ),
+        out_shape=out_shapes,
+        # We set all dimensions to arbitrary because:
+        # 1) for kv_seq_len, the splash attention prefetch schedule assumes no
+        #    megacore
+        # 2) for heads, we are reducing over heads
+        # 3) for q_seq_len, we are reducing over it to compute dkv
+        compiler_params=pltpu.CompilerParams(
+          dimension_semantics=("arbitrary", "arbitrary", "arbitrary"),
+        ),
+        name=kernel_name,
+        interpret=interpret,
+    )(
+        mask_info.data_next,
+        mask_info.block_mask,
+        mask_info.mask_next,
+        q if q_layout == QKVLayout.HEAD_DIM_MINOR else q.swapaxes(-1, -2),
+        k if k_layout == QKVLayout.HEAD_DIM_MINOR else k.swapaxes(-1, -2),
+        v if v_layout == QKVLayout.HEAD_DIM_MINOR else v.swapaxes(-1, -2),
+        q_segment_ids,
+        kv_segment_ids,
+        logsumexp,
+        do,
+        di,
+        mask_info.partial_mask_blocks,
+        q_sequence,
+    )
+  if use_fused_bwd_kernel:
+    assert dq_unreduced is not None
+    dq = dq_unreduced.sum(axis=0)
+  else:
+    assert dq_unreduced is None
+    dq = None
+  return dq, dk, dv
+
+
+def _splash_attention_bwd(
+    save_residuals: bool,
+    mask_value: float,
+    is_mqa: bool,
+    block_sizes: BlockSizes,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    attn_logits_soft_cap: float | None,
+    interpret: bool,
+    res: SplashResidualsType,
+    do: jax.Array,
+) -> tuple[
+    mask_info_lib.MaskInfo | None,  # fwd_mask_info
+    mask_info_lib.MaskInfo | None,  # dq_mask_info
+    mask_info_lib.MaskInfo | None,  # dvk_mask_info
+    jax.Array,  # q
+    jax.Array,  # k
+    jax.Array,  # v
+    SegmentIds | None,  # segmend_ids
+]:
+  del save_residuals, residual_checkpoint_name
+  if not block_sizes.has_backward_blocks:
+    raise ValueError("Need to specify backward blocks.")
+  bq_dq, bkv_dq = block_sizes.block_q_dq, block_sizes.block_kv_dq
+  bq_dkv, bkv_dkv_memory, bkv_dkv_compute = (
+      block_sizes.block_q_dkv,
+      block_sizes.block_kv_dkv,
+      block_sizes.block_kv_dkv_compute,
+  )
+  use_fused_bwd_kernel = block_sizes.use_fused_bwd_kernel
+  (
+      q,
+      k,
+      v,
+      segment_ids,
+      o,
+      logsumexp,
+      dq_mask_info,
+      dkv_mask_info,
+  ) = res
+
+  # di: [num_heads, q_seq_len]
+  di = jnp.einsum("hsd,hsd->hs", o.astype(jnp.float32), do.astype(jnp.float32))  # pytype: disable=attribute-error
+  dq, dk, dv = _splash_attention_bwd_dkv(
+      q,
+      k,
+      v,
+      segment_ids,
+      logsumexp,
+      do,
+      di,
+      bq=bq_dkv,
+      bkv=bkv_dkv_memory,
+      bkv_compute=bkv_dkv_compute,
+      is_mqa=is_mqa,
+      mask_info=dkv_mask_info,
+      mask_value=mask_value,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      use_fused_bwd_kernel=use_fused_bwd_kernel,
+      q_layout=block_sizes.q_layout,
+      k_layout=block_sizes.k_layout,
+      v_layout=block_sizes.v_layout,
+      mask_function=mask_function,
+      interpret=interpret,
+  )
+  if not use_fused_bwd_kernel:
+    assert dq is None
+    dq = _splash_attention_bwd_dq(
+        q,
+        k,
+        v,
+        segment_ids,
+        logsumexp,
+        do,
+        di,
+        bq=bq_dq,
+        bkv=bkv_dq,
+        is_mqa=is_mqa,
+        mask_info=dq_mask_info,
+        mask_value=mask_value,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        q_layout=block_sizes.q_layout,
+        k_layout=block_sizes.k_layout,
+        v_layout=block_sizes.v_layout,
+        mask_function=mask_function,
+        interpret=interpret,
+    )
+  # Match the signature of the fwd function.
+  assert dq is not None
+  return (
+      None,  # fwd_mask_info
+      None,  # dq_mask_info
+      None,  # dvk_mak_info
+      dq,  # q
+      dk,  # k
+      dv,  # v
+      None,  # segment_ids
+  )
+
+
+_splash_attention_custom.defvjp(_splash_attention_fwd, _splash_attention_bwd)
+
+
+@partial(
+    jax.jit,
+    static_argnames=[
+        "is_mqa",
+        "block_sizes",
+        "save_residuals",
+        "mask_value",
+        "attn_logits_soft_cap",
+        "residual_checkpoint_name",
+        "mask_function",
+        "interpret",
+    ],
+)
+def _splash_attention(
+    fwd_mask_info: mask_info_lib.MaskInfo,
+    dq_mask_info: mask_info_lib.MaskInfo | None,
+    dkv_mask_info: mask_info_lib.MaskInfo | None,
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    segment_ids: SegmentIds | None = None,
+    *,
+    is_mqa: bool,
+    block_sizes: BlockSizes | None,
+    save_residuals: bool,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    residual_checkpoint_name: str | None,
+    mask_function: MaskFunctionType | None,
+    interpret: bool,
+) -> SplashCustomReturnType:
+  """
+  For dynamic masks, `partial_mask_blocks` has shape (head_count, q_blocks, kv_blocks, block_q, block_kv).
+  This shape allows sharding across both head count and query sequence dimensions.
+
+  Note: The leading dimensions (head_count, q_blocks, kv_blocks) must be
+  collapsed into a single dimension before being passed to the kernel.
+  """
+  def _collapse_partial_mask_blocks(mask_info: mask_info_lib.MaskInfo | None):
+    if mask_info is None or mask_info.partial_mask_blocks is None:
+        return mask_info
+
+    return mask_info._replace(
+        partial_mask_blocks=mask_info.partial_mask_blocks.reshape(
+            -1, *mask_info.partial_mask_blocks.shape[-2:]
+        )
+    )
+
+  fwd_mask_info = _collapse_partial_mask_blocks(fwd_mask_info)
+  dq_mask_info = _collapse_partial_mask_blocks(dq_mask_info)
+  dkv_mask_info = _collapse_partial_mask_blocks(dkv_mask_info)
+  return _splash_attention_custom(
+      fwd_mask_info,
+      dq_mask_info,
+      dkv_mask_info,
+      q,
+      k,
+      v,
+      segment_ids,
+      mask_value=mask_value,
+      is_mqa=is_mqa,
+      block_sizes=block_sizes,
+      save_residuals=save_residuals,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      residual_checkpoint_name=residual_checkpoint_name,
+      mask_function=mask_function,
+      interpret=interpret,
+  )
+
+
+@jax.tree_util.register_pytree_node_class
+class SplashAttentionKernel:
+
+  def __init__(
+      self,
+      fwd_mask_info: mask_info_lib.MaskInfo,
+      dq_mask_info: mask_info_lib.MaskInfo | None,
+      dkv_mask_info: mask_info_lib.MaskInfo | None,
+      **kwargs,
+  ):
+    self.kwargs = kwargs
+    self.fwd_mask_info = fwd_mask_info
+    self.dq_mask_info = dq_mask_info
+    self.dkv_mask_info = dkv_mask_info
+
+  def __call__(self, *args, **kwargs) -> SplashCustomReturnType:
+    return _splash_attention(
+        self.fwd_mask_info,
+        self.dq_mask_info,
+        self.dkv_mask_info,
+        *args,
+        **kwargs,
+        **self.kwargs,
+    )
+
+  def manual_sharding_spec(self, sharding: jax.sharding.NamedSharding):
+    """Returns a value that can be used as a shard_map partition spec for the kernel."""
+    if self.fwd_mask_info.data_next is not None:
+      block_mask_shape = self.fwd_mask_info.data_next.shape
+      try:
+        shard_shape = sharding.shard_shape(block_mask_shape)
+      except ValueError as exc:
+        raise ValueError(
+            "The sharding must divide the mask blocks evenly between devices"
+        ) from exc
+      if block_mask_shape[-1] != shard_shape[-1]:
+        raise ValueError("Sharding the kv sequence dimension is not supported")
+    spec = sharding.spec
+    assert len(spec) == 2
+    replicated = jax.sharding.PartitionSpec()
+    partial_mask_blocks_spec = (
+        spec if self.fwd_mask_info.is_dynamic_mask else replicated
+    )
+    # Shard q_sequence over the sequence dimension only.
+    q_sequence_spec = jax.sharding.PartitionSpec(spec[1])
+    mask_info_specs = mask_info_lib.MaskInfo(  # pytype: disable=wrong-arg-types
+        data_next=spec if self.fwd_mask_info.data_next is not None else None,
+        mask_next=spec if self.fwd_mask_info.mask_next is not None else None,
+        block_mask=spec if self.fwd_mask_info.block_mask is not None else None,
+        partial_mask_blocks=partial_mask_blocks_spec
+        if self.fwd_mask_info.partial_mask_blocks is not None
+        else None,
+        q_sequence=q_sequence_spec
+        if self.fwd_mask_info.q_sequence is not None
+        else None,
+    )
+    return SplashAttentionKernel(
+        mask_info_specs,
+        mask_info_specs if self.dq_mask_info is not None else None,
+        mask_info_specs if self.dkv_mask_info is not None else None,
+        **self.kwargs,
+    )
+
+  def tree_flatten(self):
+    return (
+        (self.fwd_mask_info, self.dq_mask_info, self.dkv_mask_info),
+        self.kwargs,
+    )
+
+  @classmethod
+  def tree_unflatten(cls, kwargs, values):
+    fwd_mask_info, dq_mask_info, dkv_mask_info = values
+    # NamedTuples are not preserved during pytree serialization.
+    dq_mask_info = (
+        mask_info_lib.MaskInfo(*dq_mask_info)
+        if dq_mask_info is not None
+        else None
+    )
+    dkv_mask_info = (
+        mask_info_lib.MaskInfo(*dkv_mask_info)
+        if dkv_mask_info is not None
+        else None
+    )
+    return SplashAttentionKernel(
+        mask_info_lib.MaskInfo(*fwd_mask_info),
+        dq_mask_info,
+        dkv_mask_info,
+        **kwargs,
+    )
+
+
+def _make_splash_attention(
+    mask: np.ndarray | jax.Array | mask_lib.MultiHeadMask,
+    *,
+    block_sizes: BlockSizes | None = None,
+    is_mqa: bool,
+    save_residuals: bool = False,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    attn_logits_soft_cap: float | None = None,
+    downcast_smem_data: bool = True,
+    head_shards: int,
+    q_seq_shards: int,
+    residual_checkpoint_name: str | None = None,
+    interpret: bool = False,
+):
+  if len(mask.shape) != 3:
+    raise ValueError(f'Unexpected mask shape: {mask.shape}')
+
+  if isinstance(mask, np.ndarray):
+    mask = mask_lib.MultiHeadMask(
+        [mask_lib.NumpyMask(head_mask) for head_mask in mask]
+    )
+
+  if block_sizes is None:
+    block_sizes = BlockSizes.get_default()
+
+  process_mask_fn = (
+      mask_info_lib.process_dynamic_mask
+      if isinstance(mask, jax.Array)
+      else mask_info_lib.process_mask
+  )
+
+  process_mask_dvk_fn = (
+      mask_info_lib.process_dynamic_mask_dkv
+      if isinstance(mask, jax.Array)
+      else mask_info_lib.process_mask_dkv
+  )
+
+  fwd_mask_info, mask_function_fwd = process_mask_fn(
+      mask,
+      (block_sizes.block_q, block_sizes.block_kv),
+      downcast_smem_data=downcast_smem_data,
+      head_shards=head_shards,
+      q_seq_shards=q_seq_shards,
+  )
+  fwd_mask_info = tree_util.tree_map(jnp.array, fwd_mask_info)
+
+  dq_mask_info = None
+  dkv_mask_info = None
+  if block_sizes.has_backward_blocks:
+    if block_sizes.use_fused_bwd_kernel:
+      dq_mask_info = None
+    else:
+      bq_dq, bkv_dq = block_sizes.block_q_dq, block_sizes.block_kv_dq
+      dq_mask_info, mask_function_dq = process_mask_fn(
+          mask,
+          (bq_dq, bkv_dq),
+          downcast_smem_data=downcast_smem_data,
+          head_shards=head_shards,
+          q_seq_shards=q_seq_shards,
+      )
+      assert (mask_function_fwd is None) == (mask_function_dq is None)
+      dq_mask_info = tree_util.tree_map(jnp.array, dq_mask_info)
+    bq_dkv, bkv_dkv = block_sizes.block_q_dkv, block_sizes.block_kv_dkv
+    dkv_mask_info, mask_function_dkv = process_mask_dvk_fn(
+        mask,
+        (bq_dkv, bkv_dkv),
+        downcast_smem_data=downcast_smem_data,
+        head_shards=head_shards,
+        q_seq_shards=q_seq_shards,
+        shrink_grid=not block_sizes.use_fused_bwd_kernel,
+    )
+    assert (mask_function_fwd is None) == (mask_function_dkv is None)
+
+    dkv_mask_info = tree_util.tree_map(jnp.array, dkv_mask_info)
+
+  return SplashAttentionKernel(
+      fwd_mask_info,
+      dq_mask_info,
+      dkv_mask_info,
+      block_sizes=block_sizes,
+      is_mqa=is_mqa,
+      save_residuals=save_residuals,
+      mask_value=mask_value,
+      attn_logits_soft_cap=attn_logits_soft_cap,
+      residual_checkpoint_name=residual_checkpoint_name,
+      mask_function=mask_function_fwd,
+      interpret=interpret,
+  )
+
+
+make_splash_mha = partial(_make_splash_attention, is_mqa=False)
+make_splash_mqa = partial(_make_splash_attention, is_mqa=True)
+
+make_splash_mha_single_device = partial(
+    make_splash_mha, is_mqa=False, head_shards=1, q_seq_shards=1
+)
+
+make_splash_mqa_single_device = partial(
+    make_splash_mha, is_mqa=True, head_shards=1, q_seq_shards=1
+)
+
+
+CONFIG = {
+    'name': 'pallas_splash_attention_llama70b',
+    'model': 'Llama-3.1-70B',
+    'operator': 'pallas_splash_attention',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_query_heads': 64,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+    'atol': 3e-3,
+    'rtol': 3e-3,
+}
+
+# Tuned by autotune_block_sizes.py. Re-run to update.
+TUNED_PARAMS = {
+    # Autotuned (forward pass).
+    'block_q': 2048,
+    'block_kv': 2048,
+    'block_kv_compute': 1024,
+    'q_layout': 1,  # QKVLayout.HEAD_DIM_MINOR=1, SEQ_MINOR=2
+    'k_layout': 1,
+    'v_layout': 1,
+    'head_shards': 1,
+    'q_seq_shards': 1,
+    # Not autotuned (backward-only).
+    'block_q_dkv': None,
+    'block_kv_dkv': None,
+    'block_kv_dkv_compute': None,
+    'block_q_dq': None,
+    'block_kv_dq': None,
+}
+
+
+def get_flops():
+    B = CONFIG['batch']
+    H_q = CONFIG['num_query_heads']
+    S = CONFIG['seq_len']
+    D = CONFIG['head_dim']
+    return 4 * B * H_q * S * S * D
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    B = CONFIG['batch']
+    S = CONFIG['seq_len']
+    H_q = CONFIG['num_query_heads']
+    H_kv = CONFIG['num_kv_heads']
+    D = CONFIG['head_dim']
+    q = jax.random.normal(k1, (B, H_q, S, D), dtype=dtype)
+    k = jax.random.normal(k2, (B, H_kv, S, D), dtype=dtype)
+    v = jax.random.normal(k3, (B, H_kv, S, D), dtype=dtype)
+    return q, k, v
+
+
+def workload(q, k, v):
+    B, H_q, S, D = q.shape
+    H_kv = v.shape[1]
+    heads_per_group = H_q // H_kv
+    mask = mask_lib.CausalMask(shape=(S, S))
+    multi_head_mask = mask_lib.MultiHeadMask([mask] * H_q)
+    block_sizes = BlockSizes(
+        block_q=TUNED_PARAMS['block_q'],
+        block_kv=TUNED_PARAMS['block_kv'],
+        block_kv_compute=TUNED_PARAMS['block_kv_compute'],
+        q_layout=QKVLayout(TUNED_PARAMS['q_layout']),
+        k_layout=QKVLayout(TUNED_PARAMS['k_layout']),
+        v_layout=QKVLayout(TUNED_PARAMS['v_layout']),
+        block_q_dkv=TUNED_PARAMS['block_q_dkv'],
+        block_kv_dkv=TUNED_PARAMS['block_kv_dkv'],
+        block_kv_dkv_compute=TUNED_PARAMS['block_kv_dkv_compute'],
+        block_q_dq=TUNED_PARAMS['block_q_dq'],
+        block_kv_dq=TUNED_PARAMS['block_kv_dq'],
+    )
+    splash_kernel = _make_splash_attention(
+        multi_head_mask, block_sizes=block_sizes,
+        is_mqa=False,
+        head_shards=TUNED_PARAMS['head_shards'],
+        q_seq_shards=TUNED_PARAMS['q_seq_shards'],
+    )
+    @jax.vmap
+    def _attend(q_batch, k_batch, v_batch):
+        k_repeated = jnp.repeat(k_batch, heads_per_group, axis=0)
+        v_repeated = jnp.repeat(v_batch, heads_per_group, axis=0)
+        return splash_kernel(q_batch, k_repeated, v_repeated)
+    return _attend(q, k, v)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator', 'atol', 'rtol')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/50k_Matmul_GELU_Softmax/baseline.py
+++ b/JAXBench/benchmark/50k_Matmul_GELU_Softmax/baseline.py
@@ -1,0 +1,60 @@
+"""99_Matmul_GELU_Softmax — JAXBench fused operator workload."""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': '99_Matmul_GELU_Softmax',
+    'batch_size': 4096,
+    'in_features': 8192,
+    'out_features': 8192,
+}
+
+
+def create_inputs(dtype=jnp.float32):
+    """Create all inputs including weights."""
+    key = jax.random.key(0)
+    x = jax.random.uniform(key, (4096, 8192), dtype=dtype)
+    weight = jnp.zeros((8192, 8192), dtype=dtype)
+    bias = jnp.zeros(8192, dtype=dtype)
+    return x, weight, bias
+
+
+def workload(x, weight, bias):
+    """Matmul + GELU + Softmax."""
+    x = jnp.matmul(x, weight) + bias
+    x = jax.nn.gelu(x)
+    x = jax.nn.softmax(x, axis=1)
+    return x
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times_ms = np.array(times) * 1000
+    avg = float(np.mean(times_ms))
+    return {
+        'name': CONFIG['name'],
+        'config': {k: v for k, v in CONFIG.items() if k != 'name'},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times_ms)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/5p_Flex_Attention/baseline.py
+++ b/JAXBench/benchmark/5p_Flex_Attention/baseline.py
@@ -1,0 +1,99 @@
+"""Flex Attention — Llama-3.1-70B with custom score modification.
+
+Flexible attention with arbitrary score_mod function support, the JAX
+equivalent of PyTorch's flex_attention. Baseline uses causal mask with
+relative position bias as the score modifier.
+From MaxText layers/attention_op.py (dot_product_attention with masks).
+"""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'llama3_70b_flex_attention',
+    'model': 'Llama-3.1-70B',
+    'operator': 'flex_attention',
+    'batch': 4,
+    'seq_len': 4096,
+    'num_heads': 64,
+    'head_dim': 128,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (q, k, v, rel_pos_bias) tensors."""
+    key = jax.random.key(42)
+    k1, k2, k3, k4 = jax.random.split(key, 4)
+    B = CONFIG['batch']
+    S = CONFIG['seq_len']
+    H = CONFIG['num_heads']
+    D = CONFIG['head_dim']
+    q = jax.random.normal(k1, (B, H, S, D), dtype=dtype)
+    k = jax.random.normal(k2, (B, H, S, D), dtype=dtype) * 0.02
+    v = jax.random.normal(k3, (B, H, S, D), dtype=dtype) * 0.02
+    # Relative position bias per head (learned, as in ALiBi-style)
+    rel_pos_bias = jax.random.normal(k4, (H, S, S), dtype=dtype) * 0.01
+    return q, k, v, rel_pos_bias
+
+
+def workload(q, k, v, rel_pos_bias):
+    """Flex attention: dot-product attention with score modification."""
+    D = CONFIG['head_dim']
+    S = CONFIG['seq_len']
+    sm_scale = D ** -0.5
+
+    # Attention scores
+    attn = jnp.einsum('bhqd,bhkd->bhqk', q, k) * sm_scale
+
+    # Score modification: add relative position bias
+    attn = attn + rel_pos_bias[None, :, :, :]
+
+    # Causal mask
+    causal = jnp.tril(jnp.ones((S, S), dtype=jnp.bool_))
+    attn = jnp.where(causal[None, None, :, :], attn, -1e30)
+
+    attn = jax.nn.softmax(attn, axis=-1)
+
+    # Output
+    out = jnp.einsum('bhqk,bhkd->bhqd', attn, v)
+    return out
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B = CONFIG['batch']
+    H = CONFIG['num_heads']
+    S = CONFIG['seq_len']
+    D = CONFIG['head_dim']
+    # QK dot: 2*B*H*S*S*D, score_mod add: B*H*S*S, AV dot: 2*B*H*S*S*D
+    flops = 4 * B * H * S * S * D + B * H * S * S
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/6p_Paged_Attention/baseline.py
+++ b/JAXBench/benchmark/6p_Paged_Attention/baseline.py
@@ -1,0 +1,138 @@
+"""Ragged Paged Attention — Llama-3.1-70B inference decode.
+
+Paged KV-cache attention with variable-length sequences, as used in
+serving frameworks. Supports grouped-query attention (GQA).
+From MaxText inference/paged_attention_kernel_v2.py.
+"""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'llama3_70b_paged_attention',
+    'model': 'Llama-3.1-70B',
+    'operator': 'paged_attention',
+    'num_seqs': 64,
+    'max_seq_len': 4096,
+    'num_query_heads': 64,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+    'page_size': 16,
+    'pages_per_seq': 256,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (queries, k_pages, v_pages, kv_lens, page_indices, cu_q_lens)."""
+    key = jax.random.key(42)
+    keys = jax.random.split(key, 5)
+    num_seqs = CONFIG['num_seqs']
+    max_seq_len = CONFIG['max_seq_len']
+    num_q_heads = CONFIG['num_query_heads']
+    num_kv_heads = CONFIG['num_kv_heads']
+    head_dim = CONFIG['head_dim']
+    page_size = CONFIG['page_size']
+    pages_per_seq = CONFIG['pages_per_seq']
+    total_pages = num_seqs * pages_per_seq
+
+    # Each sequence has 1 query token (decode mode)
+    max_num_tokens = num_seqs
+    queries = jax.random.normal(keys[0], (max_num_tokens, num_q_heads, head_dim), dtype=dtype)
+    k_pages = jax.random.normal(keys[1], (total_pages, page_size, num_kv_heads, head_dim), dtype=dtype) * 0.02
+    v_pages = jax.random.normal(keys[2], (total_pages, page_size, num_kv_heads, head_dim), dtype=dtype) * 0.02
+
+    # All sequences have full length
+    kv_lens = jnp.full((num_seqs,), max_seq_len, dtype=jnp.int32)
+    # Page indices: sequence i owns pages [i*pages_per_seq, (i+1)*pages_per_seq)
+    page_indices = jnp.arange(total_pages, dtype=jnp.int32).reshape(num_seqs, pages_per_seq)
+    # Cumulative query lengths: each sequence has 1 query token
+    cu_q_lens = jnp.arange(num_seqs + 1, dtype=jnp.int32)
+
+    return queries, k_pages, v_pages, kv_lens, page_indices, cu_q_lens
+
+
+def workload(queries, k_pages, v_pages, kv_lens, page_indices, cu_q_lens):
+    """Ragged paged attention: gather pages, compute GQA attention per sequence."""
+    num_seqs = CONFIG['num_seqs']
+    num_q_heads = CONFIG['num_query_heads']
+    num_kv_heads = CONFIG['num_kv_heads']
+    head_dim = CONFIG['head_dim']
+    page_size = CONFIG['page_size']
+    max_seq_len = CONFIG['pages_per_seq'] * page_size
+    pages_per_seq = CONFIG['pages_per_seq']
+    num_q_per_kv = num_q_heads // num_kv_heads
+    sm_scale = head_dim ** -0.5
+
+    def attend_one_seq(seq_idx):
+        q_start = cu_q_lens[seq_idx]
+        q_end = cu_q_lens[seq_idx + 1]
+        q = jax.lax.dynamic_slice(queries, (q_start, 0, 0), (1, num_q_heads, head_dim))  # (1, H_q, D)
+        # Gather KV pages
+        seq_pages = page_indices[seq_idx]  # (pages_per_seq,)
+        k = k_pages[seq_pages].reshape(max_seq_len, num_kv_heads, head_dim)  # (S, H_kv, D)
+        v = v_pages[seq_pages].reshape(max_seq_len, num_kv_heads, head_dim)
+        # Repeat KV heads for GQA
+        k = jnp.repeat(k, num_q_per_kv, axis=1)  # (S, H_q, D)
+        v = jnp.repeat(v, num_q_per_kv, axis=1)
+        # Attention: (1, H_q, D) x (S, H_q, D) -> (H_q, 1, S)
+        attn = jnp.einsum('qhd,khd->hqk', q, k) * sm_scale
+        # Causal mask: query at position kv_len-1, keys at 0..kv_len-1
+        kv_len = kv_lens[seq_idx]
+        mask = jnp.arange(max_seq_len) < kv_len
+        attn = jnp.where(mask[None, None, :], attn, -1e30)
+        attn = jax.nn.softmax(attn, axis=-1)
+        out = jnp.einsum('hqk,khd->qhd', attn, v)  # (1, H_q, D)
+        return out.squeeze(0)  # (H_q, D)
+
+    # Process all sequences
+    outputs = jax.vmap(attend_one_seq)(jnp.arange(num_seqs))  # (num_seqs, H_q, D)
+    return outputs
+
+
+def get_flops():
+    """Decode attention FLOPs: per seq QK^T + AV matmuls."""
+    num_seqs = CONFIG['num_seqs']
+    num_q_heads = CONFIG['num_query_heads']
+    max_seq_len = CONFIG['max_seq_len']
+    head_dim = CONFIG['head_dim']
+    return num_seqs * num_q_heads * (4 * max_seq_len * head_dim)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    num_seqs = CONFIG['num_seqs']
+    num_q_heads = CONFIG['num_query_heads']
+    max_seq_len = CONFIG['max_seq_len']
+    head_dim = CONFIG['head_dim']
+    # Per sequence: QK dot (2*1*S*D*H) + softmax + AV dot (2*1*S*D*H)
+    flops = num_seqs * num_q_heads * (4 * max_seq_len * head_dim)
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 4),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/6p_Paged_Attention/optimized.py
+++ b/JAXBench/benchmark/6p_Paged_Attention/optimized.py
@@ -1,0 +1,762 @@
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pallas PagedAttention TPU kernel — Llama-3.1-70B decode dimensions.
+
+Upstream kernel from jax.experimental.pallas.ops.tpu.paged_attention, wrapped
+as a JAXBench workload with CONFIG / create_inputs / workload.
+
+quantization_utils imported from the installed JAX package (not optimizable).
+"""
+
+from collections.abc import Sequence
+import functools
+from typing import Literal
+
+import jax
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas.ops.tpu.paged_attention import quantization_utils
+import jax.numpy as jnp
+import numpy as np
+
+
+DEFAULT_MASK_VALUE = -0.7 * float(np.finfo(np.dtype("float32")).max)
+
+
+class MultiPageAsyncCopyDescriptor:
+  """Descriptor for async copy of multiple K/V pages from HBM."""
+
+  def __init__(
+      self,
+      pages_hbm_ref,
+      scales_pages_hbm_ref,
+      vmem_buffer,
+      scales_vmem_buffer,
+      sem,
+      page_indices,
+      page_indices_start_offset,
+      num_pages_to_load,
+      head_index,
+  ):
+    self._vmem_buffer = vmem_buffer
+    self._scales_vmem_buffer = scales_vmem_buffer
+    self._num_pages_to_load = num_pages_to_load
+    if head_index is not None:
+      self._pages_hbm_ref = pages_hbm_ref.at[head_index]
+      if scales_pages_hbm_ref is not None:
+        self._scales_pages_hbm_ref = scales_pages_hbm_ref.at[head_index]
+      else:
+        self._scales_pages_hbm_ref = None
+    else:
+      self._pages_hbm_ref = pages_hbm_ref
+      self._scales_pages_hbm_ref = scales_pages_hbm_ref
+    self._sem = sem
+    self._page_indices = page_indices
+    self._page_indices_start_offset = page_indices_start_offset
+    self._async_copies = [
+        self._make_async_copy(i) for i in range(self._num_pages_to_load)
+    ]
+    if (
+        self._scales_pages_hbm_ref is not None
+        and self._scales_vmem_buffer is not None
+    ):
+      self._async_copies += [
+          self._make_scales_async_copy(i)
+          for i in range(self._num_pages_to_load)
+      ]
+
+  def _make_async_copy(self, i):
+    page_index = self._page_indices[self._page_indices_start_offset + i]
+    return pltpu.make_async_copy(
+        self._pages_hbm_ref.at[page_index], self._vmem_buffer.at[i], self._sem
+    )
+
+  def _make_scales_async_copy(self, i):
+    page_index = self._page_indices[self._page_indices_start_offset + i]
+    return pltpu.make_async_copy(
+        self._scales_pages_hbm_ref.at[page_index],  # pytype: disable=attribute-error
+        self._scales_vmem_buffer.at[i],  # pytype: disable=attribute-error
+        self._sem,
+    )
+
+  def start(self):
+    """Starts the async copies."""
+    for async_copy in self._async_copies:
+      async_copy.start()
+
+  def _maybe_dequantize(self, x, x_scale, dtype=jnp.bfloat16):
+    if x_scale is None:
+      return x.astype(dtype)
+    return quantization_utils.from_int8(x, x_scale, dtype=dtype)
+
+  def wait_and_get_loaded(self) -> jax.Array:
+    """Wait async copies and gets the loaded buffer as a jax.Array."""
+    for async_copy in self._async_copies:
+      async_copy.wait()
+    head_dim = self._vmem_buffer.shape[-1]
+    jax_array = self._vmem_buffer[...].astype(jnp.float32)
+    if self._scales_vmem_buffer is not None:
+      scales_jax_array = self._scales_vmem_buffer[...].astype(jnp.float32)
+    else:
+      scales_jax_array = None
+    jax_array = self._maybe_dequantize(jax_array, scales_jax_array)
+    return jax_array.reshape(-1, head_dim)
+
+
+def paged_flash_attention_kernel(
+    lengths_ref,
+    page_indices_ref,
+    buffer_index_ref,
+    init_flag_ref,
+    q_ref,
+    k_pages_hbm_ref,
+    k_scales_pages_hbm_ref,
+    v_pages_hbm_ref,
+    v_scales_pages_hbm_ref,
+    o_ref,
+    m_ref,
+    l_ref,
+    k_vmem_buffer,
+    k_scales_vmem_buffer,
+    v_vmem_buffer,
+    v_scales_vmem_buffer,
+    k_sems,
+    v_sems,
+    *,
+    batch_size: int,
+    pages_per_compute_block: int,
+    pages_per_sequence: int,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    megacore_mode: str | None,
+    program_ids=(),
+):
+  """Pallas kernel for paged attention."""
+  if program_ids:
+    core_index, b, h, i = program_ids
+  else:
+    core_index, b, h, i = (
+        pl.program_id(0),
+        pl.program_id(1),
+        pl.program_id(2),
+        pl.program_id(3),
+    )
+  num_kv_heads, _, page_size, _ = k_pages_hbm_ref.shape
+  bk = page_size * pages_per_compute_block
+  num_cores = pl.num_programs(0)
+
+  b_step = num_cores if megacore_mode == "batch" else 1
+  b_start = core_index if megacore_mode == "batch" else 0
+  h_step = num_cores if megacore_mode == "kv_head" else 1
+  h_start = core_index if megacore_mode == "kv_head" else 0
+
+  h = h * h_step + h_start
+  b = b * b_step + b_start
+  length = lengths_ref[b]
+
+  def compute_block_indices(b, h, i):
+
+    def advance_b():
+      next_b = b + b_step
+
+      def advance_to_next_non_zero_length():
+        next_next_b = next_b + b_step
+        return lax.fori_loop(
+            lax.div(next_next_b, b_step),
+            lax.div(batch_size, b_step),
+            lambda _, b: jnp.where(lengths_ref[b] == 0, b + b_step, b),
+            next_next_b,
+        )
+
+      return (
+          lax.cond(
+              jnp.logical_and(
+                  next_b < batch_size,
+                  lengths_ref[lax.clamp(0, next_b, batch_size - 1)] == 0),
+              advance_to_next_non_zero_length,
+              lambda: next_b,
+          ),
+          h_start,
+          0,
+      )
+
+    def advance_h():
+      next_h = h + h_step
+      return lax.cond(next_h < num_kv_heads, lambda: (b, next_h, 0), advance_b)
+
+    return lax.cond(i * bk < lengths_ref[b], lambda: (b, h, i), advance_h)
+
+  def create_kv_async_copy_descriptors(b, h, i, buffer_index):
+    page_offset = b * pages_per_sequence + i * pages_per_compute_block
+    pages_to_load = pages_per_compute_block
+    async_copy_k = MultiPageAsyncCopyDescriptor(
+        k_pages_hbm_ref,
+        k_scales_pages_hbm_ref,
+        k_vmem_buffer.at[buffer_index],
+        k_scales_vmem_buffer.at[buffer_index]
+        if k_scales_vmem_buffer is not None
+        else None,
+        k_sems.at[buffer_index],
+        page_indices_ref,
+        page_offset,
+        pages_to_load,
+        h,
+    )
+    async_copy_v = MultiPageAsyncCopyDescriptor(
+        v_pages_hbm_ref,
+        v_scales_pages_hbm_ref,
+        v_vmem_buffer.at[buffer_index],
+        v_scales_vmem_buffer.at[buffer_index]
+        if v_scales_vmem_buffer is not None
+        else None,
+        v_sems.at[buffer_index],
+        page_indices_ref,
+        page_offset,
+        pages_to_load,
+        h,
+    )
+    return async_copy_k, async_copy_v
+
+  @pl.when(i * bk < length)
+  def flash_attention():  # pylint: disable=unused-variable
+    init_flag = init_flag_ref[0]
+    init_flag_ref[0] = 0
+    buffer_index = buffer_index_ref[0]
+    next_b, next_h, next_i = compute_block_indices(b, h, i + 1)
+
+    @pl.when(init_flag)
+    def prefetch_first_block():  # pylint: disable=unused-variable
+      async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
+          b, h, i, buffer_index
+      )
+      async_copy_k.start()
+      async_copy_v.start()
+
+    @pl.when(i == 0)
+    def init():  # pylint: disable=unused-variable
+      m_ref[...] = jnp.full_like(m_ref, -jnp.inf)
+      l_ref[...] = jnp.zeros_like(l_ref)
+      o_ref[...] = jnp.zeros_like(o_ref)
+
+    @pl.when(next_b < batch_size)
+    def prefetch_next_block():  # pylint: disable=unused-variable
+      next_buffer_index = jnp.where(buffer_index == 0, 1, 0)
+      async_copy_next_k, async_copy_next_v = create_kv_async_copy_descriptors(
+          next_b, next_h, next_i, next_buffer_index
+      )
+      async_copy_next_k.start()
+      async_copy_next_v.start()
+      buffer_index_ref[0] = next_buffer_index
+
+    async_copy_k, async_copy_v = create_kv_async_copy_descriptors(
+        b, h, i, buffer_index
+    )
+    q = q_ref[...].astype(jnp.float32)
+    k = async_copy_k.wait_and_get_loaded()
+    qk = jnp.einsum("gd,td->gt", q, k, preferred_element_type=jnp.float32)
+    if attn_logits_soft_cap is not None:
+      capped_qk = jnp.tanh(qk / attn_logits_soft_cap)
+      qk = capped_qk * attn_logits_soft_cap
+
+    mask = i * bk + jax.lax.broadcasted_iota(jnp.int32, qk.shape, 1) < length
+    qk = qk + jnp.where(mask, 0.0, mask_value)
+    m_curr = qk.max(axis=-1)
+
+    s_curr = jnp.exp(qk - m_curr[..., None])
+    m_prev, l_prev = m_ref[...], l_ref[...]
+    l_curr = jax.lax.broadcast_in_dim(s_curr.sum(axis=-1), l_prev.shape, (0,))
+    m_curr = jax.lax.broadcast_in_dim(m_curr, m_prev.shape, (0,))
+    m_next = jnp.maximum(m_prev, m_curr)
+    alpha = jnp.exp(m_prev - m_next)
+    beta = jnp.exp(m_curr - m_next)
+    l_next = alpha * l_prev + beta * l_curr
+    m_ref[...], l_ref[...] = m_next, l_next
+
+    v = async_copy_v.wait_and_get_loaded()
+    o_curr = jnp.einsum("gt,td->gd", s_curr, v)
+
+    o_ref[...] = (
+        (l_prev * alpha * o_ref[...] + beta * o_curr) / l_next
+    ).astype(o_ref.dtype)
+
+
+def paged_flash_attention_kernel_inline_seq_dim(
+    lengths_ref,
+    page_indices_ref,
+    buffer_index_ref,
+    init_flag_ref,
+    q_ref,
+    k_pages_hbm_ref,
+    k_scales_pages_hbm_ref,
+    v_pages_hbm_ref,
+    v_scales_pages_hbm_ref,
+    o_ref,
+    m_ref,
+    l_ref,
+    k_vmem_buffer,
+    k_scales_vmem_buffer,
+    v_vmem_buffer,
+    v_scales_vmem_buffer,
+    k_sems,
+    v_sems,
+    *,
+    batch_size: int,
+    pages_per_compute_block: int,
+    pages_per_sequence: int,
+    mask_value: float,
+    attn_logits_soft_cap: float | None,
+    megacore_mode: str | None,
+):
+  core_index, b, h = pl.program_id(0), pl.program_id(1), pl.program_id(2)
+
+  # Initialize the output HBM buffers to avoid accessing garbage memory inside
+  # the kernel body below.
+  m_ref[...] = jnp.full_like(m_ref, -jnp.inf)
+  l_ref[...] = jnp.zeros_like(l_ref)
+  o_ref[...] = jnp.zeros_like(o_ref)
+
+  def body(i, _):
+    paged_flash_attention_kernel(
+        lengths_ref,
+        page_indices_ref,
+        buffer_index_ref,
+        init_flag_ref,
+        q_ref,
+        k_pages_hbm_ref,
+        k_scales_pages_hbm_ref,
+        v_pages_hbm_ref,
+        v_scales_pages_hbm_ref,
+        o_ref,
+        m_ref,
+        l_ref,
+        k_vmem_buffer,
+        k_scales_vmem_buffer,
+        v_vmem_buffer,
+        v_scales_vmem_buffer,
+        k_sems,
+        v_sems,
+        batch_size=batch_size,
+        pages_per_compute_block=pages_per_compute_block,
+        pages_per_sequence=pages_per_sequence,
+        mask_value=mask_value,
+        attn_logits_soft_cap=attn_logits_soft_cap,
+        megacore_mode=megacore_mode,
+        program_ids=(core_index, b, h, i),
+    )
+    return ()
+
+  bk = pages_per_compute_block * k_pages_hbm_ref.shape[-2]
+
+  if megacore_mode == "batch":
+    num_cores = pl.num_programs(0)
+    length = lengths_ref[b * num_cores + core_index]
+  else:
+    length = lengths_ref[b]
+
+  lax.fori_loop(0, lax.div(length + bk - 1, bk), body, ())
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "pages_per_compute_block",
+        "attn_logits_soft_cap",
+        "mask_value",
+        "megacore_mode",
+        "inline_seq_dim",
+    ],
+)
+def paged_attention(
+    q: jax.Array,
+    k_pages: jax.Array | quantization_utils.QuantizedTensor,
+    v_pages: jax.Array | quantization_utils.QuantizedTensor,
+    lengths: jax.Array,
+    page_indices: jax.Array,
+    *,
+    mask_value: float = DEFAULT_MASK_VALUE,
+    attn_logits_soft_cap: float | None = None,
+    pages_per_compute_block: int,
+    megacore_mode: str | None = None,
+    inline_seq_dim: bool = True,
+) -> jax.Array:
+  """Paged grouped query attention.
+
+  Args:
+    q: A [batch_size, num_q_heads, head_dim] jax.Array.
+    k_pages: A [num_kv_heads, total_num_pages, page_size, head_dim] jax.Array.
+    v_pages: A [num_kv_heads, total_num_pages, page_size, head_dim] jax.Array.
+    lengths: A i32[batch_size] jax.Array the length of each example.
+    page_indices: A i32[batch_size, pages_per_sequence] jax.Array. Each entry
+      should be in the range of [0, total_num_pages), indicating where to locate
+      the page in `k_pages` or `v_pages`.
+    mask_value: The value used for padding in attention. By default it is a very
+      negative floating point number.
+    attn_logits_soft_cap: The value used for soft capping the attention logits.
+    pages_per_compute_block: how many pages to be processed in one flash
+      attention block in the pallas kernel.
+    megacore_mode: if set, enable megacore to parallelize the computation. Must
+      be one of ['kv_head', 'batch', None]. Caveat: set this only if megacore is
+      enabled, otherwise the kernel may hang. If you are not sure, leave it to
+      None.
+      * None: disable megacore parallelism.
+      * kv_head: megacore parallelism on KV heads; requires number of KV heads
+        divisible by 2.
+      * batch: megacore parallelism on batch dimension; requires batch divisible
+        by 2.
+    inline_seq_dim: whether to fuse kernel instances along the sequence dim into
+      one kernel.
+
+  Returns:
+    The output of attention([batch_size, num_q_heads, head_dim]).
+  """
+  if isinstance(k_pages, quantization_utils.QuantizedTensor):
+    k_pages, k_scales_pages = k_pages.weight, k_pages.scales
+    assert isinstance(k_scales_pages, jax.Array)  # For typing.
+    k_scales_pages = jnp.broadcast_to(
+        k_scales_pages, (*k_scales_pages.shape[:-1], k_pages.shape[-1])
+    )
+  else:
+    k_scales_pages = None
+  if isinstance(v_pages, quantization_utils.QuantizedTensor):
+    v_pages, v_scales_pages = v_pages.weight, v_pages.scales
+    assert isinstance(v_scales_pages, jax.Array)  # For typing.
+    v_scales_pages = jnp.broadcast_to(
+        v_scales_pages, (*v_scales_pages.shape[:-1], v_pages.shape[-1])
+    )
+  else:
+    v_scales_pages = None
+
+  batch_size, num_q_heads, head_dim = q.shape
+  num_kv_heads, _, page_size, head_dim_k = k_pages.shape
+  batch_size_paged_indices, pages_per_sequence = page_indices.shape
+
+  if k_pages.shape != v_pages.shape:
+    raise ValueError(
+        f"k_pages and v_pages must have the same shape. Got {k_pages.shape} and"
+        f" {v_pages.shape}"  # pytype: disable=attribute-error
+    )
+  if num_q_heads % num_kv_heads != 0:
+    raise ValueError(
+        "Number of Q heads must be divisible by number of KV heads. Got"
+        f" {num_q_heads} and {num_kv_heads}."
+    )
+  if head_dim_k != head_dim:
+    raise ValueError(
+        "head_dim of Q must be the same as that of K/V. Got"
+        f" {head_dim} and {head_dim_k}."
+    )
+  if pages_per_sequence % pages_per_compute_block != 0:
+    raise ValueError(
+        "pages_per_compute_block must be divisible by pages per sequence. Got"
+        f" {pages_per_compute_block} and {pages_per_sequence}."
+    )
+  if lengths.shape != (batch_size,):
+    raise ValueError("`lengths` and `q` must have the same batch size")
+  if batch_size_paged_indices != batch_size:
+    raise ValueError("`page_indices` and `q` must have the same batch size")
+  if lengths.dtype != jnp.int32:
+    raise ValueError(
+        f"The dtype of `lengths` must be int32. Got {lengths.dtype}"
+    )
+
+  # TODO(dinghua): get the actual cores per chip once there's an official API.
+  if megacore_mode == "kv_head":
+    if num_kv_heads % 2 != 0:
+      raise ValueError(
+          "number of KV heads must be even when megacore_mode is 'kv_head'"
+      )
+    num_cores = 2
+  elif megacore_mode == "batch":
+    if batch_size % 2 != 0:
+      raise ValueError("batch size must be even when megacore_mode is 'batch'")
+    num_cores = 2
+  elif megacore_mode is None:
+    num_cores = 1
+  else:
+    raise ValueError("megacore_mode must be one of ['kv_head', 'batch', None]")
+
+  num_groups = num_q_heads // num_kv_heads
+  if (num_groups) % 8 != 0:
+    # Reshape q to hint XLA to pick a <1x128> layout otherwise it will pick a
+    # <8x128> layout for a <1x128> memref inside the kernel and error out.
+    q = q.reshape(batch_size, num_q_heads, 1, head_dim)
+    if megacore_mode == "kv_head":
+      q_block_spec = pl.BlockSpec(
+          (None, num_groups, None, head_dim),
+          lambda core_index, b, h, *_: (b, h * num_cores + core_index, 0, 0),
+      )
+    elif megacore_mode == "batch":
+      q_block_spec = pl.BlockSpec(
+          (None, num_groups, None, head_dim),
+          lambda core_index, b, h, *_: (b * num_cores + core_index, h, 0, 0),
+      )
+    else:
+      q_block_spec = pl.BlockSpec(
+          (None, num_groups, None, head_dim),
+          lambda core_index, b, h, *_: (b, h, 0, 0),
+      )
+    q_dtype_for_kernel_launch = jnp.float32
+  else:
+    if megacore_mode == "kv_head":
+      q_block_spec = pl.BlockSpec(
+          (None, num_groups, head_dim),
+          lambda core_index, b, h, *_: (b, h * num_cores + core_index, 0),
+      )
+    elif megacore_mode == "batch":
+      q_block_spec = pl.BlockSpec(
+          (None, num_groups, head_dim),
+          lambda core_index, b, h, *_: (b * num_cores + core_index, h, 0),
+      )
+    else:
+      q_block_spec = pl.BlockSpec(
+          (None, num_groups, head_dim),
+          lambda core_index, b, h, *_: (b, h, 0),
+      )
+    q_dtype_for_kernel_launch = q.dtype
+
+  dimension_semantics: Sequence[Literal["parallel", "arbitrary"]]
+  if inline_seq_dim:
+    kernel = paged_flash_attention_kernel_inline_seq_dim
+    grid = (
+        num_cores,
+        batch_size // num_cores if megacore_mode == "batch" else batch_size,
+        num_kv_heads // num_cores
+        if megacore_mode == "kv_head"
+        else num_kv_heads,
+    )
+    dimension_semantics = ("parallel", "arbitrary", "arbitrary")
+  else:
+    kernel = paged_flash_attention_kernel
+    grid = (
+        num_cores,
+        batch_size // num_cores if megacore_mode == "batch" else batch_size,
+        num_kv_heads // num_cores
+        if megacore_mode == "kv_head"
+        else num_kv_heads,
+        pages_per_sequence // pages_per_compute_block,
+    )  # type: ignore
+    dimension_semantics = ("parallel", "arbitrary", "arbitrary", "arbitrary")
+
+  if k_scales_pages is not None and v_scales_pages is not None:
+    in_specs = [
+        q_block_spec,
+        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=pltpu.ANY),
+    ]
+    scratch_shapes = (
+        pltpu.VMEM(
+            (
+                2,  # For double buffering during DMA copies.
+                pages_per_compute_block,
+                page_size,
+                head_dim,
+            ),
+            k_pages.dtype,
+        ),  # k_pages buffer
+        pltpu.VMEM(
+            (
+                2,  # For double buffering during DMA copies.
+                pages_per_compute_block,
+                page_size,
+                head_dim,
+            ),
+            k_scales_pages.dtype,  # pytype: disable=attribute-error
+        ),  # k_scales_pages buffer
+        pltpu.VMEM(
+            (
+                2,  # For double buffering during DMA copies.
+                pages_per_compute_block,
+                page_size,
+                head_dim,
+            ),
+            v_pages.dtype,
+        ),  # v_pages buffer
+        pltpu.VMEM(
+            (
+                2,  # For double buffering during DMA copies.
+                pages_per_compute_block,
+                page_size,
+                head_dim,
+            ),
+            v_scales_pages.dtype,  # pytype: disable=attribute-error
+        ),  # v_scales_pages buffer
+        pltpu.SemaphoreType.DMA((2,)),
+        pltpu.SemaphoreType.DMA((2,)),
+    )
+  else:
+    in_specs = [
+        q_block_spec,
+        pl.BlockSpec(memory_space=pltpu.ANY),
+        None,  # type: ignore[list-item]
+        pl.BlockSpec(memory_space=pltpu.ANY),
+        None,  # type: ignore[list-item]
+    ]
+    scratch_shapes = (
+        pltpu.VMEM(
+            (
+                2,  # For double buffering during DMA copies.
+                pages_per_compute_block,
+                page_size,
+                head_dim,
+            ),
+            k_pages.dtype,
+        ),  # k_pages buffer
+        None,
+        pltpu.VMEM(
+            (
+                2,  # For double buffering during DMA copies.
+                pages_per_compute_block,
+                page_size,
+                head_dim,
+            ),
+            v_pages.dtype,
+        ),  # v_pages buffer
+        None,
+        pltpu.SemaphoreType.DMA((2,)),
+        pltpu.SemaphoreType.DMA((2,)),
+    )
+
+  out, _, _ = pl.pallas_call(
+      functools.partial(
+          kernel,
+          pages_per_sequence=pages_per_sequence,
+          batch_size=batch_size,
+          pages_per_compute_block=pages_per_compute_block,
+          mask_value=mask_value,
+          attn_logits_soft_cap=attn_logits_soft_cap,
+          megacore_mode=megacore_mode,
+      ),
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          # There are 4 scalars prefetched per kernel call: `lengths_ref`,
+          # `page_indices_ref`, `buffer_index_ref`, `init_flag_ref`
+          num_scalar_prefetch=4,
+          in_specs=in_specs,
+          out_specs=[
+              q_block_spec,
+              q_block_spec,
+              q_block_spec,
+          ],
+          grid=grid,
+          scratch_shapes=scratch_shapes,
+      ),
+      compiler_params=pltpu.CompilerParams(
+          dimension_semantics=dimension_semantics
+      ),
+      out_shape=[
+          jax.ShapeDtypeStruct(q.shape, q_dtype_for_kernel_launch),
+          jax.ShapeDtypeStruct((*q.shape[:-1], 1), jnp.float32),
+          jax.ShapeDtypeStruct((*q.shape[:-1], 1), jnp.float32),
+      ],
+  )(
+      lengths,
+      page_indices.reshape(-1),
+      jnp.zeros((1,), jnp.int32),  # buffer index
+      jnp.ones((1,), jnp.int32),  # init flag
+      q.astype(q_dtype_for_kernel_launch),
+      k_pages,
+      k_scales_pages,
+      v_pages,
+      v_scales_pages,
+  )
+  return out.reshape(batch_size, num_q_heads, head_dim).astype(q.dtype)
+
+
+CONFIG = {
+    'name': 'pallas_paged_attention_llama70b',
+    'model': 'Llama-3.1-70B',
+    'operator': 'pallas_paged_attention',
+    'batch': 64,
+    'num_q_heads': 64,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+    'page_size': 16,
+    'pages_per_seq': 256,
+    'atol': 1e-2,
+    'rtol': 2e-2,
+}
+
+# Tuned by autotune_block_sizes.py. Re-run to update.
+TUNED_PARAMS = {'pages_per_compute_block': 128}
+
+
+def get_flops():
+    B = CONFIG['batch']
+    H_q = CONFIG['num_q_heads']
+    D = CONFIG['head_dim']
+    seq_len = CONFIG['pages_per_seq'] * CONFIG['page_size']
+    return B * H_q * (4 * seq_len * D)
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2, k3 = jax.random.split(key, 3)
+    B = CONFIG['batch']
+    H_q = CONFIG['num_q_heads']
+    H_kv = CONFIG['num_kv_heads']
+    D = CONFIG['head_dim']
+    page_size = CONFIG['page_size']
+    pages_per_seq = CONFIG['pages_per_seq']
+    total_num_pages = B * pages_per_seq
+    q = jax.random.normal(k1, (B, H_q, D), dtype=dtype)
+    k_pages = jax.random.normal(k2, (H_kv, total_num_pages, page_size, D), dtype=dtype)
+    v_pages = jax.random.normal(k3, (H_kv, total_num_pages, page_size, D), dtype=dtype)
+    seq_len = pages_per_seq * page_size
+    lengths = jnp.full((B,), seq_len, dtype=jnp.int32)
+    page_indices = jnp.arange(total_num_pages, dtype=jnp.int32).reshape(B, pages_per_seq)
+    return q, k_pages, v_pages, lengths, page_indices
+
+
+def workload(q, k_pages, v_pages, lengths, page_indices):
+    return paged_attention(
+        q, k_pages, v_pages, lengths, page_indices,
+        pages_per_compute_block=TUNED_PARAMS['pages_per_compute_block'],
+    )
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator', 'atol', 'rtol')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/7p_Ragged_Paged_Attention/baseline.py
+++ b/JAXBench/benchmark/7p_Ragged_Paged_Attention/baseline.py
@@ -1,0 +1,155 @@
+"""Ragged Paged Attention — Llama-3.1-70B mixed prefill+decode.
+
+Reference implementation with data-dependent slicing on per-sequence boundaries.
+Processes each sequence independently with variable-length queries and paged KV cache.
+From JAX experimental pallas ops (ref_ragged_paged_attention).
+
+Not jit-compatible: uses data-dependent slicing.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+
+DEFAULT_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.dtype("float32")).max)
+
+CONFIG = {
+    'name': 'ragged_paged_attention_llama70b',
+    'model': 'Llama-3.1-70B',
+    'operator': 'ragged_paged_attention',
+    'max_num_batched_tokens': 4096,
+    'max_num_seqs': 64,
+    'num_q_heads': 64,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+    'page_size': 16,
+    'pages_per_seq': 256,
+}
+
+_skip_jit = True
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    max_tokens = CONFIG['max_num_batched_tokens']
+    max_seqs = CONFIG['max_num_seqs']
+    H_q = CONFIG['num_q_heads']
+    H_kv = CONFIG['num_kv_heads']
+    D = CONFIG['head_dim']
+    page_size = CONFIG['page_size']
+    pages_per_seq = CONFIG['pages_per_seq']
+    num_combined_kv_heads = 2 * H_kv
+    total_num_pages = max_seqs * pages_per_seq
+    q = jax.random.normal(k1, (max_tokens, H_q, D), dtype=dtype)
+    kv_pages = jax.random.normal(
+        k2, (total_num_pages, page_size, num_combined_kv_heads, D), dtype=dtype
+    )
+    tokens_per_seq = max_tokens // max_seqs
+    kv_len_per_seq = pages_per_seq * page_size
+    kv_lens = jnp.full((max_seqs,), kv_len_per_seq, dtype=jnp.int32)
+    page_indices = jnp.arange(total_num_pages, dtype=jnp.int32).reshape(
+        max_seqs, pages_per_seq
+    )
+    cu_q_lens = jnp.arange(max_seqs + 1, dtype=jnp.int32) * tokens_per_seq
+    num_seqs = jnp.array([max_seqs], dtype=jnp.int32)
+    return q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs
+
+
+def workload(queries, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs):
+    """Reference ragged paged attention from upstream JAX.
+
+    Processes each sequence independently with data-dependent slicing.
+    Must be run eagerly (not under jax.jit).
+    """
+    sm_scale = 1.0 / math.sqrt(CONFIG['head_dim'])
+    mask_value = DEFAULT_MASK_VALUE
+    _, _, num_combined_kv_heads, head_dim = kv_pages.shape
+    num_kv_heads = num_combined_kv_heads // 2
+    num_q_heads = queries.shape[1]
+    num_query_per_kv = num_q_heads // num_kv_heads
+
+    outputs = []
+    for i in range(num_seqs[0]):
+        q_start = cu_q_lens[i]
+        q_end = cu_q_lens[i + 1]
+        q_len = q_end - q_start
+        kv_len = kv_lens[i]
+        indices = page_indices[i]
+
+        q = queries[q_start:q_end]
+        k = kv_pages[indices, :, 0::2, :].reshape(-1, num_kv_heads, head_dim)[:kv_len]
+        v = kv_pages[indices, :, 1::2, :].reshape(-1, num_kv_heads, head_dim)[:kv_len]
+
+        k = jnp.repeat(k, num_query_per_kv, axis=1)
+        v = jnp.repeat(v, num_query_per_kv, axis=1)
+
+        attn = jnp.einsum(
+            "qhd,khd->hqk", q, k, preferred_element_type=jnp.float32
+        )
+        attn *= sm_scale
+
+        q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(
+            jnp.int32, attn.shape, 1
+        )
+        kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
+        mask = q_span < kv_span
+        attn += jnp.where(mask, mask_value, 0.0)
+
+        attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
+        out = jnp.einsum("hqk,khd->qhd", attn, v).astype(queries.dtype)
+        outputs.append(out)
+
+    return jnp.concatenate(outputs, axis=0)
+
+
+def get_flops():
+    """Ragged paged attention FLOPs: per seq QK^T + AV matmuls."""
+    max_seqs = CONFIG['max_num_seqs']
+    H_q = CONFIG['num_q_heads']
+    D = CONFIG['head_dim']
+    tokens_per_seq = CONFIG['max_num_batched_tokens'] // max_seqs
+    kv_len = CONFIG['pages_per_seq'] * CONFIG['page_size']
+    return max_seqs * H_q * (4 * tokens_per_seq * kv_len * D)
+
+
+def benchmark(num_warmup=2, num_iters=10):
+    """Benchmark eagerly (no JIT — data-dependent control flow)."""
+    import time
+    inputs = create_inputs()
+    # Warmup
+    for _ in range(num_warmup):
+        out = workload(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = workload(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    max_seqs = CONFIG['max_num_seqs']
+    H_q = CONFIG['num_q_heads']
+    D = CONFIG['head_dim']
+    tokens_per_seq = CONFIG['max_num_batched_tokens'] // max_seqs
+    kv_len = CONFIG['pages_per_seq'] * CONFIG['page_size']
+    flops = max_seqs * H_q * (4 * tokens_per_seq * kv_len * D)
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 4),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/7p_Ragged_Paged_Attention/optimized.py
+++ b/JAXBench/benchmark/7p_Ragged_Paged_Attention/optimized.py
@@ -1,0 +1,1007 @@
+# Copyright 2025 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TPU-Friendly Ragged Paged Attention kernel.
+
+This kernel offers a highly optimized implementation of ragged paged attention,
+specifically designed for TPU and compatible with a wide range of model
+specifications. It supports mixed prefill and decoding, enhancing throughput
+during inference.
+"""
+import functools
+import jax
+from jax import lax
+from jax._src import dtypes
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas.ops.tpu.ragged_paged_attention.tuned_block_sizes import get_tuned_block_sizes
+import jax.numpy as jnp
+
+
+DEFAULT_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.dtype("float32")).max)
+
+
+class MultiPageAsyncCopyDescriptor:
+  """Descriptor for async copy of multiple K/V pages from HBM."""
+
+  def __init__(
+      self,
+      pages_hbm_ref,  # [total_num_pages, page_size, num_combined_kv_heads_per_blk, head_dim]
+      vmem_buf,  # [num_kv_pages_per_blk, page_size, num_combined_kv_heads_per_blk, head_dim]
+      sem,
+      page_indices_ref,  # i32[max_num_seqs, pages_per_seq]
+      metadata,  # [seq_idx, start_page_idx, end_page_idx]
+  ):
+    self._vmem_buf = vmem_buf
+    seq_id, start_page_idx, end_page_idx = metadata
+    self._async_copies = []
+    # TODO(jevinjiang): Only fetch dynamic shape in need! This will insert
+    # a bunch of if-ops. Check the performance when we have benchmarking setup.
+    for i in range(vmem_buf.shape[0]):
+      page_idx = start_page_idx + i
+      page_idx = jax.lax.select(page_idx < end_page_idx, page_idx, 0)
+      self._async_copies.append(
+          pltpu.make_async_copy(
+              pages_hbm_ref.at[page_indices_ref[seq_id, page_idx]],
+              vmem_buf.at[i],
+              sem,
+          )
+      )
+
+  def start(self):
+    """Starts the async copies."""
+    for async_copy in self._async_copies:
+      async_copy.start()
+
+  def wait(self):
+    for async_copy in self._async_copies:
+      async_copy.wait()
+    return self._vmem_buf
+
+
+def ref_ragged_paged_attention(
+    queries: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_lens: jax.Array,  # i32[max_num_seqs]
+    page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
+    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
+    num_seqs: jax.Array,  # i32[1],
+    *,
+    sm_scale: float = 1.0,
+    sliding_window: int | None = None,
+    soft_cap: float | None = None,
+    mask_value: float | None = DEFAULT_MASK_VALUE,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+):
+  static_validate_inputs(
+      queries,
+      kv_pages,
+      kv_lens,
+      page_indices,
+      cu_q_lens,
+      num_seqs,
+      sm_scale=sm_scale,
+      k_scale=k_scale,
+      v_scale=v_scale,
+      sliding_window=sliding_window,
+      soft_cap=soft_cap,
+      mask_value=mask_value,
+  )
+  if mask_value is None:
+    mask_value = DEFAULT_MASK_VALUE
+  _, _, num_combined_kv_heads, head_dim = kv_pages.shape
+  assert num_combined_kv_heads % 2 == 0
+  num_kv_heads = num_combined_kv_heads // 2
+  num_q_heads = queries.shape[1]
+  assert num_q_heads % num_kv_heads == 0
+  num_query_per_kv = num_q_heads // num_kv_heads
+  outputs = []
+  for i in range(num_seqs[0]):
+    q_start = cu_q_lens[i]
+    q_end = cu_q_lens[i + 1]
+    q_len = q_end - q_start
+    kv_len = kv_lens[i]
+    indices = page_indices[i]
+    q = queries[q_start:q_end]
+    k = kv_pages[indices, :, 0::2, :].reshape(-1, num_kv_heads, head_dim)[
+        :kv_len
+    ]
+    v = kv_pages[indices, :, 1::2, :].reshape(-1, num_kv_heads, head_dim)[
+        :kv_len
+    ]
+    if k_scale is not None:
+      k = k.astype(jnp.float32) * k_scale
+      k = k.astype(q.dtype)
+    if v_scale is not None:
+      v = v.astype(jnp.float32) * v_scale
+      v = v.astype(q.dtype)
+    k = jnp.repeat(k, num_query_per_kv, axis=1)
+    v = jnp.repeat(v, num_query_per_kv, axis=1)
+    attn = jnp.einsum("qhd,khd->hqk", q, k, preferred_element_type=jnp.float32)
+    attn *= sm_scale
+    q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(
+        jnp.int32, attn.shape, 1
+    )
+    kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
+    mask = q_span < kv_span
+    if sliding_window is not None:
+      mask = jnp.logical_or(mask, q_span - sliding_window >= kv_span)
+    if soft_cap is not None:
+      attn = soft_cap * jnp.tanh(attn / soft_cap)
+    attn += jnp.where(mask, mask_value, 0.0)
+    attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
+    out = jnp.einsum("hqk,khd->qhd", attn, v).astype(queries.dtype)
+    outputs.append(out)
+
+  return jnp.concatenate(outputs, axis=0)
+
+
+# Expect to run these checks during runtime.
+def dynamic_validate_inputs(
+    q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_lens: jax.Array,  # i32[max_num_seqs]
+    page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
+    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
+    num_seqs: jax.Array,  # i32[1]
+    *,
+    # These inputs are optional. If not specified, we will not validate them.
+    sm_scale: float | None = None,
+    sliding_window: int | None = None,
+    soft_cap: float | None = None,
+    mask_value: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+    # Kernel tuning params.
+    num_kv_pages_per_block: int | None = None,
+    num_queries_per_block: int | None = None,
+    vmem_limit_bytes: int | None = None,
+):
+  static_validate_inputs(
+      q,
+      kv_pages,
+      kv_lens,
+      page_indices,
+      cu_q_lens,
+      num_seqs,
+      sm_scale=sm_scale,
+      sliding_window=sliding_window,
+      soft_cap=soft_cap,
+      mask_value=mask_value,
+      k_scale=k_scale,
+      v_scale=v_scale,
+      num_kv_pages_per_block=num_kv_pages_per_block,
+      num_queries_per_block=num_queries_per_block,
+      vmem_limit_bytes=vmem_limit_bytes,
+  )
+  max_num_batched_tokens = q.shape[0]
+  page_size = kv_pages.shape[1]
+  max_num_seqs, pages_per_seq = page_indices.shape
+  if num_seqs[0] > max_num_seqs:
+    raise ValueError(f"{num_seqs[0]=} must be less or equal to {max_num_seqs=}")
+  max_kv_len = jnp.max(kv_lens)
+  min_pages_per_seq = pl.cdiv(max_kv_len, page_size)
+  if pages_per_seq < min_pages_per_seq:
+    raise ValueError(
+        f"{pages_per_seq=} must be greater or equal to"
+        f" {min_pages_per_seq=} given {max_kv_len=} and {page_size=}."
+    )
+  if cu_q_lens[num_seqs[0]] > max_num_batched_tokens:
+    raise ValueError(
+        f"Total q tokens {cu_q_lens[num_seqs[0]]} must be less or equal to"
+        f" {max_num_batched_tokens=}."
+    )
+  for i in range(num_seqs[0]):
+    q_len = cu_q_lens[i + 1] - cu_q_lens[i]
+    kv_len = kv_lens[i]
+    if q_len > kv_len:
+      raise ValueError(
+          f"{q_len=} must be less or equal to {kv_len=} at sequence {i}."
+      )
+
+
+# Expect to run these checks during compile time.
+def static_validate_inputs(
+    q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_lens: jax.Array,  # i32[max_num_seqs]
+    page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
+    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
+    num_seqs: jax.Array,  # i32[1]
+    *,
+    # These inputs are optional. If not specified, we will not validate them.
+    sm_scale: float | None = None,
+    sliding_window: int | None = None,
+    soft_cap: float | None = None,
+    mask_value: float | None = None,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+    # Kernel tuning params.
+    num_kv_pages_per_block: int | None = None,
+    num_queries_per_block: int | None = None,
+    vmem_limit_bytes: int | None = None,
+):
+  _, num_q_heads, head_dim = q.shape
+  _, _, num_combined_kv_heads, head_dim_k = kv_pages.shape
+  assert num_combined_kv_heads % 2 == 0
+  assert isinstance(k_scale, float) or k_scale is None
+  assert isinstance(v_scale, float) or v_scale is None
+  num_kv_heads = num_combined_kv_heads // 2
+  max_num_seqs, pages_per_seq = page_indices.shape
+  if num_seqs.shape != (1,):
+    raise ValueError(f"{num_seqs.shape=} must be (1,)")
+  if head_dim_k != head_dim:
+    raise ValueError(
+        f"Q head_dim {head_dim} must be the same as that of K/V {head_dim_k}."
+    )
+  if kv_lens.shape != (max_num_seqs,):
+    raise ValueError(
+        f"Expected {kv_lens.shape=} to be ({max_num_seqs},) where"
+        " `max_num_seqs` is `page_indices.shape[0]`."
+    )
+  if cu_q_lens.shape != (max_num_seqs + 1,):
+    raise ValueError(
+        f"Expected {cu_q_lens.shape=} to be ({max_num_seqs + 1},)  where"
+        " `max_num_seqs` is `page_indices.shape[0]`."
+    )
+  if (
+      kv_lens.dtype != jnp.int32
+      or page_indices.dtype != jnp.int32
+      or cu_q_lens.dtype != jnp.int32
+  ):
+    raise ValueError(
+        "The dtype of `kv_lens`, `page_indices`, and `cu_q_lens` must be"
+        f" int32. Got {kv_lens.dtype=}, {page_indices.dtype=},"
+        f" {cu_q_lens.dtype=}."
+    )
+  if num_q_heads % num_kv_heads != 0:
+    raise ValueError(f"{num_q_heads=} must be divisible by {num_kv_heads=}")
+  if sliding_window is not None and sliding_window <= 0:
+    raise ValueError(f"{sliding_window=} must be positive.")
+  if soft_cap is not None and soft_cap == 0.0:
+    raise ValueError(f"{soft_cap=} must not be 0.0.")
+  if (
+      num_kv_pages_per_block is not None
+      and not 0 < num_kv_pages_per_block <= pages_per_seq
+  ):
+    raise ValueError(
+        f"{num_kv_pages_per_block=} must be in range (0, {pages_per_seq}]."
+    )
+  if num_queries_per_block is not None and num_queries_per_block <= 0:
+    raise ValueError(f"{num_queries_per_block=} must be positive.")
+  if vmem_limit_bytes is not None and vmem_limit_bytes <= 0:
+    raise ValueError(f"{vmem_limit_bytes=} must be positive.")
+  del sm_scale  # No constraints on sm_scale.
+  del mask_value  # No consstraints on mask_value.
+
+
+def ragged_paged_attention_kernel(
+    # Prefetch
+    kv_lens_ref,  # [max_num_seqs]
+    page_indices_ref,  # [max_num_seqs, pages_per_seq]
+    cu_q_lens_ref,  # [max_num_seqs + 1]
+    seq_buf_idx_ref,
+    # TODO(jevinjiang): if OOM in SMEM, consider pack to other scalar refs.
+    num_seqs_ref,
+    # Input
+    q_ref,  # [num_q_per_blk, num_q_heads_per_blk, head_dim]
+    kv_pages_hbm_ref,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    # Output
+    o_ref,  # [num_q_per_blk, num_q_heads_per_blk, head_dim]
+    # Scratch
+    kv_bufs,  # [2, num_kv_pages_per_blk, page_size, num_combined_kv_heads_per_blk, head_dim]
+    sems,  # [2, 2]
+    l_ref,  # [num_kv_heads_per_blk, num_q_per_blk * num_q_heads_per_kv_head, 128]
+    m_ref,  # [num_kv_heads_per_blk, num_q_per_blk * num_q_heads_per_kv_head, 128]
+    acc_ref,  # [num_q_per_blk, num_q_heads_per_blk, head_dim]
+    *,
+    sm_scale: float,
+    sliding_window: int | None = None,
+    soft_cap: float | None = None,
+    mask_value: float | None = DEFAULT_MASK_VALUE,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+):
+  if mask_value is None:
+    mask_value = DEFAULT_MASK_VALUE
+  num_q_per_blk, num_q_heads_per_blk, head_dim = q_ref.shape
+  pages_per_seq = page_indices_ref.shape[-1]
+  num_seqs = num_seqs_ref[0]
+  _, num_kv_pages_per_blk, page_size, num_combined_kv_heads_per_blk, _ = (
+      kv_bufs.shape
+  )
+  num_kv_heads_per_blk = num_combined_kv_heads_per_blk // 2
+  num_kv_per_blk = num_kv_pages_per_blk * page_size
+  num_q_heads_per_kv_head = num_q_heads_per_blk // num_kv_heads_per_blk
+  heads_blk_idx, q_blk_idx = (
+      pl.program_id(0),
+      pl.program_id(1),
+  )
+  num_heads_blks = pl.num_programs(0)
+  init_seq_idx = seq_buf_idx_ref[0]
+  init_buf_idx = seq_buf_idx_ref[1]
+  q_len_start = q_blk_idx * num_q_per_blk
+  q_len_end = q_len_start + num_q_per_blk
+
+  def create_kv_async_copy_descriptors(
+      heads_blk_idx, seq_idx, kv_blk_idx, buf_idx
+  ):
+    start_kv_page_idx = kv_blk_idx * num_kv_pages_per_blk
+    end_kv_page_idx = jnp.minimum(
+        pages_per_seq, pl.cdiv(kv_lens_ref[seq_idx], page_size)
+    )
+    metadata = (seq_idx, start_kv_page_idx, end_kv_page_idx)
+    heads_start = heads_blk_idx * num_combined_kv_heads_per_blk
+    async_copy_kv = MultiPageAsyncCopyDescriptor(
+        kv_pages_hbm_ref.at[
+            :, :, pl.ds(heads_start, num_combined_kv_heads_per_blk), :
+        ],
+        kv_bufs.at[buf_idx],
+        sems.at[buf_idx],
+        page_indices_ref,
+        metadata,
+    )
+    return async_copy_kv
+
+  # TODO(jevinjiang): Add these to Mosaic:
+  # 1. Support arbitrary strided load/store for int4 and int8 dtype.
+  # 2. Support arbitrary strided load/store for any last dimension.
+  def strided_load_kv(ref, start, step):
+    packing = get_dtype_packing(ref.dtype)
+    if packing == 1:
+      return [ref[start::step, :]], [ref[start + 1 :: step, :]]
+    assert packing in (2, 4, 8)
+    assert step % packing == 0
+    k_list, v_list = [], []
+    b_start = start // packing
+    b_step = step // packing
+    b_ref = ref.bitcast(jnp.uint32)
+    b = b_ref[b_start::b_step, :]
+
+    # TODO(chengjiyao): use the general strided loading logic for bf16 after
+    # fixing the issue in mosaic's infer vector layout pass
+    if ref.dtype == jnp.bfloat16:
+      bk = b << 16
+      bv = b & jnp.uint32(0xFFFF0000)
+      k = pltpu.bitcast(bk, jnp.float32).astype(jnp.bfloat16)
+      v = pltpu.bitcast(bv, jnp.float32).astype(jnp.bfloat16)
+      k_list.append(k)
+      v_list.append(v)
+    else:
+      bitwidth = 32 // packing
+      bitcast_dst_dtype = jnp.dtype(f"uint{bitwidth}")
+      for i in range(0, packing, 2):
+        bk = b >> (i * bitwidth)
+        k = pltpu.bitcast(bk.astype(bitcast_dst_dtype), ref.dtype)
+        k_list.append(k)
+        bv = b >> ((i + 1) * bitwidth)
+        v = pltpu.bitcast(bv.astype(bitcast_dst_dtype), ref.dtype)
+        v_list.append(v)
+
+    return k_list, v_list
+
+  def fold_on_2nd_minor(vec):
+    assert vec.dtype == jnp.bfloat16 or vec.dtype == jnp.float32
+    assert len(vec.shape) >= 2
+    last_dim = vec.shape[-1]
+    packing = get_dtype_packing(vec.dtype)
+    if vec.shape[-2] % packing != 0:
+      vec = vec.astype(jnp.float32)
+    return vec.reshape(-1, last_dim)
+
+  @pl.when(heads_blk_idx + q_blk_idx == 0)
+  def prefetch_first_kv_blk():
+    async_copy_kv = create_kv_async_copy_descriptors(
+        heads_blk_idx, init_seq_idx, 0, init_buf_idx
+    )
+    async_copy_kv.start()
+
+  def is_cur_q_blk_needed(q_states):
+    done, cur_seq_idx, _ = q_states
+    should_run = jnp.logical_and(q_len_start < cu_q_lens_ref[num_seqs],
+                                 cur_seq_idx < num_seqs)
+    return jnp.logical_and(done == 0, should_run)
+
+  def compute_with_cur_q_blk(q_states):
+    done, cur_seq_idx, cur_buf_idx = q_states
+    q_start = cu_q_lens_ref[cur_seq_idx]
+    q_end = cu_q_lens_ref[cur_seq_idx + 1]
+    q_len = q_end - q_start
+    kv_len = kv_lens_ref[cur_seq_idx]
+
+    def get_next_prefetch_ids(
+        heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
+    ):
+      next_kv_blk_idx = kv_blk_idx + 1
+      is_last_kv_blk = next_kv_blk_idx * num_kv_per_blk >= kv_len
+      next_kv_blk_idx = lax.select(
+          is_last_kv_blk,
+          0,
+          next_kv_blk_idx,
+      )
+      is_cur_seq_end_in_cur_q_blk = q_end <= q_len_end
+      next_seq_idx = lax.select(
+          is_last_kv_blk,
+          lax.select(is_cur_seq_end_in_cur_q_blk, cur_seq_idx + 1, cur_seq_idx),
+          cur_seq_idx,
+      )
+      is_last_seq = next_seq_idx == num_seqs
+      next_seq_idx = lax.select(
+          is_last_seq,
+          0,
+          next_seq_idx,
+      )
+      next_heads_blk_idx = lax.select(
+          is_last_seq,
+          heads_blk_idx + 1,
+          heads_blk_idx,
+      )
+      next_buf_idx = lax.select(cur_buf_idx == 0, 1, 0)
+      return next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx
+
+    def flash_attention(
+        q,  # [num_q_per_blk * num_q_heads_per_kv_head, head_dim]
+        k,  # [num_kv_per_blk, head_dim]
+        v,  # [num_kv_per_blk, head_dim]
+        head_l_ref,  # [num_q_per_blk * num_q_heads_per_kv_head, 128]
+        head_m_ref,  # [num_q_per_blk * num_q_heads_per_kv_head, 128]
+        head_acc_ref,  # [num_q_per_blk, num_q_heads_per_kv_head, head_dim]
+        *,
+        kv_blk_idx,
+    ):
+      assert q.shape == (
+          num_q_per_blk * num_q_heads_per_kv_head,
+          head_dim,
+      )
+      assert (
+          k.shape
+          == v.shape
+          == (
+              num_kv_per_blk,
+              head_dim,
+          )
+      )
+      assert k.dtype == v.dtype
+      assert (
+          head_m_ref.shape
+          == head_l_ref.shape
+          == (
+              num_q_per_blk * num_q_heads_per_kv_head,
+              128,
+          )
+      )
+      assert head_acc_ref.shape == (
+          num_q_per_blk,
+          num_q_heads_per_kv_head,
+          head_dim,
+      )
+      kv_len_start = kv_blk_idx * num_kv_per_blk
+
+      def masked_store(ref, val, start, end, group=1):
+        iota = lax.broadcasted_iota(jnp.int32, ref.shape, 0) // group
+        pltpu.store(ref, val, mask=jnp.logical_and(iota >= start, iota < end))
+
+      def load_with_init(ref, init_val):
+        return jnp.where(
+            kv_blk_idx == 0, jnp.full_like(ref, init_val), ref[...]
+        )
+
+      # kv lens will be contracting dim, we should mask out the NaNs.
+      kv_mask = (
+          lax.broadcasted_iota(jnp.int32, k.shape, 0) < kv_len - kv_len_start
+      )
+      k = jnp.where(kv_mask, k.astype(jnp.float32), 0).astype(k.dtype)
+      v = jnp.where(kv_mask, v.astype(jnp.float32), 0).astype(v.dtype)
+
+      qk = (
+          jnp.einsum("nd,md->nm", q, k, preferred_element_type=jnp.float32)
+          * sm_scale
+      )
+      store_start = jnp.maximum(q_start - q_len_start, 0)
+      store_end = jnp.minimum(q_end - q_len_start, num_q_per_blk)
+
+      row_ids = (
+          (kv_len - q_len)
+          + q_len_start
+          - q_start
+          + jax.lax.broadcasted_iota(
+              jnp.int32,
+              (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
+              0,
+          )
+          // num_q_heads_per_kv_head
+      )
+      col_ids = kv_len_start + jax.lax.broadcasted_iota(
+          jnp.int32,
+          (num_q_per_blk * num_q_heads_per_kv_head, num_kv_per_blk),
+          1,
+      )
+      causal_mask = row_ids < col_ids
+      if sliding_window is not None:
+        causal_mask = jnp.logical_or(causal_mask,
+                                     row_ids - sliding_window >= col_ids)
+      if soft_cap is not None:
+        qk = soft_cap * jnp.tanh(qk / soft_cap)
+      qk += jnp.where(causal_mask, mask_value, 0.0)
+      m_curr = jnp.max(qk, axis=1, keepdims=True)
+      s_curr = jnp.exp(qk - m_curr)
+      qkv = jnp.dot(s_curr, v, preferred_element_type=jnp.float32)
+      lm_store_shape = head_m_ref.shape
+      m_curr = jnp.broadcast_to(m_curr, lm_store_shape)
+      l_curr = jnp.broadcast_to(
+          s_curr.sum(axis=1, keepdims=True), lm_store_shape
+      )
+      m_prev = load_with_init(head_m_ref, -jnp.inf)
+      l_prev = load_with_init(head_l_ref, 0.0)
+      m_next = jnp.maximum(m_prev, m_curr)
+      masked_store(
+          head_m_ref, m_next, store_start, store_end, num_q_heads_per_kv_head
+      )
+      alpha = jnp.exp(m_prev - m_next)
+      beta = jnp.exp(m_curr - m_next)
+      l_alpha = alpha * l_prev
+      l_next = l_alpha + beta * l_curr
+      l_next_safe = jnp.where(l_next == 0.0, 1.0, l_next)
+      masked_store(
+          head_l_ref,
+          l_next_safe,
+          store_start,
+          store_end,
+          num_q_heads_per_kv_head,
+      )
+
+      def broadcast_to_shape(arr, shape):
+        if arr.shape == shape:
+          return arr
+        assert len(arr.shape) == len(shape)
+        assert arr.shape[0] == shape[0]
+        assert shape[1] % arr.shape[1] == 0
+        # no-op concatenation.
+        return jnp.concatenate(
+            [arr for _ in range(shape[1] // arr.shape[1])], axis=1
+        )
+
+      o_curr = load_with_init(head_acc_ref, 0.0).reshape(-1, head_dim)
+      l_alpha = broadcast_to_shape(l_alpha, qkv.shape)
+      beta = broadcast_to_shape(beta, qkv.shape)
+      l_next_safe = broadcast_to_shape(l_next_safe, qkv.shape)
+      out = lax.div(
+          l_alpha * o_curr + beta * qkv,
+          l_next_safe,
+      )
+      masked_store(
+          head_acc_ref,
+          out.reshape(head_acc_ref.shape),
+          store_start,
+          store_end,
+      )
+
+    def is_valid_kv_blk_in_cur_seq(kv_states):
+      kv_blk_idx, _ = kv_states
+      return kv_blk_idx * num_kv_per_blk < kv_len
+
+    def compute_with_kv_blk_in_cur_seq(kv_states):
+      kv_blk_idx, cur_buf_idx = kv_states
+      next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx = (
+          get_next_prefetch_ids(
+              heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
+          )
+      )
+
+      @pl.when(next_heads_blk_idx < num_heads_blks)
+      def prefetch_next_kv_blk():
+        # TODO(jevinjiang): reuse the same buffer if it is already prefetched!
+        # TODO(jevinjiang): only fetch effective dynamic size to hold kv_len and
+        # DMA to fixed size buffer!
+        next_async_copy_kv = create_kv_async_copy_descriptors(
+            next_heads_blk_idx, next_seq_idx, next_kv_blk_idx, next_buf_idx
+        )
+        next_async_copy_kv.start()
+
+      cur_async_copy_kv = create_kv_async_copy_descriptors(
+          heads_blk_idx, cur_seq_idx, kv_blk_idx, cur_buf_idx
+      )
+      kv_ref = cur_async_copy_kv.wait().reshape(
+          num_kv_pages_per_blk * page_size * num_combined_kv_heads_per_blk,
+          head_dim,
+      )
+      kv_packing = get_dtype_packing(kv_ref.dtype)
+      # NOTE: kv_packing is divided by 2 because k and v are packed together.
+      kv_load_step = max(1, kv_packing // 2)
+      for kv_head_chunk_idx in range(0, num_kv_heads_per_blk, kv_load_step):
+        k_list, v_list = strided_load_kv(
+            kv_ref, kv_head_chunk_idx * 2, num_combined_kv_heads_per_blk
+        )
+        for step_idx in range(kv_load_step):
+          k = k_list[step_idx]
+          v = v_list[step_idx]
+          if k_scale is not None:
+            # NOTE: Conversion between arbitrary data types is not supported.
+            # That's why it is converted to float32 first.
+            k = k.astype(jnp.float32) * k_scale
+            k = k.astype(q_ref.dtype)
+          if v_scale is not None:
+            v = v.astype(jnp.float32) * v_scale
+            v = v.astype(q_ref.dtype)
+          kv_head_idx = kv_head_chunk_idx + step_idx
+          q_head_idx = kv_head_idx * num_q_heads_per_kv_head
+          # TODO(jevinjiang): extra handling for packed type that can start at
+          # unaligned position!
+          q = fold_on_2nd_minor(
+              q_ref[:, q_head_idx : q_head_idx + num_q_heads_per_kv_head, :]
+          )
+          flash_attention(
+              q,
+              k,
+              v,
+              l_ref.at[kv_head_idx],
+              m_ref.at[kv_head_idx],
+              acc_ref.at[
+                  :, q_head_idx : q_head_idx + num_q_heads_per_kv_head, :
+              ],
+              kv_blk_idx=kv_blk_idx,
+          )
+      return kv_blk_idx + 1, next_buf_idx
+
+    _, next_buf_idx = lax.while_loop(
+        is_valid_kv_blk_in_cur_seq,
+        compute_with_kv_blk_in_cur_seq,
+        (0, cur_buf_idx),  # (kv_blk_idx, buf_idx)
+    )
+    next_seq_idx = lax.select(q_end <= q_len_end, cur_seq_idx + 1, cur_seq_idx)
+    done = lax.select(q_end < q_len_end, done, 1)
+    return done, next_seq_idx, next_buf_idx
+
+  _, seq_idx, buf_idx = lax.while_loop(
+      is_cur_q_blk_needed,
+      compute_with_cur_q_blk,
+      (0, init_seq_idx, init_buf_idx),  # (done, seq_idx, buf_idx)
+  )
+  # Reset seq_idx for next kv_heads_blk if run out of seqs!
+  seq_buf_idx_ref[0] = lax.select(seq_idx < num_seqs, seq_idx, 0)
+  seq_buf_idx_ref[1] = buf_idx
+  o_ref[...] = acc_ref[...].astype(q_ref.dtype)
+
+
+
+def get_dtype_packing(dtype):
+  bits = dtypes.itemsize_bits(dtype)
+  return 32 // bits
+
+
+def get_min_heads_per_blk(
+    num_q_heads, num_combined_kv_heads, q_dtype, kv_dtype
+):
+  q_packing = get_dtype_packing(q_dtype)
+  kv_packing = get_dtype_packing(kv_dtype)
+
+  def can_be_xla_fully_tiled(x, packing):
+    if x % packing != 0:
+      return False
+    x //= packing
+    return x in (1, 2, 4, 8) or x % 8 == 0
+
+  # TODO(jevinjiang): support unaligned number of heads!
+  if not can_be_xla_fully_tiled(num_combined_kv_heads, kv_packing):
+    raise ValueError(
+        f"Not implemented: {num_combined_kv_heads=} can not be XLA fully tiled."
+    )
+  assert num_combined_kv_heads % 2 == 0
+  num_kv_heads = num_combined_kv_heads // 2
+  assert num_q_heads % num_kv_heads == 0
+  ratio = num_q_heads // num_kv_heads
+  # TODO(jevinjiang): we can choose smaller tiling for packed type if large
+  # second minor tiling is not on.
+  max_combined_kv_tiling = 8 * kv_packing
+  min_combined_kv_heads = (
+      max_combined_kv_tiling
+      if num_combined_kv_heads % max_combined_kv_tiling == 0
+      else num_combined_kv_heads
+  )
+  min_q_heads = min_combined_kv_heads // 2 * ratio
+  if can_be_xla_fully_tiled(min_q_heads, q_packing):
+    return min_q_heads, min_combined_kv_heads
+  return num_q_heads, num_combined_kv_heads
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=[
+        "sm_scale",
+        "mask_value",
+        "num_kv_pages_per_block",
+        "num_queries_per_block",
+        "vmem_limit_bytes",
+        "sliding_window",
+        "soft_cap",
+        "k_scale",
+        "v_scale",
+    ],
+)
+def ragged_paged_attention(
+    q: jax.Array,  # [max_num_batched_tokens, num_q_heads, head_dim]
+    # TODO(jevinjiang): create a write_to_kv_cache kernel!
+    kv_pages: jax.Array,  # [total_num_pages, page_size, num_combined_kv_heads, head_dim]
+    kv_lens: jax.Array,  # i32[max_num_seqs]
+    page_indices: jax.Array,  # i32[max_num_seqs, pages_per_seq]
+    cu_q_lens: jax.Array,  # i32[max_num_seqs + 1]
+    num_seqs: jax.Array,  # i32[1]
+    *,
+    sm_scale: float = 1.0,
+    sliding_window: int | None = None,
+    soft_cap: float | None = None,
+    mask_value: float | None = DEFAULT_MASK_VALUE,
+    k_scale: float | None = None,
+    v_scale: float | None = None,
+    num_kv_pages_per_block: int | None = None,
+    num_queries_per_block: int | None = None,
+    vmem_limit_bytes: int | None = None,
+):
+  """Ragged paged attention that supports mixed prefill and decode.
+
+  Args:
+    q: concatenated all sequences' queries.
+    kv_pages: paged KV cache. Normally in HBM.
+    kv_lens: padded kv lengths. Only the first num_seqs values are valid.
+    page_indices: the first index indicates which page to use in the kv cache
+      for each sequence. Only the first num_seqs values are valid.
+    cu_q_lens: the cumulative sum of the effective query lengths. Similar to
+      kv_lens, only the first num_seqs+1 values are valid.
+    num_seqs: the dynamic number of sequences.
+    sm_scale: the softmax scale which will be applied to the Q@K^T.
+    sliding_window: the sliding window size for the attention.
+    soft_cap: the logit soft cap for the attention.
+    mask_value: mask value for causal mask.
+    k_scale: the scale for the key cache.
+    v_scale: the scale for the value cache.
+    num_kv_pages_per_block: number of kv pages to be processed in one flash
+      attention block in the pallas kernel.
+    num_queries_per_block: number of kv pages to be processed in one flash
+      attention block in the pallas kernel.
+    vmem_limit_bytes: the vmem limit for the pallas kernel.
+
+  Returns:
+    The output of the attention.
+  """
+  static_validate_inputs(
+      q,
+      kv_pages,
+      kv_lens,
+      page_indices,
+      cu_q_lens,
+      num_seqs,
+      sm_scale=sm_scale,
+      sliding_window=sliding_window,
+      soft_cap=soft_cap,
+      mask_value=mask_value,
+      k_scale=k_scale,
+      v_scale=v_scale,
+      num_kv_pages_per_block=num_kv_pages_per_block,
+      num_queries_per_block=num_queries_per_block,
+      vmem_limit_bytes=vmem_limit_bytes,
+  )
+  if mask_value is None:
+    mask_value = DEFAULT_MASK_VALUE
+  num_q_tokens, num_q_heads, head_dim = q.shape
+  _, page_size, num_combined_kv_heads, _ = kv_pages.shape
+  assert num_combined_kv_heads % 2 == 0
+  num_kv_heads = num_combined_kv_heads // 2
+  _, pages_per_seq = page_indices.shape
+  num_q_heads_per_blk, num_combined_kv_heads_per_blk = get_min_heads_per_blk(
+      num_q_heads, num_combined_kv_heads, q.dtype, kv_pages.dtype
+  )
+  num_q_per_blk = num_queries_per_block
+  num_kv_pages_per_blk = num_kv_pages_per_block
+  if num_q_per_blk is None or num_kv_pages_per_blk is None:
+    num_kv_pages_per_blk, num_q_per_blk = get_tuned_block_sizes(
+        q.dtype,
+        kv_pages.dtype,
+        num_q_heads_per_blk,
+        num_combined_kv_heads_per_blk // 2,
+        head_dim,
+        page_size,
+        num_q_tokens,
+        pages_per_seq,
+    )
+  num_q_heads_per_kv_head = num_q_heads // num_kv_heads
+  num_q_blks = pl.cdiv(num_q_tokens, num_q_per_blk)
+  assert num_combined_kv_heads_per_blk % 2 == 0
+  num_kv_heads_per_blk = num_combined_kv_heads_per_blk // 2
+  assert num_q_heads_per_blk % num_q_heads_per_kv_head == 0
+  num_heads_blks = num_q_heads // num_q_heads_per_blk
+  grid = (num_heads_blks, num_q_blks)
+
+  def q_index_map(heads_blk_idx, q_blk_idx, *_):
+    return (q_blk_idx, heads_blk_idx, 0)
+
+  q_block_spec = pl.BlockSpec(
+      (num_q_per_blk, num_q_heads_per_blk, head_dim),
+      q_index_map,
+  )
+  in_specs = [
+      q_block_spec,
+      pl.BlockSpec(memory_space=pltpu.ANY),
+  ]
+  out_specs = q_block_spec
+  lm_scratch = pltpu.VMEM(
+      # TODO(jevinjiang): use 128 instead of 1 is due to Mosaic does not support
+      # unaligned slicing!
+      (num_kv_heads_per_blk, num_q_per_blk * num_q_heads_per_kv_head, 128),
+      jnp.float32,
+  )
+  acc_scratch = pltpu.VMEM(
+      (num_q_per_blk, num_q_heads_per_blk, head_dim),
+      jnp.float32,
+  )
+  double_buf_scratch = pltpu.VMEM(
+      (
+          2,  # For double buffering during DMA copies.
+          num_kv_pages_per_blk,
+          page_size,
+          num_combined_kv_heads_per_blk,
+          head_dim,
+      ),
+      kv_pages.dtype,
+  )
+  scratch_shapes = [
+      double_buf_scratch,  # kv_bufs
+      pltpu.SemaphoreType.DMA((2,)),  # Semaphores for double buffers.
+      lm_scratch,  # l_ref
+      lm_scratch,  # m_ref
+      acc_scratch,
+  ]
+  scalar_prefetches = (
+      kv_lens,
+      page_indices,
+      cu_q_lens,
+      jnp.array((0, 0), jnp.int32),  # seq_idx, buf_idx
+      num_seqs,
+  )
+  kernel = pl.pallas_call(
+      functools.partial(
+          ragged_paged_attention_kernel,
+          sm_scale=sm_scale,
+          sliding_window=sliding_window,
+          soft_cap=soft_cap,
+          mask_value=mask_value,
+          k_scale=k_scale,
+          v_scale=v_scale,
+      ),
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          num_scalar_prefetch=len(scalar_prefetches),
+          in_specs=in_specs,
+          out_specs=out_specs,
+          grid=grid,
+          scratch_shapes=scratch_shapes,
+      ),
+      compiler_params=pltpu.CompilerParams(
+          dimension_semantics=(
+              "arbitrary",
+              "arbitrary",
+          ),
+          vmem_limit_bytes=vmem_limit_bytes,
+      ),
+      out_shape=jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype),
+      name="ragged_paged_attention_kernel",
+  )
+
+  return kernel(*scalar_prefetches, q, kv_pages)
+
+
+import math
+
+
+CONFIG = {
+    'name': 'pallas_ragged_paged_attention_llama70b',
+    'model': 'Llama-3.1-70B',
+    'operator': 'pallas_ragged_paged_attention',
+    'max_num_batched_tokens': 4096,
+    'max_num_seqs': 64,
+    'num_q_heads': 64,
+    'num_kv_heads': 8,
+    'head_dim': 128,
+    'page_size': 16,
+    'pages_per_seq': 256,
+    'atol': 0.2,
+    'rtol': 0.2,
+}
+
+# Tuned by autotune_block_sizes.py. Re-run to update.
+TUNED_PARAMS = {
+    'num_kv_pages_per_block': 64,  # autotuned (was 32)
+    'num_queries_per_block': 64,  # autotuned
+    'vmem_limit_bytes': 33554432,  # not autotuned (hardware constraint)
+}
+
+
+def get_flops():
+    max_seqs = CONFIG['max_num_seqs']
+    H_q = CONFIG['num_q_heads']
+    D = CONFIG['head_dim']
+    tokens_per_seq = CONFIG['max_num_batched_tokens'] // max_seqs
+    kv_len = CONFIG['pages_per_seq'] * CONFIG['page_size']
+    return max_seqs * H_q * (4 * tokens_per_seq * kv_len * D)
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    max_tokens = CONFIG['max_num_batched_tokens']
+    max_seqs = CONFIG['max_num_seqs']
+    H_q = CONFIG['num_q_heads']
+    H_kv = CONFIG['num_kv_heads']
+    D = CONFIG['head_dim']
+    page_size = CONFIG['page_size']
+    pages_per_seq = CONFIG['pages_per_seq']
+    num_combined_kv_heads = 2 * H_kv
+    total_num_pages = max_seqs * pages_per_seq
+    q = jax.random.normal(k1, (max_tokens, H_q, D), dtype=dtype)
+    kv_pages = jax.random.normal(
+        k2, (total_num_pages, page_size, num_combined_kv_heads, D), dtype=dtype
+    )
+    tokens_per_seq = max_tokens // max_seqs
+    kv_len_per_seq = pages_per_seq * page_size
+    kv_lens = jnp.full((max_seqs,), kv_len_per_seq, dtype=jnp.int32)
+    page_indices = jnp.arange(total_num_pages, dtype=jnp.int32).reshape(
+        max_seqs, pages_per_seq
+    )
+    cu_q_lens = jnp.arange(max_seqs + 1, dtype=jnp.int32) * tokens_per_seq
+    num_seqs = jnp.array([max_seqs], dtype=jnp.int32)
+    return q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs
+
+
+def workload(q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs):
+    sm_scale = 1.0 / math.sqrt(CONFIG['head_dim'])
+    return ragged_paged_attention(
+        q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs,
+        sm_scale=sm_scale,
+        num_kv_pages_per_block=TUNED_PARAMS['num_kv_pages_per_block'],
+        num_queries_per_block=TUNED_PARAMS['num_queries_per_block'],
+        vmem_limit_bytes=TUNED_PARAMS['vmem_limit_bytes'],
+    )
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator', 'atol', 'rtol')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/8p_GEMM/baseline.py
+++ b/JAXBench/benchmark/8p_GEMM/baseline.py
@@ -1,0 +1,68 @@
+"""Dense bf16 GEMM — Llama-70B FFN dimensions.
+
+Baseline dense matrix multiplication at Llama-3.1-70B hidden-to-FFN scale.
+A = (8192, 8192), B = (8192, 28672) — matches hidden_dim -> mlp_dim projection.
+"""
+import jax
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'gemm_llama70b',
+    'model': 'Llama-3.1-70B',
+    'operator': 'dense_matmul',
+    'M': 8192,
+    'K': 8192,
+    'N': 28672,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (A, B) matrices."""
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    M, K, N = CONFIG['M'], CONFIG['K'], CONFIG['N']
+    A = jax.random.normal(k1, (M, K), dtype=dtype)
+    B = jax.random.normal(k2, (K, N), dtype=dtype) * 0.02
+    return A, B
+
+
+def workload(A, B):
+    """Dense matmul: C = A @ B"""
+    return jnp.dot(A, B)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    M, K, N = CONFIG['M'], CONFIG['K'], CONFIG['N']
+    flops = 2 * M * K * N
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/8p_GEMM/optimized.py
+++ b/JAXBench/benchmark/8p_GEMM/optimized.py
@@ -1,0 +1,153 @@
+# Copyright 2023 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pallas matmul TPU kernel — Llama-3.1-70B FFN dimensions.
+
+Upstream kernel from jax.experimental.pallas.ops.tpu.matmul, wrapped as a
+JAXBench workload with CONFIG / create_inputs / workload.
+
+See discussion in https://docs.jax.dev/en/latest/pallas/tpu/matmul.html.
+"""
+
+import functools
+
+import jax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+import jax.numpy as jnp
+
+CONFIG = {
+    'name': 'pallas_matmul_llama70b',
+    'model': 'Llama-3.1-70B',
+    'operator': 'pallas_matmul',
+    'M': 8192,
+    'K': 8192,
+    'N': 28672,
+    'atol': 1e-3,
+    'rtol': 1e-2,
+}
+
+# Tuned by autotune_block_sizes.py. Re-run to update.
+TUNED_PARAMS = {'block_shape': [1024, 2048], 'block_k': 1024}
+
+
+def matmul_kernel(x_tile_ref, y_tile_ref, o_tile_ref, acc_ref):
+  @pl.when(pl.program_id(2) == 0)
+  def init():
+    acc_ref[...] = jnp.zeros_like(acc_ref)
+
+  acc_ref[...] = acc_ref[...] + jnp.dot(
+      x_tile_ref[...],
+      y_tile_ref[...],
+      preferred_element_type=acc_ref.dtype,
+  )
+  # It is possible to make this conditional but in general this bundle packs
+  # quite well for a simple matmul kernel
+  o_tile_ref[...] = acc_ref[...].astype(o_tile_ref.dtype)
+
+
+@functools.partial(
+    jax.jit, static_argnames=["block_shape", "block_k", "debug", "out_dtype"]
+)
+def matmul(
+    x: jax.Array,
+    y: jax.Array,
+    *,
+    block_shape,
+    block_k: int = 256,
+    out_dtype: jnp.dtype | None = None,
+    debug: bool = False,
+) -> jax.Array:
+  if out_dtype is None:
+    if x.dtype != y.dtype:
+      # TODO(tlongeri): Maybe we could use a deduction similar to jnp.dot
+      raise TypeError(
+          f"Cannot deduce output dtype for different input dtypes: {x.dtype},"
+          f" {y.dtype}"
+      )
+    out_dtype = x.dtype
+  acc_dtype = jnp.float32
+  if x.dtype in [jnp.int8, jnp.int4, jnp.uint8, jnp.uint4]:
+    acc_dtype = jnp.int32
+
+  l, r = block_shape
+  return pl.pallas_call(
+      matmul_kernel,
+      out_shape=jax.ShapeDtypeStruct((x.shape[0], y.shape[1]), out_dtype),
+      grid_spec=pltpu.PrefetchScalarGridSpec(
+          num_scalar_prefetch=0,
+          in_specs=[
+              pl.BlockSpec((l, block_k), lambda i, _, k: (i, k)),
+              pl.BlockSpec((block_k, r), lambda _, j, k: (k, j)),
+          ],
+          out_specs=pl.BlockSpec((l, r), lambda i, j, k: (i, j)),
+          grid=(x.shape[0] // l, y.shape[1] // r, x.shape[1] // block_k),
+          scratch_shapes=[pltpu.VMEM((l, r), acc_dtype)],
+      ),
+      compiler_params=pltpu.CompilerParams(
+          dimension_semantics=("parallel", "parallel", "arbitrary")),
+      debug=debug,
+  )(x, y)
+
+
+def get_flops():
+    M, K, N = CONFIG['M'], CONFIG['K'], CONFIG['N']
+    return 2 * M * K * N
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    key = jax.random.key(42)
+    k1, k2 = jax.random.split(key, 2)
+    M, K, N = CONFIG['M'], CONFIG['K'], CONFIG['N']
+    x = jax.random.normal(k1, (M, K), dtype=dtype)
+    y = jax.random.normal(k2, (K, N), dtype=dtype) * 0.02
+    return x, y
+
+
+def workload(x, y):
+    return matmul(x, y, block_shape=tuple(TUNED_PARAMS['block_shape']), block_k=TUNED_PARAMS['block_k'])
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator', 'atol', 'rtol')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/9p_SwiGLU_MLP/baseline.py
+++ b/JAXBench/benchmark/9p_SwiGLU_MLP/baseline.py
@@ -1,0 +1,70 @@
+"""SwiGLU MLP — Llama 3.1 70B. Extracted from MaxText."""
+import jax
+import jax.numpy as jnp
+from functools import partial
+
+CONFIG = {
+    'name': 'llama3_70b_swiglu',
+    'model': 'Llama-3.1-70B',
+    'operator': 'swiglu_mlp',
+    'batch': 2,
+    'seq_len': 4096,
+    'emb_dim': 8192,
+    'mlp_dim': 28672,
+}
+
+
+def create_inputs(dtype=jnp.bfloat16):
+    """Returns (x, gate_kernel, up_kernel, down_kernel)."""
+    key = jax.random.key(42)
+    k1, k2, k3, k4 = jax.random.split(key, 4)
+    B, S, E, M = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim'], CONFIG['mlp_dim']
+    x = jax.random.normal(k1, (B, S, E), dtype=dtype)
+    gate = jax.random.normal(k2, (E, M), dtype=dtype) * 0.02
+    up = jax.random.normal(k3, (E, M), dtype=dtype) * 0.02
+    down = jax.random.normal(k4, (M, E), dtype=dtype) * 0.02
+    return x, gate, up, down
+
+
+def workload(x, gate_kernel, up_kernel, down_kernel):
+    """SwiGLU: output = (SiLU(x @ gate) * (x @ up)) @ down"""
+    gate = jax.nn.silu(jnp.dot(x, gate_kernel))
+    up = jnp.dot(x, up_kernel)
+    return jnp.dot(gate * up, down_kernel)
+
+
+def benchmark(num_warmup=5, num_iters=100):
+    """Benchmark and return results dict."""
+    import time
+    inputs = create_inputs()
+    fn = jax.jit(workload)
+    for _ in range(num_warmup):
+        out = fn(*inputs)
+        out.block_until_ready()
+    times = []
+    for _ in range(num_iters):
+        t0 = time.perf_counter()
+        out = fn(*inputs)
+        out.block_until_ready()
+        times.append(time.perf_counter() - t0)
+    import numpy as np
+    times = np.array(times) * 1000
+    B, S, E, M = CONFIG['batch'], CONFIG['seq_len'], CONFIG['emb_dim'], CONFIG['mlp_dim']
+    flops = B * S * E * M * 2 * 3
+    avg = float(np.mean(times))
+    return {
+        'name': CONFIG['name'],
+        'model': CONFIG['model'],
+        'operator': CONFIG['operator'],
+        'config': {k: v for k, v in CONFIG.items() if k not in ('name', 'model', 'operator')},
+        'time_ms': round(avg, 4),
+        'std_ms': round(float(np.std(times)), 4),
+        'tflops': round(flops / (avg / 1000) / 1e12, 2),
+        'output_shape': list(out.shape),
+        'status': 'success',
+    }
+
+
+if __name__ == '__main__':
+    import json
+    print(json.dumps(benchmark()))

--- a/JAXBench/benchmark/__init__.py
+++ b/JAXBench/benchmark/__init__.py
@@ -1,0 +1,41 @@
+"""JAXBench workload discovery and loading."""
+
+import os
+
+BENCHMARK_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def list_workloads():
+    """Return sorted list of workload names (e.g. ['1p_Flash_Attention', ...])."""
+    workloads = []
+    for d in os.listdir(BENCHMARK_DIR):
+        full = os.path.join(BENCHMARK_DIR, d)
+        if (os.path.isdir(full)
+                and not d.startswith(('_', '.'))
+                and os.path.exists(os.path.join(full, 'baseline.py'))):
+            workloads.append(d)
+    return sorted(workloads, key=_sort_key)
+
+
+def get_workload_dir(name):
+    """Return absolute path to workload directory. Raises ValueError if not found."""
+    path = os.path.join(BENCHMARK_DIR, name)
+    if not os.path.isdir(path) or not os.path.exists(os.path.join(path, 'baseline.py')):
+        raise ValueError(f"Workload '{name}' not found in {BENCHMARK_DIR}")
+    return path
+
+
+def has_optimized(name):
+    """Check if a workload has an optimized.py variant."""
+    return os.path.exists(os.path.join(BENCHMARK_DIR, name, 'optimized.py'))
+
+
+def _sort_key(name):
+    """Sort by numeric prefix (1p before 18k, etc.)."""
+    num = ''
+    for c in name:
+        if c.isdigit():
+            num += c
+        else:
+            break
+    return int(num) if num else 999

--- a/JAXBench/harness/__init__.py
+++ b/JAXBench/harness/__init__.py
@@ -1,0 +1,6 @@
+"""JAXBench evaluation harness."""
+
+from JAXBench.harness.evaluator import evaluate_kernel
+from JAXBench.harness.runner import run_workload, run_all
+
+__all__ = ['evaluate_kernel', 'run_workload', 'run_all']

--- a/JAXBench/harness/correctness.py
+++ b/JAXBench/harness/correctness.py
@@ -1,0 +1,60 @@
+"""Correctness checking for kernel outputs.
+
+Uses the same tolerance as KernelBench: atol=1e-2, rtol=1e-2.
+"""
+
+import jax
+import numpy as np
+
+ATOL = 1e-2
+RTOL = 1e-2
+
+
+def check_correctness(ref_output, test_output, atol=ATOL, rtol=RTOL):
+    """Compare reference and test outputs after converting to float32.
+
+    Handles single tensors, tuples, and pytree outputs.
+
+    Returns:
+        dict with keys:
+            correct (bool): Whether outputs match within tolerance
+            max_diff (float): Maximum absolute difference
+            reason (str): 'ok', 'output count mismatch', 'shape mismatch: ...', 'values differ'
+    """
+    ref_flat = jax.tree.leaves(ref_output) if isinstance(ref_output, (tuple, list)) else [ref_output]
+    test_flat = jax.tree.leaves(test_output) if isinstance(test_output, (tuple, list)) else [test_output]
+
+    if len(ref_flat) != len(test_flat):
+        return {
+            'correct': False,
+            'max_diff': float('inf'),
+            'reason': f'output count mismatch: {len(ref_flat)} vs {len(test_flat)}',
+        }
+
+    max_diff = 0.0
+    for r, t in zip(ref_flat, test_flat):
+        r_np = np.array(r, dtype=np.float32)
+        t_np = np.array(t, dtype=np.float32)
+
+        if r_np.shape != t_np.shape:
+            return {
+                'correct': False,
+                'max_diff': float('inf'),
+                'reason': f'shape mismatch: {r_np.shape} vs {t_np.shape}',
+            }
+
+        diff = float(np.max(np.abs(r_np - t_np)))
+        max_diff = max(max_diff, diff)
+
+        if not np.allclose(r_np, t_np, atol=atol, rtol=rtol):
+            return {
+                'correct': False,
+                'max_diff': max_diff,
+                'reason': 'values differ',
+            }
+
+    return {
+        'correct': True,
+        'max_diff': max_diff,
+        'reason': 'ok',
+    }

--- a/JAXBench/harness/evaluator.py
+++ b/JAXBench/harness/evaluator.py
@@ -1,0 +1,231 @@
+"""Agent-facing kernel evaluation: compile -> correctness -> benchmark -> report.
+
+This is the primary interface for agents optimizing JAX kernels. Given a workload
+name and a path to a kernel file (which must export a workload(*inputs) function),
+this module compiles the kernel, checks correctness against the baseline, benchmarks
+it, and returns a structured comparison.
+"""
+
+import json
+import os
+import sys
+import traceback
+
+import jax
+import jax.numpy as jnp
+
+from JAXBench.benchmark import get_workload_dir, has_optimized
+from JAXBench.harness.loader import load_module, load_kernel
+from JAXBench.harness.profiler import benchmark_fn
+from JAXBench.harness.correctness import check_correctness
+from JAXBench.harness.runner import get_flop_count
+from JAXBench.harness.tpu_specs import get_tpu_spec
+
+
+def evaluate_kernel(workload_name, kernel_path, tpu='auto', num_warmup=5,
+                    num_iters=50):
+    """Evaluate an agent-generated kernel against a workload.
+
+    Steps:
+        1. Load baseline module, create inputs, run baseline to get reference output
+        2. Load the agent's kernel file (must have a workload() function)
+        3. Run agent's kernel with the same inputs
+        4. Check correctness (atol=1e-2, rtol=1e-2)
+        5. If correct, benchmark both with device profiling
+        6. If optimized.py exists, benchmark that too for three-way comparison
+
+    Args:
+        workload_name: Name of the workload (e.g. '1p_Flash_Attention')
+        kernel_path: Path to a Python file with a workload(*inputs) function
+        tpu: TPU target ('v5e', 'v6e', or 'auto')
+        num_warmup: Number of warmup iterations
+        num_iters: Number of benchmark iterations
+
+    Returns:
+        dict with evaluation results (see below for schema).
+    """
+    tpu_name, tpu_spec = get_tpu_spec(tpu)
+    peak_tflops = tpu_spec['peak_tflops_bf16']
+
+    result = {
+        'workload': workload_name,
+        'status': 'error',
+        'tpu': tpu_name,
+    }
+
+    try:
+        # --- Step 1: Load baseline ---
+        workload_dir = get_workload_dir(workload_name)
+        baseline_path = os.path.join(workload_dir, 'baseline.py')
+        baseline_mod = load_module(baseline_path, f'{workload_name}.baseline')
+
+        config = getattr(baseline_mod, 'CONFIG', {})
+        result['config'] = {k: v for k, v in config.items()
+                            if isinstance(v, (int, float, str, bool))}
+
+        skip_jit = getattr(baseline_mod, '_skip_jit', False)
+
+        create_fn = getattr(baseline_mod, 'create_inputs')
+        if 'dtype' in create_fn.__code__.co_varnames:
+            inputs = create_fn(dtype=jnp.bfloat16)
+        else:
+            inputs = create_fn()
+        if not isinstance(inputs, (list, tuple)):
+            inputs = (inputs,)
+
+        # Get FLOP count from baseline
+        baseline_fn = baseline_mod.workload
+        xla_flops = get_flop_count(baseline_mod, baseline_fn, inputs, skip_jit)
+
+        # Run baseline to get reference output
+        run_baseline = baseline_fn if skip_jit else jax.jit(baseline_fn)
+        ref_output = run_baseline(*inputs)
+        if hasattr(ref_output, 'block_until_ready'):
+            ref_output.block_until_ready()
+
+        # --- Step 2: Load agent kernel ---
+        try:
+            kernel_mod = load_kernel(kernel_path)
+        except (FileNotFoundError, ValueError) as e:
+            result['status'] = 'compile_error'
+            result['error'] = str(e)
+            return result
+
+        kernel_fn = kernel_mod.workload
+        kernel_skip_jit = getattr(kernel_mod, '_skip_jit', False)
+
+        # --- Step 3: Run agent kernel ---
+        try:
+            run_kernel = kernel_fn if kernel_skip_jit else jax.jit(kernel_fn)
+            test_output = run_kernel(*inputs)
+            if hasattr(test_output, 'block_until_ready'):
+                test_output.block_until_ready()
+        except Exception as e:
+            result['status'] = 'runtime_error'
+            result['error'] = str(e)[:300]
+            result['traceback'] = traceback.format_exc()[-500:]
+            return result
+
+        # --- Step 4: Check correctness ---
+        correctness = check_correctness(ref_output, test_output)
+        result['correctness'] = correctness
+
+        if not correctness['correct']:
+            result['status'] = 'incorrect'
+            return result
+
+        # --- Step 5: Benchmark both ---
+        jax.clear_caches()
+
+        baseline_bench = benchmark_fn(
+            baseline_fn, inputs,
+            num_warmup=num_warmup, num_iters=num_iters,
+            skip_jit=skip_jit, label=f'{workload_name}_baseline',
+        )
+        baseline_out = baseline_bench.pop('output')
+
+        jax.clear_caches()
+
+        kernel_bench = benchmark_fn(
+            kernel_fn, inputs,
+            num_warmup=num_warmup, num_iters=num_iters,
+            skip_jit=kernel_skip_jit, label=f'{workload_name}_kernel',
+        )
+        kernel_out = kernel_bench.pop('output')
+
+        def _perf_dict(bench):
+            median = bench['median_ms']
+            tflops = 0.0
+            util = 0.0
+            if xla_flops > 0 and median > 0:
+                tflops = xla_flops / (median / 1000) / 1e12
+                util = (tflops / peak_tflops) * 100
+            return {
+                'median_ms': bench['median_ms'],
+                'mean_ms': bench['mean_ms'],
+                'std_ms': bench['std_ms'],
+                'min_ms': bench['min_ms'],
+                'timing_method': bench['timing_method'],
+                'tflops': round(tflops, 2),
+                'utilization_pct': round(util, 1),
+            }
+
+        result['baseline'] = _perf_dict(baseline_bench)
+        result['kernel'] = _perf_dict(kernel_bench)
+
+        speedup = (baseline_bench['median_ms'] / kernel_bench['median_ms']
+                    if kernel_bench['median_ms'] > 0 else 0)
+        result['speedup_vs_baseline'] = round(speedup, 2)
+
+        # --- Step 6: Benchmark pallas reference if present ---
+        result['pallas_reference'] = None
+        result['speedup_vs_pallas'] = None
+
+        if has_optimized(workload_name):
+            try:
+                jax.clear_caches()
+                opt_path = os.path.join(workload_dir, 'optimized.py')
+                opt_mod = load_module(opt_path, f'{workload_name}.optimized')
+                opt_fn = opt_mod.workload
+                opt_skip_jit = getattr(opt_mod, '_skip_jit', False)
+
+                opt_bench = benchmark_fn(
+                    opt_fn, inputs,
+                    num_warmup=num_warmup, num_iters=num_iters,
+                    skip_jit=opt_skip_jit, label=f'{workload_name}_pallas',
+                )
+                opt_bench.pop('output')
+
+                result['pallas_reference'] = _perf_dict(opt_bench)
+                pallas_speedup = (opt_bench['median_ms'] / kernel_bench['median_ms']
+                                  if kernel_bench['median_ms'] > 0 else 0)
+                result['speedup_vs_pallas'] = round(pallas_speedup, 2)
+            except Exception:
+                pass  # Pallas reference is optional
+
+        result['status'] = 'correct'
+
+    except Exception as e:
+        result['error'] = str(e)[:300]
+        result['traceback'] = traceback.format_exc()[-500:]
+
+    return result
+
+
+def format_eval_result(result):
+    """Format an evaluation result as human-readable text."""
+    lines = []
+    lines.append(f"Workload: {result['workload']}")
+    lines.append(f"Status:   {result['status']}")
+    lines.append(f"TPU:      {result.get('tpu', '?')}")
+    lines.append("")
+
+    if 'correctness' in result:
+        c = result['correctness']
+        lines.append(f"Correctness: {'PASS' if c['correct'] else 'FAIL'} "
+                      f"(max_diff={c['max_diff']:.6f}, {c['reason']})")
+        lines.append("")
+
+    if result['status'] == 'correct':
+        b = result['baseline']
+        k = result['kernel']
+        lines.append(f"{'':>20} {'Median(ms)':>12} {'TFLOPS':>10} {'Util%':>8}")
+        lines.append(f"{'Baseline (XLA)':>20} {b['median_ms']:>12.3f} "
+                      f"{b['tflops']:>10.1f} {b['utilization_pct']:>7.1f}%")
+        lines.append(f"{'Your Kernel':>20} {k['median_ms']:>12.3f} "
+                      f"{k['tflops']:>10.1f} {k['utilization_pct']:>7.1f}%")
+
+        if result.get('pallas_reference'):
+            p = result['pallas_reference']
+            lines.append(f"{'Pallas Reference':>20} {p['median_ms']:>12.3f} "
+                          f"{p['tflops']:>10.1f} {p['utilization_pct']:>7.1f}%")
+
+        lines.append("")
+        lines.append(f"Speedup vs Baseline: {result['speedup_vs_baseline']:.2f}x")
+        if result.get('speedup_vs_pallas') is not None:
+            lines.append(f"Speedup vs Pallas:   {result['speedup_vs_pallas']:.2f}x")
+
+    elif 'error' in result:
+        lines.append(f"Error: {result['error']}")
+
+    return '\n'.join(lines)

--- a/JAXBench/harness/loader.py
+++ b/JAXBench/harness/loader.py
@@ -1,0 +1,45 @@
+"""Dynamic module loading utilities."""
+
+import importlib.util
+import os
+import sys
+
+
+def load_module(path, module_name=None):
+    """Import a Python file as a module.
+
+    Registers in sys.modules to fix dataclass __module__ resolution.
+    Returns the loaded module.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Module not found: {path}")
+
+    if module_name is None:
+        module_name = os.path.splitext(os.path.basename(path))[0]
+
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def load_kernel(path):
+    """Load an agent-provided kernel file.
+
+    The file must export a workload(*inputs) function.
+    Returns the loaded module.
+    """
+    mod = load_module(path, f"agent_kernel_{os.path.basename(path)}")
+
+    if not hasattr(mod, 'workload'):
+        raise ValueError(
+            f"Kernel file {path} must define a workload(*inputs) function"
+        )
+
+    if not callable(mod.workload):
+        raise ValueError(
+            f"workload in {path} is not callable"
+        )
+
+    return mod

--- a/JAXBench/harness/profiler.py
+++ b/JAXBench/harness/profiler.py
@@ -1,0 +1,144 @@
+"""Device-side profiling via jax.profiler.trace() and Perfetto trace parsing.
+
+Captures TPU kernel execution times by parsing jit_*() events from Perfetto
+JSON traces, measuring only actual device execution (excluding host dispatch).
+"""
+
+import glob
+import gzip
+import json
+import os
+import shutil
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+def extract_device_times(trace_dir, num_iters, is_eager=False):
+    """Parse Perfetto JSON trace and extract per-iteration device kernel times.
+
+    For JIT workloads: matches jit_workload(...) events which wrap the complete
+    device execution per iteration (including all sub-fusions/Pallas kernels).
+
+    For eager (_skip_jit) workloads: collects all jit_*() device events and
+    groups them into per-iteration batches.
+
+    Returns list of durations in milliseconds, or None if no events found.
+    """
+    perfetto_files = glob.glob(
+        f"{trace_dir}/**/perfetto_trace.json.gz", recursive=True
+    )
+    if not perfetto_files:
+        return None
+
+    with gzip.open(perfetto_files[0], 'rt') as f:
+        data = json.load(f)
+
+    events = data.get('traceEvents', data) if isinstance(data, dict) else data
+
+    if not is_eager:
+        kernel_times_ms = []
+        for e in events:
+            if not isinstance(e, dict) or e.get('dur', 0) <= 0:
+                continue
+            name = e.get('name', '')
+            if name.startswith('jit_') and '(' in name:
+                kernel_times_ms.append(e['dur'] / 1000.0)
+        return kernel_times_ms if kernel_times_ms else None
+    else:
+        all_jit_times = []
+        for e in events:
+            if not isinstance(e, dict) or e.get('dur', 0) <= 0:
+                continue
+            name = e.get('name', '')
+            if name.startswith('jit_') and '(' in name:
+                all_jit_times.append(e['dur'] / 1000.0)
+
+        if not all_jit_times:
+            return None
+
+        ops_per_iter = len(all_jit_times) // num_iters if num_iters > 0 else 0
+        if ops_per_iter <= 0:
+            return None
+
+        iter_times = []
+        for i in range(num_iters):
+            batch = all_jit_times[i * ops_per_iter:(i + 1) * ops_per_iter]
+            iter_times.append(sum(batch))
+        return iter_times
+
+
+def benchmark_fn(fn, inputs, num_warmup=5, num_iters=50, skip_jit=False,
+                 label='workload'):
+    """Run a function with device-side profiling.
+
+    Args:
+        fn: The function to benchmark (raw, not yet JIT'd unless skip_jit=True).
+        inputs: Tuple of input tensors.
+        num_warmup: Number of warmup iterations.
+        num_iters: Number of timed iterations.
+        skip_jit: If True, run eagerly (don't wrap in jax.jit).
+        label: Label for trace directory naming.
+
+    Returns:
+        dict with keys:
+            timing_method: 'device_profiler' or 'wall_clock_fallback'
+            median_ms, mean_ms, std_ms, min_ms: float
+            wall_clock_median_ms: float
+            raw_times_ms: list[float]
+    """
+    run_fn = fn if skip_jit else jax.jit(fn)
+    bench_iters = 10 if skip_jit else num_iters
+
+    # Warmup
+    for _ in range(num_warmup):
+        out = run_fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+
+    # Wall-clock timing
+    wall_times = []
+    for _ in range(bench_iters):
+        t0 = time.perf_counter()
+        out = run_fn(*inputs)
+        if hasattr(out, 'block_until_ready'):
+            out.block_until_ready()
+        wall_times.append((time.perf_counter() - t0) * 1000)
+
+    # Device-side profiler timing
+    trace_dir = f'/tmp/jax_profile_{label}_{os.getpid()}'
+    if os.path.exists(trace_dir):
+        shutil.rmtree(trace_dir)
+    os.makedirs(trace_dir, exist_ok=True)
+
+    with jax.profiler.trace(trace_dir, create_perfetto_link=False,
+                            create_perfetto_trace=True):
+        for _ in range(bench_iters):
+            with jax.named_scope('bench_kernel'):
+                out = run_fn(*inputs)
+            if hasattr(out, 'block_until_ready'):
+                out.block_until_ready()
+
+    device_times = extract_device_times(trace_dir, bench_iters, is_eager=skip_jit)
+    shutil.rmtree(trace_dir, ignore_errors=True)
+
+    if device_times and len(device_times) >= bench_iters:
+        times = device_times[:bench_iters]
+        timing_method = 'device_profiler'
+    else:
+        times = wall_times
+        timing_method = 'wall_clock_fallback'
+
+    times_arr = np.array(times)
+    return {
+        'timing_method': timing_method,
+        'median_ms': round(float(np.median(times_arr)), 4),
+        'mean_ms': round(float(np.mean(times_arr)), 4),
+        'std_ms': round(float(np.std(times_arr)), 4),
+        'min_ms': round(float(np.min(times_arr)), 4),
+        'wall_clock_median_ms': round(float(np.median(wall_times)), 4),
+        'raw_times_ms': [round(t, 4) for t in times],
+        'output': out,
+    }

--- a/JAXBench/harness/runner.py
+++ b/JAXBench/harness/runner.py
@@ -1,0 +1,282 @@
+"""Core benchmark runner: run individual or all workloads."""
+
+import csv
+import json
+import os
+import sys
+import time
+import traceback
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from JAXBench.benchmark import list_workloads, get_workload_dir, has_optimized, BENCHMARK_DIR
+from JAXBench.harness.loader import load_module
+from JAXBench.harness.profiler import benchmark_fn
+from JAXBench.harness.tpu_specs import get_tpu_spec
+
+
+def get_flop_count(mod, workload_fn, inputs, skip_jit):
+    """Get FLOP count: prefer module's get_flops(), fall back to XLA cost_analysis."""
+    get_flops_fn = getattr(mod, 'get_flops', None)
+    if get_flops_fn is not None:
+        return int(get_flops_fn())
+
+    if not skip_jit:
+        try:
+            compiled = jax.jit(workload_fn).lower(*inputs).compile()
+            cost = compiled.cost_analysis()
+            if isinstance(cost, list):
+                cost = cost[0] if cost else {}
+            return int(cost.get('flops', 0))
+        except Exception:
+            pass
+
+    return 0
+
+
+def run_workload(name, variant='baseline', tpu='auto', num_warmup=5,
+                 num_iters=50):
+    """Run a single workload variant with device profiling.
+
+    Args:
+        name: Workload name (e.g. '1p_Flash_Attention')
+        variant: 'baseline' or 'optimized'
+        tpu: TPU target ('v5e', 'v6e', or 'auto')
+        num_warmup: Number of warmup iterations
+        num_iters: Number of benchmark iterations
+
+    Returns:
+        dict with structured results including timing, FLOPS, utilization.
+    """
+    tpu_name, tpu_spec = get_tpu_spec(tpu)
+    peak_tflops = tpu_spec['peak_tflops_bf16']
+
+    workload_dir = get_workload_dir(name)
+    module_path = os.path.join(workload_dir, f'{variant}.py')
+
+    if not os.path.exists(module_path):
+        return None
+
+    result = {
+        'name': name,
+        'variant': variant,
+        'status': 'error',
+        'tpu': tpu_name,
+    }
+
+    try:
+        mod = load_module(module_path, f'{name}.{variant}')
+
+        config = getattr(mod, 'CONFIG', {})
+        result['config'] = {k: v for k, v in config.items()
+                            if isinstance(v, (int, float, str, bool))}
+
+        skip_jit = getattr(mod, '_skip_jit', False)
+
+        create_fn = getattr(mod, 'create_inputs')
+        if 'dtype' in create_fn.__code__.co_varnames:
+            inputs = create_fn(dtype=jnp.bfloat16)
+        else:
+            inputs = create_fn()
+        if not isinstance(inputs, (list, tuple)):
+            inputs = (inputs,)
+
+        result['input_shapes'] = [
+            list(x.shape) if hasattr(x, 'shape') else str(type(x))
+            for x in inputs
+        ]
+
+        workload_fn = getattr(mod, 'workload')
+        xla_flops = get_flop_count(mod, workload_fn, inputs, skip_jit)
+        result['xla_flops'] = xla_flops
+
+        # Benchmark
+        bench = benchmark_fn(
+            workload_fn, inputs,
+            num_warmup=num_warmup,
+            num_iters=num_iters,
+            skip_jit=skip_jit,
+            label=f'{name}_{variant}',
+        )
+
+        out = bench.pop('output')
+
+        # Compute TFLOPS and utilization
+        tflops = 0.0
+        utilization_pct = 0.0
+        median_ms = bench['median_ms']
+        if xla_flops > 0 and median_ms > 0:
+            tflops = xla_flops / (median_ms / 1000) / 1e12
+            utilization_pct = (tflops / peak_tflops) * 100
+
+        result.update({
+            'status': 'success',
+            'timing_method': bench['timing_method'],
+            'median_ms': bench['median_ms'],
+            'mean_ms': bench['mean_ms'],
+            'std_ms': bench['std_ms'],
+            'min_ms': bench['min_ms'],
+            'wall_clock_median_ms': bench['wall_clock_median_ms'],
+            'xla_flops': xla_flops,
+            'tflops': round(tflops, 2),
+            'utilization_pct': round(utilization_pct, 1),
+            'output_shape': list(out.shape) if hasattr(out, 'shape') else [],
+            'num_iters': num_iters,
+        })
+
+    except Exception as e:
+        result['error'] = str(e)[:300]
+        result['traceback'] = traceback.format_exc()[-500:]
+
+    return result
+
+
+def run_all(tpu='auto', num_warmup=5, num_iters=50, output_dir=None):
+    """Run all workloads (baseline + optimized if present).
+
+    Args:
+        tpu: TPU target ('v5e', 'v6e', or 'auto')
+        num_warmup: Number of warmup iterations
+        num_iters: Number of benchmark iterations
+        output_dir: Directory for results.json and results.csv (default: benchmark/)
+
+    Returns:
+        dict with metadata and results list.
+    """
+    if output_dir is None:
+        output_dir = BENCHMARK_DIR
+
+    tpu_name, tpu_spec = get_tpu_spec(tpu)
+
+    print(f"JAX {jax.__version__} | Devices: {jax.devices()}")
+    print(f"TPU: {tpu_name} | Peak: {tpu_spec['peak_tflops_bf16']} TFLOPS (bf16)")
+    print(f"Timing: jax.profiler device-side (jit_*() events)")
+    print()
+
+    workload_names = list_workloads()
+    print(f"Found {len(workload_names)} workloads")
+    print()
+
+    results = []
+    header = (f"{'#':>3} {'Workload':<42} {'Var':<10} {'Median(ms)':>10} "
+              f"{'TFLOPS':>8} {'Util%':>7} {'Method':<18}")
+    print(header)
+    print("-" * len(header))
+
+    for i, name in enumerate(workload_names, 1):
+        for variant in ['baseline', 'optimized']:
+            vpath = os.path.join(get_workload_dir(name), f'{variant}.py')
+            if not os.path.exists(vpath):
+                continue
+
+            jax.clear_caches()
+
+            r = run_workload(name, variant, tpu=tpu_name,
+                             num_warmup=num_warmup, num_iters=num_iters)
+            if r is None:
+                continue
+
+            results.append(r)
+
+            if r['status'] == 'success':
+                tflops_str = f"{r['tflops']:.1f}" if r['tflops'] > 0 else "—"
+                util_str = f"{r['utilization_pct']:.1f}%" if r['utilization_pct'] > 0 else "—"
+                method = r.get('timing_method', '?')
+                print(f"{i:>3} {name:<42} {variant:<10} "
+                      f"{r['median_ms']:>10.3f} {tflops_str:>8} "
+                      f"{util_str:>7} {method:<18}")
+            else:
+                err = r.get('error', '?')[:40]
+                print(f"{i:>3} {name:<42} {variant:<10} "
+                      f"{'ERROR':>10} {'':>8} {'':>7} {err}")
+
+    # Summary
+    print()
+    successes = [r for r in results if r['status'] == 'success']
+    baselines = [r for r in successes if r['variant'] == 'baseline']
+    optimized = [r for r in successes if r['variant'] == 'optimized']
+
+    print(f"Total: {len(results)} runs ({len(successes)} success, "
+          f"{len(results) - len(successes)} error)")
+    print(f"Baselines: {len(baselines)}/{len(workload_names)} succeeded")
+    if optimized:
+        print(f"Optimized: {len(optimized)} variants")
+
+    profiler_count = sum(1 for r in successes
+                         if r.get('timing_method') == 'device_profiler')
+    wall_count = sum(1 for r in successes
+                     if 'wall_clock' in r.get('timing_method', ''))
+    print(f"\nTiming: {profiler_count} device_profiler, {wall_count} wall_clock")
+
+    utils = [r['utilization_pct'] for r in baselines if r['utilization_pct'] > 0]
+    if utils:
+        print(f"\nTPU Utilization (baselines):")
+        print(f"  Median: {np.median(utils):.1f}%")
+        print(f"  Mean:   {np.mean(utils):.1f}%")
+        print(f"  Max:    {np.max(utils):.1f}%")
+        print(f"  Min:    {np.min(utils):.1f}%")
+
+    if optimized:
+        print(f"\nOptimized vs Baseline speedups:")
+        for opt_r in optimized:
+            base_r = next((r for r in baselines if r['name'] == opt_r['name']), None)
+            if base_r:
+                sp = (base_r['median_ms'] / opt_r['median_ms']
+                      if opt_r['median_ms'] > 0 else 0)
+                print(f"  {opt_r['name']}: {base_r['median_ms']:.3f}ms -> "
+                      f"{opt_r['median_ms']:.3f}ms ({sp:.2f}x)")
+
+    # Save results
+    output = {
+        'metadata': {
+            'jax_version': jax.__version__,
+            'devices': str(jax.devices()),
+            'tpu': tpu_name,
+            'tpu_peak_tflops_bf16': tpu_spec['peak_tflops_bf16'],
+            'timing_method': 'jax.profiler device-side (jit_*() events from Perfetto trace)',
+            'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'num_workloads': len(workload_names),
+            'num_succeeded': len(successes),
+            'num_warmup': num_warmup,
+            'num_iters': num_iters,
+        },
+        'results': results,
+    }
+
+    json_path = os.path.join(output_dir, 'results.json')
+    with open(json_path, 'w') as f:
+        json.dump(output, f, indent=2)
+    print(f"\nResults saved to {json_path}")
+
+    csv_path = os.path.join(output_dir, 'results.csv')
+    _save_csv(results, csv_path)
+    print(f"CSV saved to {csv_path}")
+
+    return output
+
+
+def _save_csv(results, path):
+    """Save results as CSV, sorted by workload number."""
+    from JAXBench.benchmark import _sort_key
+
+    with open(path, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            'workload', 'variant', 'status', 'timing_method',
+            'median_ms', 'mean_ms', 'std_ms', 'min_ms',
+            'xla_flops', 'tflops', 'utilization_pct',
+            'output_shape', 'error',
+        ])
+
+        for r in sorted(results, key=lambda r: _sort_key(r['name'])):
+            writer.writerow([
+                r['name'], r['variant'], r['status'],
+                r.get('timing_method', ''),
+                r.get('median_ms', ''), r.get('mean_ms', ''),
+                r.get('std_ms', ''), r.get('min_ms', ''),
+                r.get('xla_flops', ''), r.get('tflops', ''),
+                r.get('utilization_pct', ''),
+                str(r.get('output_shape', '')), r.get('error', ''),
+            ])

--- a/JAXBench/harness/tpu_specs.py
+++ b/JAXBench/harness/tpu_specs.py
@@ -1,0 +1,43 @@
+"""TPU hardware specifications and auto-detection."""
+
+TPU_SPECS = {
+    'v5e': {
+        'peak_tflops_bf16': 197.0,
+        'hbm_bandwidth_gbs': 819.0,
+    },
+    'v6e': {
+        'peak_tflops_bf16': 918.0,
+        'hbm_bandwidth_gbs': 1600.0,
+    },
+}
+
+
+def detect_tpu():
+    """Auto-detect TPU type from JAX devices. Returns 'v5e', 'v6e', etc."""
+    try:
+        import jax
+        devices = jax.devices()
+        if not devices:
+            raise RuntimeError("No JAX devices found")
+        kind = devices[0].device_kind.lower()
+        for tpu_type in TPU_SPECS:
+            if tpu_type in kind:
+                return tpu_type
+        raise RuntimeError(f"Unknown TPU type: {devices[0].device_kind}")
+    except Exception as e:
+        raise RuntimeError(f"Could not detect TPU type: {e}")
+
+
+def get_tpu_spec(tpu='auto'):
+    """Return TPU spec dict. If tpu='auto', auto-detects from JAX devices."""
+    if tpu == 'auto':
+        tpu = detect_tpu()
+    if tpu not in TPU_SPECS:
+        raise ValueError(f"Unknown TPU type '{tpu}'. Available: {list(TPU_SPECS.keys())}")
+    return tpu, TPU_SPECS[tpu]
+
+
+def get_peak_tflops(tpu='auto'):
+    """Return peak TFLOPS for the given TPU target."""
+    _, spec = get_tpu_spec(tpu)
+    return spec['peak_tflops_bf16']

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ hardware accelerators like TPUs becomes increasingly challenging. This project
 aims to provide a suite of "Agents"—specialized AI tools powered by Gemini—to
 automate and assist with these complex tasks.
 
+
+
 The project includes two primary agents:
 
 ### 1. MaxCode
@@ -55,6 +57,23 @@ language).
     suggestions to improve kernel performance (MFU).
 *   **Test Harness Generation:** Automatically generates boilerplate code for
     correctness testing and compilation checks.
+
+### 3. JAXBench (Temporary)
+**JAXBench** is a suite of 50 curated JAX/TPU kernel workloads with an evaluation
+harness for benchmarking AI-generated kernel optimizations. 
+
+> **Note:** This is a temporary addition to the repository and will be migrated to
+> a permanent standalone home in the future.
+
+**Features:**
+* **50 Workloads:** Includes 17 priority production operators and 33 KernelBench
+  fused ops with a consistent interface.
+* **Evaluation Harness:** Features a device-side profiling pipeline via
+  `jax.profiler.trace()`, correctness checking, and three-way comparison
+  (baseline XLA vs candidate vs Pallas reference).
+* **CLI Support:** Provides a simple CLI for evaluation and benchmarking:
+  `python -m JAXBench {evaluate,run,list}`.
+
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- Adds **JAXBench**, a suite of 50 curated JAX/TPU kernel workloads with a production-ready evaluation harness for benchmarking AI-generated kernel optimizations.
- **`benchmark/`**: 50 workloads (17 priority production operators + 33 KernelBench fused ops) with consistent interface. 8 have hand-optimized Pallas TPU kernel variants.
- **`harness/`**: Evaluation pipeline with device-side profiling via `jax.profiler.trace()`, correctness checking (atol=1e-2, rtol=1e-2), and three-way comparison (baseline XLA vs candidate vs Pallas reference).
- CLI: `python -m JAXBench {evaluate,run,list}` for both agent and user workflows.

## Test plan

- [ ] `python -m JAXBench list` shows all 50 workloads (works on CPU)
- [ ] `python -m JAXBench list --json` returns valid JSON
- [ ] `python -m JAXBench run --workload 8p_GEMM --tpu v6e` produces timing results (requires TPU)
- [ ] `python -m JAXBench evaluate --workload 8p_GEMM --kernel JAXBench/benchmark/8p_GEMM/optimized.py --json` returns structured eval output (requires TPU)
- [ ] `python -m JAXBench run --all --tpu v6e` produces results.json + results.csv (requires TPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)