### PR TITLE
Configurable workspace selection and compilation retries

### DIFF
--- a/MaxKernel/auto_agent/config.py
+++ b/MaxKernel/auto_agent/config.py
@@ -12,6 +12,7 @@ WORKDIR = os.environ.get("WORKDIR", os.path.dirname(os.path.abspath(__file__)))
 TPU_VERSION = os.environ.get("TPU_VERSION", "")
 RAG_CORPUS = os.environ.get("RAG_CORPUS", "")
 INCLUDE_THOUGHTS = os.environ.get("INCLUDE_THOUGHTS", "true").lower() == "true"
+MAX_COMPILATION_RETRIES = int(os.environ.get("MAX_COMPILATION_RETRIES", "6"))
 
 # Model configuration
 model_config = types.GenerateContentConfig(

--- a/MaxKernel/auto_agent/subagents/kernel_writing/agent.py
+++ b/MaxKernel/auto_agent/subagents/kernel_writing/agent.py
@@ -16,7 +16,7 @@ from auto_agent.callbacks import (
   load_kernel_and_plan_to_state,
   load_single_kernel_to_state,
 )
-from auto_agent.config import model_config, thinking_planner
+from auto_agent.config import model_config, thinking_planner, MAX_COMPILATION_RETRIES
 from auto_agent.constants import MODEL_NAME
 from auto_agent.custom_types import CustomLlmAgent
 from auto_agent.subagents.kernel_writing.kernel_compilation import (
@@ -46,7 +46,7 @@ class KernelCompilationValidationLoop(BaseAgent):
   compilation_checker: Optional[BaseAgent] = None
   fix_agent: Optional[BaseAgent] = None
   debug_agent: Optional[BaseAgent] = None
-  max_retries: int = 4
+  max_retries: int = 6
 
   def __init__(
     self,
@@ -54,7 +54,7 @@ class KernelCompilationValidationLoop(BaseAgent):
     compilation_checker: BaseAgent,
     fix_agent: BaseAgent,
     debug_agent: Optional[BaseAgent] = None,
-    max_retries: int = 4,
+    max_retries: int = 6,
   ):
     super().__init__(
       name=name,
@@ -353,7 +353,7 @@ kernel_compilation_validation_loop = KernelCompilationValidationLoop(
   compilation_checker=kernel_compilation_checker_for_validation,
   fix_agent=fix_kernel_compilation_agent,
   debug_agent=add_debug_statements_agent,
-  max_retries=6,
+  max_retries=MAX_COMPILATION_RETRIES,
 )
 
 kernel_compilation_summary_agent = CustomLlmAgent(

--- a/MaxKernel/auto_agent/subagents/kernel_writing/prompts/ask_validation_prompt.py
+++ b/MaxKernel/auto_agent/subagents/kernel_writing/prompts/ask_validation_prompt.py
@@ -8,7 +8,7 @@ The kernel implementation has just been completed and saved. The user now needs 
 YOUR TASK:
 Present the user with clear options for what to do next:
 
-1. **Validate & Auto-Fix Compilation**: Run automatic compilation validation with error fixing (up to 4 attempts)
+1. **Validate & Auto-Fix Compilation**: Run automatic compilation validation with error fixing (includes up to 6 automatic error-fixing attempts; you can ask me to change this limit at any time)
 2. **Generate Tests**: Skip validation and proceed directly to test generation
 3. **Something Else**: Ask a question or perform another action
 

--- a/MaxKernel/auto_agent/subagents/profiling/agent.py
+++ b/MaxKernel/auto_agent/subagents/profiling/agent.py
@@ -118,13 +118,22 @@ summarize_profile_agent = SummarizeProfileAgent(
   ),
   output_key="profiling_summary",
   include_contents="none",
-  tools=[
-    offline_tools.load_xplane_and_query,
-    offline_tools.get_hlo_dump,
-    offline_tools.create_chart_from_xplane,
-    offline_tools.get_overview_page_metrics,
-    vertex_ai_rag_tool,
-  ],
+  tools=(
+    [
+      offline_tools.load_xplane_and_query,
+      offline_tools.get_hlo_dump,
+      offline_tools.create_chart_from_xplane,
+      offline_tools.get_overview_page_metrics,
+      vertex_ai_rag_tool,
+    ]
+    if vertex_ai_rag_tool
+    else [
+      offline_tools.load_xplane_and_query,
+      offline_tools.get_hlo_dump,
+      offline_tools.create_chart_from_xplane,
+      offline_tools.get_overview_page_metrics,
+    ]
+  ),
 )
 
 # Main profiling orchestrator agent

--- a/MaxKernel/hitl_agent/agent.py
+++ b/MaxKernel/hitl_agent/agent.py
@@ -31,7 +31,11 @@ from hitl_agent.subagents.testing import (
   unified_test_agent,
   validated_test_generation_agent,
 )
-from hitl_agent.tools.tools import filesystem_tool_r, set_working_directory
+from hitl_agent.tools.tools import (
+  filesystem_tool_r,
+  set_working_directory,
+  set_max_compilation_retries,
+)
 
 # Root orchestration agent
 root_agent = CustomLlmAgent(
@@ -58,6 +62,7 @@ root_agent = CustomLlmAgent(
   tools=[
     filesystem_tool_r,
     set_working_directory,
+    set_max_compilation_retries,
   ],  # Read-only access - orchestrator delegates writes to sub-agents
   instruction=interactive_prompt.PROMPT,
   description="Orchestrates the human-in-the-loop kernel generation process with GPU to JAX conversion capability.",

--- a/MaxKernel/hitl_agent/agent.py
+++ b/MaxKernel/hitl_agent/agent.py
@@ -31,7 +31,7 @@ from hitl_agent.subagents.testing import (
   unified_test_agent,
   validated_test_generation_agent,
 )
-from hitl_agent.tools.tools import filesystem_tool_r
+from hitl_agent.tools.tools import filesystem_tool_r, set_working_directory
 
 # Root orchestration agent
 root_agent = CustomLlmAgent(
@@ -56,7 +56,8 @@ root_agent = CustomLlmAgent(
     autotune_agent,  # Step 7: Auto-tune kernel
   ],
   tools=[
-    filesystem_tool_r
+    filesystem_tool_r,
+    set_working_directory,
   ],  # Read-only access - orchestrator delegates writes to sub-agents
   instruction=interactive_prompt.PROMPT,
   description="Orchestrates the human-in-the-loop kernel generation process with GPU to JAX conversion capability.",

--- a/MaxKernel/hitl_agent/config.py
+++ b/MaxKernel/hitl_agent/config.py
@@ -12,6 +12,7 @@ WORKDIR = os.environ.get("WORKDIR", os.path.dirname(os.path.abspath(__file__)))
 TPU_VERSION = os.environ.get("TPU_VERSION", "")
 RAG_CORPUS = os.environ.get("RAG_CORPUS", "")
 INCLUDE_THOUGHTS = os.environ.get("INCLUDE_THOUGHTS", "true").lower() == "true"
+MAX_COMPILATION_RETRIES = int(os.environ.get("MAX_COMPILATION_RETRIES", "6"))
 
 # Model configuration
 model_config = types.GenerateContentConfig(

--- a/MaxKernel/hitl_agent/prompts/interactive_prompt.py
+++ b/MaxKernel/hitl_agent/prompts/interactive_prompt.py
@@ -42,9 +42,11 @@ Your primary responsibility is to understand the user's request and route to the
 
     * **If the request is to CHANGE/SET the workspace or working directory**:
         * **Action**: Call `set_working_directory` tool with the absolute path.
+        * **Note**: Set `persist=True` ONLY if the user explicitly asks to persist, save, or make the change permanent. Otherwise, leave it as `False` (default).
 
     * **If the request is to CHANGE/SET the maximum compilation retries**:
         * **Action**: Call `set_max_compilation_retries` tool with the integer value.
+        * **Note**: Set `persist=True` ONLY if the user explicitly asks to persist, save, or make the change permanent. Otherwise, leave it as `False` (default).
 
     * **If the request is simple explanation** (like "What is a TPU?"):
         * **Action**: Delegate to `ExplanationAgent`.

--- a/MaxKernel/hitl_agent/prompts/interactive_prompt.py
+++ b/MaxKernel/hitl_agent/prompts/interactive_prompt.py
@@ -11,10 +11,11 @@ You are an expert orchestrator for Pallas kernel generation. Your goal is to und
 
 1.  **Filesystem Tool (Read-Only)**: You have a `filesystem_tool` that can **only read and list files** - you cannot write files. All file writing must be delegated to the appropriate sub-agents. Assume that all files you need to read are located in {workdir}. For example, if the user asks to read file `script.py`, you should call the tool with the path `{workdir}/script.py`.
 2.  **Set Working Directory Tool**: You have a `set_working_directory` tool that can update the active workspace/working directory path for the session. Use this tool when the user requests to switch, set, or change the active working directory or workspace folder.
-3.  **Specialist Sub-Agents**: You have a team of sub-agents you can delegate tasks to:
+3.  **Set Max Compilation Retries Tool**: You have a `set_max_compilation_retries` tool that can update the maximum number of compilation validation and auto-fixing attempts. Use this tool when the user requests to set or change the maximum compilation retries or fixing attempts count.
+4.  **Specialist Sub-Agents**: You have a team of sub-agents you can delegate tasks to:
     * **PlanKernelAgent**: Creates or revises optimization plans for Pallas kernels. Automatically presents plans to the user with approval options. Use for both new plans ("optimize X") and revisions ("change Y in the plan").
     * **ImplementKernelAgent**: Implements a Pallas kernel following an approved plan. Use ONLY after user approves the plan. Automatically asks the user about validation options after completion.
-    * **ValidateKernelCompilationAgent**: Validates kernel compilation with automatic error fixing and debugging (up to 4 attempts). Use when user requests validation or wants to check compilation.
+    * **ValidateKernelCompilationAgent**: Validates kernel compilation with automatic error fixing and debugging (up to 6 attempts by default; the user can ask you to change this limit). Use when user requests validation or wants to check compilation.
     * **ExplanationAgent**: Explains TPU or Pallas concepts.
     * **GenerateTestFileAgent**: Generates a comprehensive pytest test file with compilation, correctness, and performance tests for kernel files.
     * **UnifiedTestAgent**: Executes the generated pytest test file on TPU and provides comprehensive results including full tracebacks. Automatically manages server lifecycle (starts/stops TPU and eval servers as needed).
@@ -35,11 +36,15 @@ Your primary responsibility is to understand the user's request and route to the
     * Is it profiling? (e.g., "Profile the kernel", "What are the bottlenecks?")
     * Is it GPU conversion? (e.g., "Convert CUDA to JAX", "Write JAX from PyTorch")
     * Is it setting/changing the workspace or working directory? (e.g., "Change working directory to /path/to/folder", "Set workspace folder to Y")
+    * Is it changing the maximum compilation retries or attempts? (e.g., "Set max retries to 8", "Change max fixing attempts to 10")
 
 2.  **Execute the Plan**:
 
     * **If the request is to CHANGE/SET the workspace or working directory**:
         * **Action**: Call `set_working_directory` tool with the absolute path.
+
+    * **If the request is to CHANGE/SET the maximum compilation retries**:
+        * **Action**: Call `set_max_compilation_retries` tool with the integer value.
 
     * **If the request is simple explanation** (like "What is a TPU?"):
         * **Action**: Delegate to `ExplanationAgent`.

--- a/MaxKernel/hitl_agent/prompts/interactive_prompt.py
+++ b/MaxKernel/hitl_agent/prompts/interactive_prompt.py
@@ -10,7 +10,8 @@ You are an expert orchestrator for Pallas kernel generation. Your goal is to und
 ### Your Capabilities
 
 1.  **Filesystem Tool (Read-Only)**: You have a `filesystem_tool` that can **only read and list files** - you cannot write files. All file writing must be delegated to the appropriate sub-agents. Assume that all files you need to read are located in {workdir}. For example, if the user asks to read file `script.py`, you should call the tool with the path `{workdir}/script.py`.
-2.  **Specialist Sub-Agents**: You have a team of sub-agents you can delegate tasks to:
+2.  **Set Working Directory Tool**: You have a `set_working_directory` tool that can update the active workspace/working directory path for the session. Use this tool when the user requests to switch, set, or change the active working directory or workspace folder.
+3.  **Specialist Sub-Agents**: You have a team of sub-agents you can delegate tasks to:
     * **PlanKernelAgent**: Creates or revises optimization plans for Pallas kernels. Automatically presents plans to the user with approval options. Use for both new plans ("optimize X") and revisions ("change Y in the plan").
     * **ImplementKernelAgent**: Implements a Pallas kernel following an approved plan. Use ONLY after user approves the plan. Automatically asks the user about validation options after completion.
     * **ValidateKernelCompilationAgent**: Validates kernel compilation with automatic error fixing and debugging (up to 4 attempts). Use when user requests validation or wants to check compilation.
@@ -33,8 +34,12 @@ Your primary responsibility is to understand the user's request and route to the
     * Is it test execution? (e.g., "Run the tests", "Test the kernels")
     * Is it profiling? (e.g., "Profile the kernel", "What are the bottlenecks?")
     * Is it GPU conversion? (e.g., "Convert CUDA to JAX", "Write JAX from PyTorch")
+    * Is it setting/changing the workspace or working directory? (e.g., "Change working directory to /path/to/folder", "Set workspace folder to Y")
 
 2.  **Execute the Plan**:
+
+    * **If the request is to CHANGE/SET the workspace or working directory**:
+        * **Action**: Call `set_working_directory` tool with the absolute path.
 
     * **If the request is simple explanation** (like "What is a TPU?"):
         * **Action**: Delegate to `ExplanationAgent`.

--- a/MaxKernel/hitl_agent/subagents/kernel_writing/agent.py
+++ b/MaxKernel/hitl_agent/subagents/kernel_writing/agent.py
@@ -15,7 +15,7 @@ from hitl_agent.callbacks import (
   load_single_kernel_to_state,
   save_kernel_and_plan_paths,
 )
-from hitl_agent.config import model_config, thinking_planner
+from hitl_agent.config import model_config, thinking_planner, MAX_COMPILATION_RETRIES
 from hitl_agent.constants import MODEL_NAME
 from hitl_agent.custom_types import CustomLlmAgent
 from hitl_agent.subagents.kernel_writing.kernel_compilation import (
@@ -41,7 +41,7 @@ class KernelCompilationValidationLoop(BaseAgent):
   compilation_checker: Optional[BaseAgent] = None
   fix_agent: Optional[BaseAgent] = None
   debug_agent: Optional[BaseAgent] = None
-  max_retries: int = 4
+  max_retries: int = 6
 
   def __init__(
     self,
@@ -49,7 +49,7 @@ class KernelCompilationValidationLoop(BaseAgent):
     compilation_checker: BaseAgent,
     fix_agent: BaseAgent,
     debug_agent: Optional[BaseAgent] = None,
-    max_retries: int = 4,
+    max_retries: int = 6,
   ):
     super().__init__(
       name=name,
@@ -372,7 +372,7 @@ kernel_compilation_validation_loop = KernelCompilationValidationLoop(
   compilation_checker=kernel_compilation_checker_for_validation,
   fix_agent=fix_kernel_compilation_agent,
   debug_agent=add_debug_statements_agent,
-  max_retries=4,
+  max_retries=MAX_COMPILATION_RETRIES,
 )
 
 kernel_compilation_summary_agent = CustomLlmAgent(

--- a/MaxKernel/hitl_agent/subagents/kernel_writing/prompts/ask_validation_prompt.py
+++ b/MaxKernel/hitl_agent/subagents/kernel_writing/prompts/ask_validation_prompt.py
@@ -8,7 +8,7 @@ The kernel implementation has just been completed and saved. The user now needs 
 YOUR TASK:
 Present the user with clear options for what to do next:
 
-1. **Validate & Auto-Fix Compilation**: Run automatic compilation validation with error fixing (up to 4 attempts)
+1. **Validate & Auto-Fix Compilation**: Run automatic compilation validation with error fixing (includes up to 6 automatic error-fixing attempts; you can ask me to change this limit at any time)
 2. **Generate Tests**: Skip validation and proceed directly to test generation
 3. **Something Else**: Ask a question or perform another action
 

--- a/MaxKernel/hitl_agent/tools/filesystem_tools.py
+++ b/MaxKernel/hitl_agent/tools/filesystem_tools.py
@@ -1,0 +1,40 @@
+"""Filesystem tools configuration for the HITL agent."""
+
+import os
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+from mcp import StdioServerParameters
+
+from hitl_agent.config import WORKDIR
+
+# Read-only filesystem tool for orchestration agent (no write access)
+filesystem_tool_r = MCPToolset(
+  connection_params=StdioConnectionParams(
+    server_params=StdioServerParameters(
+      command="npx",
+      args=[
+        "-y",  # Argument for npx to auto-confirm install
+        "@modelcontextprotocol/server-filesystem@0.5.1",
+        os.path.abspath(WORKDIR),
+      ],
+    ),
+  ),
+  # Optional: Filter which tools from the MCP server are exposed
+  tool_filter=["list_directory", "read_file"],
+)
+
+# Read-write filesystem tool for sub-agents
+filesystem_tool_rw = MCPToolset(
+  connection_params=StdioConnectionParams(
+    server_params=StdioServerParameters(
+      command="npx",
+      args=[
+        "-y",  # Argument for npx to auto-confirm install
+        "@modelcontextprotocol/server-filesystem@0.5.1",
+        os.path.abspath(WORKDIR),
+      ],
+    ),
+  ),
+  # Optional: Filter which tools from the MCP server are exposed
+  tool_filter=["list_directory", "read_file", "write_file"],
+)

--- a/MaxKernel/hitl_agent/tools/retries_tool.py
+++ b/MaxKernel/hitl_agent/tools/retries_tool.py
@@ -21,9 +21,7 @@ async def set_max_compilation_retries_fn(retries: int, tool_context: ToolContext
 
   # Update in-memory config variables
   import hitl_agent.config as hitl_cfg
-  import auto_agent.config as auto_cfg
   hitl_cfg.MAX_COMPILATION_RETRIES = retries
-  auto_cfg.MAX_COMPILATION_RETRIES = retries
   os.environ["MAX_COMPILATION_RETRIES"] = str(retries)
 
   # Update .env file
@@ -51,12 +49,6 @@ async def set_max_compilation_retries_fn(retries: int, tool_context: ToolContext
     hitl_loop.max_retries = retries
   except Exception as e:
     logging.warning(f"Could not update hitl_loop max_retries: {e}")
-
-  try:
-    from auto_agent.subagents.kernel_writing.agent import kernel_compilation_validation_loop as auto_loop
-    auto_loop.max_retries = retries
-  except Exception as e:
-    logging.warning(f"Could not update auto_loop max_retries: {e}")
 
   return f"Successfully updated maximum compilation retries to: {retries}"
 

--- a/MaxKernel/hitl_agent/tools/retries_tool.py
+++ b/MaxKernel/hitl_agent/tools/retries_tool.py
@@ -1,0 +1,64 @@
+"""Tool for dynamically updating the max compilation retries setting."""
+
+import logging
+import os
+from google.adk.tools import FunctionTool, ToolContext
+
+
+async def set_max_compilation_retries_fn(retries: int, tool_context: ToolContext) -> str:
+  """Set the maximum number of compilation validation and auto-fixing attempts.
+
+  Args:
+      retries: The maximum number of attempts (must be positive).
+
+  Returns:
+      A string containing the operation result description:
+      - If successful: "Successfully updated maximum compilation retries to: <retries>"
+      - If failed: "Error: The number of retries must be a positive integer."
+  """
+  if retries <= 0:
+    return "Error: The number of retries must be a positive integer."
+
+  # Update in-memory config variables
+  import hitl_agent.config as hitl_cfg
+  import auto_agent.config as auto_cfg
+  hitl_cfg.MAX_COMPILATION_RETRIES = retries
+  auto_cfg.MAX_COMPILATION_RETRIES = retries
+  os.environ["MAX_COMPILATION_RETRIES"] = str(retries)
+
+  # Update .env file
+  try:
+    env_path = ".env"
+    if os.path.exists(env_path):
+      with open(env_path, "r") as f:
+        lines = f.readlines()
+      with open(env_path, "w") as f:
+        updated = False
+        for line in lines:
+          if line.strip().startswith("MAX_COMPILATION_RETRIES="):
+            f.write(f"MAX_COMPILATION_RETRIES={retries}\n")
+            updated = True
+          else:
+            f.write(line)
+        if not updated:
+          f.write(f"MAX_COMPILATION_RETRIES={retries}\n")
+  except Exception as e:
+    logging.error(f"Failed to update .env: {e}")
+
+  # Update the active validation loops in-memory
+  try:
+    from hitl_agent.subagents.kernel_writing.agent import kernel_compilation_validation_loop as hitl_loop
+    hitl_loop.max_retries = retries
+  except Exception as e:
+    logging.warning(f"Could not update hitl_loop max_retries: {e}")
+
+  try:
+    from auto_agent.subagents.kernel_writing.agent import kernel_compilation_validation_loop as auto_loop
+    auto_loop.max_retries = retries
+  except Exception as e:
+    logging.warning(f"Could not update auto_loop max_retries: {e}")
+
+  return f"Successfully updated maximum compilation retries to: {retries}"
+
+
+set_max_compilation_retries = FunctionTool(set_max_compilation_retries_fn)

--- a/MaxKernel/hitl_agent/tools/retries_tool.py
+++ b/MaxKernel/hitl_agent/tools/retries_tool.py
@@ -5,15 +5,18 @@ import os
 from google.adk.tools import FunctionTool, ToolContext
 
 
-async def set_max_compilation_retries_fn(retries: int, tool_context: ToolContext) -> str:
+async def set_max_compilation_retries_fn(
+    retries: int, tool_context: ToolContext, persist: bool = False
+) -> str:
   """Set the maximum number of compilation validation and auto-fixing attempts.
 
   Args:
       retries: The maximum number of attempts (must be positive).
+      persist: Whether to permanently save this change to the configuration file (default is False).
 
   Returns:
       A string containing the operation result description:
-      - If successful: "Successfully updated maximum compilation retries to: <retries>"
+      - If successful: "Successfully updated maximum compilation retries to: <retries> (persisted: <persist>)"
       - If failed: "Error: The number of retries must be a positive integer."
   """
   if retries <= 0:
@@ -24,24 +27,25 @@ async def set_max_compilation_retries_fn(retries: int, tool_context: ToolContext
   hitl_cfg.MAX_COMPILATION_RETRIES = retries
   os.environ["MAX_COMPILATION_RETRIES"] = str(retries)
 
-  # Update .env file
-  try:
-    env_path = ".env"
-    if os.path.exists(env_path):
-      with open(env_path, "r") as f:
-        lines = f.readlines()
-      with open(env_path, "w") as f:
-        updated = False
-        for line in lines:
-          if line.strip().startswith("MAX_COMPILATION_RETRIES="):
+  # Update .env file if persist is requested
+  if persist:
+    try:
+      env_path = ".env"
+      if os.path.exists(env_path):
+        with open(env_path, "r") as f:
+          lines = f.readlines()
+        with open(env_path, "w") as f:
+          updated = False
+          for line in lines:
+            if line.strip().startswith("MAX_COMPILATION_RETRIES="):
+              f.write(f"MAX_COMPILATION_RETRIES={retries}\n")
+              updated = True
+            else:
+              f.write(line)
+          if not updated:
             f.write(f"MAX_COMPILATION_RETRIES={retries}\n")
-            updated = True
-          else:
-            f.write(line)
-        if not updated:
-          f.write(f"MAX_COMPILATION_RETRIES={retries}\n")
-  except Exception as e:
-    logging.error(f"Failed to update .env: {e}")
+    except Exception as e:
+      logging.error(f"Failed to update .env: {e}")
 
   # Update the active validation loops in-memory
   try:
@@ -50,7 +54,7 @@ async def set_max_compilation_retries_fn(retries: int, tool_context: ToolContext
   except Exception as e:
     logging.warning(f"Could not update hitl_loop max_retries: {e}")
 
-  return f"Successfully updated maximum compilation retries to: {retries}"
+  return f"Successfully updated maximum compilation retries to: {retries} (persisted: {persist})"
 
 
 set_max_compilation_retries = FunctionTool(set_max_compilation_retries_fn)

--- a/MaxKernel/hitl_agent/tools/tools.py
+++ b/MaxKernel/hitl_agent/tools/tools.py
@@ -1,20 +1,17 @@
 """Tool setup for HITL kernel generation agents."""
 
 import logging
-import os
-
 from google.adk.models import LlmRequest
 from google.adk.tools import ToolContext
-from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
-from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
 from google.adk.tools.retrieval.vertex_ai_rag_retrieval import (
   VertexAiRagRetrieval,
 )
-from mcp import StdioServerParameters
 from vertexai.preview import rag
 
-from hitl_agent.config import RAG_CORPUS, WORKDIR
+from hitl_agent.config import RAG_CORPUS
 from hitl_agent.tools.search_api_tool import search_api_tool
+from hitl_agent.tools.workspace_tool import set_working_directory
+from hitl_agent.tools.filesystem_tools import filesystem_tool_r, filesystem_tool_rw
 
 
 # Custom VertexAiRagRetrieval that forces function_declarations mode to avoid
@@ -40,38 +37,6 @@ class CompatibleVertexAiRagRetrieval(VertexAiRagRetrieval):
     )
 
 
-# Read-only filesystem tool for orchestration agent (no write access)
-filesystem_tool_r = MCPToolset(
-  connection_params=StdioConnectionParams(
-    server_params=StdioServerParameters(
-      command="npx",
-      args=[
-        "-y",  # Argument for npx to auto-confirm install
-        "@modelcontextprotocol/server-filesystem@0.5.1",
-        os.path.abspath(WORKDIR),
-      ],
-    ),
-  ),
-  # Optional: Filter which tools from the MCP server are exposed
-  tool_filter=["list_directory", "read_file"],
-)
-
-# Read-write filesystem tool for sub-agents
-filesystem_tool_rw = MCPToolset(
-  connection_params=StdioConnectionParams(
-    server_params=StdioServerParameters(
-      command="npx",
-      args=[
-        "-y",  # Argument for npx to auto-confirm install
-        "@modelcontextprotocol/server-filesystem@0.5.1",
-        os.path.abspath(WORKDIR),
-      ],
-    ),
-  ),
-  # Optional: Filter which tools from the MCP server are exposed
-  tool_filter=["list_directory", "read_file", "write_file"],
-)
-
 # Vertex AI RAG Engine tool
 vertex_ai_rag_tool = None
 if RAG_CORPUS:
@@ -96,4 +61,5 @@ __all__ = [
   "filesystem_tool_rw",
   "vertex_ai_rag_tool",
   "CompatibleVertexAiRagRetrieval",
+  "set_working_directory",
 ]

--- a/MaxKernel/hitl_agent/tools/tools.py
+++ b/MaxKernel/hitl_agent/tools/tools.py
@@ -12,6 +12,7 @@ from hitl_agent.config import RAG_CORPUS
 from hitl_agent.tools.search_api_tool import search_api_tool
 from hitl_agent.tools.workspace_tool import set_working_directory
 from hitl_agent.tools.filesystem_tools import filesystem_tool_r, filesystem_tool_rw
+from hitl_agent.tools.retries_tool import set_max_compilation_retries
 
 
 # Custom VertexAiRagRetrieval that forces function_declarations mode to avoid
@@ -62,4 +63,5 @@ __all__ = [
   "vertex_ai_rag_tool",
   "CompatibleVertexAiRagRetrieval",
   "set_working_directory",
+  "set_max_compilation_retries",
 ]

--- a/MaxKernel/hitl_agent/tools/workspace_tool.py
+++ b/MaxKernel/hitl_agent/tools/workspace_tool.py
@@ -1,0 +1,86 @@
+"""Tool for dynamically updating the active workspace directory."""
+
+import logging
+import os
+from google.adk.tools import FunctionTool, ToolContext
+from google.adk.tools.mcp_tool.mcp_session_manager import MCPSessionManager
+
+import hitl_agent.config as config
+from hitl_agent.tools.filesystem_tools import filesystem_tool_r, filesystem_tool_rw
+
+
+async def set_working_directory_fn(path: str, tool_context: ToolContext) -> str:
+  """Set the active workspace/working directory path for the session.
+
+  All filesystem tools (list_directory, read_file, write_file) will use
+  the new path.
+
+  Args:
+      path: The absolute path of the directory.
+
+  Returns:
+      A string containing the operation result description:
+      - If successful: "Successfully switched working directory to: <abs_path>"
+      - If failed: "Error: Path '<path>' does not exist." or "Error: Path '<path>' is not a directory."
+  """
+  if not os.path.exists(path):
+    return f"Error: Path '{path}' does not exist."
+  if not os.path.isdir(path):
+    return f"Error: Path '{path}' is not a directory."
+
+  abs_path = os.path.abspath(path)
+
+  # Update in-memory config variables
+  config.WORKDIR = abs_path
+  os.environ["WORKDIR"] = abs_path
+
+  # Update .env file
+  try:
+    env_path = ".env"
+    if os.path.exists(env_path):
+      with open(env_path, "r") as f:
+        lines = f.readlines()
+      with open(env_path, "w") as f:
+        updated = False
+        for line in lines:
+          if line.strip().startswith("WORKDIR="):
+            f.write(f'WORKDIR="{abs_path}"\n')
+            updated = True
+          else:
+            f.write(line)
+        if not updated:
+          f.write(f'WORKDIR="{abs_path}"\n')
+  except Exception as e:
+    logging.error(f"Failed to update .env: {e}")
+
+  # Update active filesystem tools
+  # Update read-only filesystem tool
+  params_r = filesystem_tool_r._connection_params
+  server_params_r = getattr(params_r, "server_params", None) or params_r
+  if hasattr(server_params_r, "args") and len(server_params_r.args) >= 2:
+    server_params_r.args[-1] = abs_path
+    await filesystem_tool_r.close()
+    filesystem_tool_r._mcp_session_manager = MCPSessionManager(
+        connection_params=filesystem_tool_r._connection_params,
+        errlog=filesystem_tool_r._errlog,
+        sampling_callback=filesystem_tool_r._sampling_callback,
+        sampling_capabilities=filesystem_tool_r._sampling_capabilities,
+    )
+
+  # Update read-write filesystem tool
+  params_rw = filesystem_tool_rw._connection_params
+  server_params_rw = getattr(params_rw, "server_params", None) or params_rw
+  if hasattr(server_params_rw, "args") and len(server_params_rw.args) >= 2:
+    server_params_rw.args[-1] = abs_path
+    await filesystem_tool_rw.close()
+    filesystem_tool_rw._mcp_session_manager = MCPSessionManager(
+        connection_params=filesystem_tool_rw._connection_params,
+        errlog=filesystem_tool_rw._errlog,
+        sampling_callback=filesystem_tool_rw._sampling_callback,
+        sampling_capabilities=filesystem_tool_rw._sampling_capabilities,
+    )
+
+  return f"Successfully switched working directory to: {abs_path}"
+
+
+set_working_directory = FunctionTool(set_working_directory_fn)

--- a/MaxKernel/hitl_agent/tools/workspace_tool.py
+++ b/MaxKernel/hitl_agent/tools/workspace_tool.py
@@ -9,7 +9,9 @@ import hitl_agent.config as config
 from hitl_agent.tools.filesystem_tools import filesystem_tool_r, filesystem_tool_rw
 
 
-async def set_working_directory_fn(path: str, tool_context: ToolContext) -> str:
+async def set_working_directory_fn(
+    path: str, tool_context: ToolContext, persist: bool = False
+) -> str:
   """Set the active workspace/working directory path for the session.
 
   All filesystem tools (list_directory, read_file, write_file) will use
@@ -17,10 +19,11 @@ async def set_working_directory_fn(path: str, tool_context: ToolContext) -> str:
 
   Args:
       path: The absolute path of the directory.
+      persist: Whether to permanently save this change to the configuration file (default is False).
 
   Returns:
       A string containing the operation result description:
-      - If successful: "Successfully switched working directory to: <abs_path>"
+      - If successful: "Successfully switched working directory to: <abs_path> (persisted: <persist>)"
       - If failed: "Error: Path '<path>' does not exist." or "Error: Path '<path>' is not a directory."
   """
   if not os.path.exists(path):
@@ -34,24 +37,25 @@ async def set_working_directory_fn(path: str, tool_context: ToolContext) -> str:
   config.WORKDIR = abs_path
   os.environ["WORKDIR"] = abs_path
 
-  # Update .env file
-  try:
-    env_path = ".env"
-    if os.path.exists(env_path):
-      with open(env_path, "r") as f:
-        lines = f.readlines()
-      with open(env_path, "w") as f:
-        updated = False
-        for line in lines:
-          if line.strip().startswith("WORKDIR="):
+  # Update .env file if persist is requested
+  if persist:
+    try:
+      env_path = ".env"
+      if os.path.exists(env_path):
+        with open(env_path, "r") as f:
+          lines = f.readlines()
+        with open(env_path, "w") as f:
+          updated = False
+          for line in lines:
+            if line.strip().startswith("WORKDIR="):
+              f.write(f'WORKDIR="{abs_path}"\n')
+              updated = True
+            else:
+              f.write(line)
+          if not updated:
             f.write(f'WORKDIR="{abs_path}"\n')
-            updated = True
-          else:
-            f.write(line)
-        if not updated:
-          f.write(f'WORKDIR="{abs_path}"\n')
-  except Exception as e:
-    logging.error(f"Failed to update .env: {e}")
+    except Exception as e:
+      logging.error(f"Failed to update .env: {e}")
 
   # Update active filesystem tools
   # Update read-only filesystem tool
@@ -80,7 +84,7 @@ async def set_working_directory_fn(path: str, tool_context: ToolContext) -> str:
         sampling_capabilities=filesystem_tool_rw._sampling_capabilities,
     )
 
-  return f"Successfully switched working directory to: {abs_path}"
+  return f"Successfully switched working directory to: {abs_path} (persisted: {persist})"
 
 
 set_working_directory = FunctionTool(set_working_directory_fn)


### PR DESCRIPTION
This PR adds two new features to MaxKernel:

1. It allows the user to ask MaxKernel to set a working directory. Previously MaxKernel defaulted to only working out of the accelerator-agents/MaxKernel directory, which limited it's ability to read and write to kernel files located in other directories. In my testing, this was an inconvenience because I would have to manually copy the optimized kernel over to the directory I wanted to work from when MaxKernel was finished. Now the user can simply ask MaxKernel to work in a specified directory and it will do so; no manual copying needed. I verified this worked in the MaxKernel UI: 
<img width="2814" height="1348" alt="image" src="https://github.com/user-attachments/assets/b4632456-c76f-4060-bedc-f868a19e9484" />

<img width="2792" height="930" alt="image" src="https://github.com/user-attachments/assets/c63235a6-3fdb-4a69-b768-cb5b2ed26968" />

2. It also allows the user to configure the max number of retries MaxKernel works through a compilation error. Currently this is set to 4 for the hitl_agent and 6 for the auto_agent. In my testing, I found that four iterations was fine when asking it to make incremental commits with clear direction, but it was too restrictive when giving it a larger goal of fully optimizing a kernel in which significant code changes might be required. When I asked it to do this, it almost always hit the 4 iteration limit which blocked further progress. For this reason, I have incremented the default iteration limit for the hitl_agent to be 6 (matching the auto_agent) and also added the ability for the user to request this limit be changed if needed. I verified this worked by testing in the MaxKernel UI:
<img width="2104" height="404" alt="image" src="https://github.com/user-attachments/assets/7dba56ef-2bcf-4072-9aba-3b7739ccaf56" />