### PR TITLE
fix: correct arithmetic mean speedup calculation and add ignore format for jaxbench_adapted_dataset to pyproject.toml

### DIFF
--- a/MaxKernel/evaluation/evaluation_utils.py
+++ b/MaxKernel/evaluation/evaluation_utils.py
@@ -144,7 +144,10 @@ def summarize_results(
   max_speedup = max(speedups_cliped) if speedups_cliped else 1
 
   arithmetic_mean_speedup = (
-    sum(speedups_cliped) / total_attempted if speedups_cliped else 1
+    (sum(speedups_cliped) + (total_attempted - len(speedups_cliped)))
+    / total_attempted
+    if speedups_cliped
+    else 1
   )
 
   # Geometric mean is more robust for averaging ratios like speedup.

--- a/MaxKernel/pyproject.toml
+++ b/MaxKernel/pyproject.toml
@@ -2,6 +2,7 @@
 line-length = 80
 target-version = "py310"
 indent-width = 2
+extend-exclude = ["evaluation/jaxbench_adapted_dataset"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W"]


### PR DESCRIPTION
1. The mean speedup calculation was wrong in that it didn't add failed cases' speed as 1; This change correct this error;
2. Ignore format for code in jaxbench_adapted_dataset.