### PR TITLE
feat: support customizable and per-input absolute/relative tolerances for kernel evaluation

### DIFF
--- a/MaxKernel/evaluation/benchmark.py
+++ b/MaxKernel/evaluation/benchmark.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 from dataclasses import asdict
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from evaluation.custom_types.evaluation_result import EvaluationResult
 from evaluation.evaluation_utils import summarize_results, visualize_speed_up
@@ -28,8 +28,8 @@ def benchmark(
   task_file_name: str = "kernel_task.yaml",
   adapt: Optional[List[str]] = None,
   timeout_seconds: int = 300,
-  atol: float = 1e-3,
-  rtol: float = 1e-3,
+  atol: Optional[Union[float, List[float]]] = None,
+  rtol: Optional[Union[float, List[float]]] = None,
 ):
   """
   Evaluates JAX kernels across a dataset of problems on a remote TPU VM.
@@ -256,14 +256,16 @@ if __name__ == "__main__":
   parser.add_argument(
     "--atol",
     type=float,
-    default=1e-3,
-    help="Absolute tolerance for comparison.",
+    nargs="+",
+    default=None,
+    help="Absolute tolerance for comparison. Can be a single float or list of floats.",
   )
   parser.add_argument(
     "--rtol",
     type=float,
-    default=1e-3,
-    help="Relative tolerance for comparison.",
+    nargs="+",
+    default=None,
+    help="Relative tolerance for comparison. Can be a single float or list of floats.",
   )
   parser.add_argument(
     "--timeout_seconds",
@@ -272,6 +274,14 @@ if __name__ == "__main__":
     help="Maximum time in seconds to wait for execution.",
   )
   args = parser.parse_args()
+
+  atol = args.atol
+  if atol is not None and len(atol) == 1:
+    atol = atol[0]
+
+  rtol = args.rtol
+  if rtol is not None and len(rtol) == 1:
+    rtol = rtol[0]
 
   benchmark(
     local=args.local,
@@ -285,6 +295,6 @@ if __name__ == "__main__":
     task_file_name=args.task_file_name,
     adapt=args.adapt,
     timeout_seconds=args.timeout_seconds,
-    atol=args.atol,
-    rtol=args.rtol,
+    atol=atol,
+    rtol=rtol,
   )

--- a/MaxKernel/evaluation/code_adapter/code_adapter.py
+++ b/MaxKernel/evaluation/code_adapter/code_adapter.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import List, Optional, Union
 
 from google import genai
 
@@ -92,7 +93,12 @@ class CodeAdapter:
     )
 
   def generate_kernel_task(
-    self, task_id: str, description: str, jax_code: str
+    self,
+    task_id: str,
+    description: str,
+    jax_code: str,
+    atol: Optional[Union[float, List[float]]] = None,
+    rtol: Optional[Union[float, List[float]]] = None,
   ) -> KernelTask:
     """
     Generates a KernelTask YAML by extracting the relevant sections
@@ -105,6 +111,8 @@ class CodeAdapter:
       task_id=task_id,
       description=description,
       input_gen_code=input_gen_code,
+      atol=atol,
+      rtol=rtol,
     )
 
     return kernel_task

--- a/MaxKernel/evaluation/custom_types/kernel_task.py
+++ b/MaxKernel/evaluation/custom_types/kernel_task.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional, Union
 
 
 @dataclass
@@ -7,3 +7,5 @@ class KernelTask:
   task_id: str
   description: Optional[str] = None
   input_gen_code: Optional[str] = None
+  atol: Optional[Union[float, List[float]]] = None
+  rtol: Optional[Union[float, List[float]]] = None

--- a/MaxKernel/evaluation/evaluation_utils.py
+++ b/MaxKernel/evaluation/evaluation_utils.py
@@ -65,6 +65,8 @@ def load_kernel_task_from_yaml(yaml_path: str) -> KernelTask:
     task_id=data.get("task_id"),
     description=data.get("description"),
     input_gen_code=data.get("input_gen_code"),
+    atol=data.get("atol"),
+    rtol=data.get("rtol"),
   )
 
 

--- a/MaxKernel/evaluation/examples/dsv4/kernel_task.yaml
+++ b/MaxKernel/evaluation/examples/dsv4/kernel_task.yaml
@@ -43,3 +43,6 @@ input_gen_code: |-
           outputs.append((dynamic_args, static_args))
 
       return outputs
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/harness_code.py
+++ b/MaxKernel/evaluation/harness_code.py
@@ -109,6 +109,8 @@ def main():
       task_data = json.load(f)
 
     input_gen_code = task_data.get("input_gen_code")
+    task_atol = task_data.get("atol")
+    task_rtol = task_data.get("rtol")
 
     if input_gen_code:
       ldict = {}
@@ -168,6 +170,32 @@ def main():
 
       args = tuple(dynamic_args) + tuple(static_args)
       static_argnums = tuple(range(len(dynamic_args), len(args)))
+
+      if isinstance(task_atol, list):
+        if idx < len(task_atol):
+          curr_atol = task_atol[idx]
+        else:
+          curr_atol = task_atol[-1]
+          harness_logs.append(
+              f"atol list length ({len(task_atol)}) is shorter than input "
+              f"count ({len(inputs_list)}). Reusing last atol ({curr_atol}) "
+              f"for input {idx}."
+          )
+      else:
+        curr_atol = float(task_atol) if task_atol is not None else 1e-3
+
+      if isinstance(task_rtol, list):
+        if idx < len(task_rtol):
+          curr_rtol = task_rtol[idx]
+        else:
+          curr_rtol = task_rtol[-1]
+          harness_logs.append(
+              f"rtol list length ({len(task_rtol)}) is shorter than input "
+              f"count ({len(inputs_list)}). Reusing last rtol ({curr_rtol}) "
+              f"for input {idx}."
+          )
+      else:
+        curr_rtol = float(task_rtol) if task_rtol is not None else 1e-3
 
       # 1. Correctness Check
       try:
@@ -237,7 +265,7 @@ def main():
         for b, o in zip(out_base_flat, out_optimized_flat):
           if b.shape != o.shape:
              raise ValueError(f"Shape mismatch: {b.shape} vs {o.shape}")
-          is_correct = is_correct and bool(jnp.allclose(b, o, atol={atol}, rtol={rtol}))
+          is_correct = is_correct and bool(jnp.allclose(b, o, atol=curr_atol, rtol=curr_rtol))
           max_abs_diff = max(max_abs_diff, float(jnp.max(jnp.abs(b - o))))
           max_rel_diff = max(max_rel_diff, float(jnp.max(jnp.abs((b - o) / b))))
       except Exception as e:

--- a/MaxKernel/evaluation/jax_kernel_evaluator.py
+++ b/MaxKernel/evaluation/jax_kernel_evaluator.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from google import genai
 
@@ -24,6 +24,9 @@ from evaluation.harness_code import HARNESS_TEMPLATE
 from evaluation.remote_client.tpu_client import TPUVMClient
 
 logger = logging.getLogger(__name__)  # Get a logger for this module
+
+DEFAULT_ATOL = 1e-3
+DEFAULT_RTOL = 1e-3
 
 
 class JAXKernelEvaluator:
@@ -71,8 +74,8 @@ class JAXKernelEvaluator:
     adapt: Optional[List[str]] = None,
     timeout_seconds: int = 300,  # Default timeout of 5 minutes
     cleanup: bool = True,
-    atol: float = 1e-3,
-    rtol: float = 1e-3,
+    atol: Optional[Union[float, List[float]]] = None,
+    rtol: Optional[Union[float, List[float]]] = None,
   ) -> EvaluationResult:
     """Runs the evaluation pipeline for a given reference and kernel script."""
     if self.local:
@@ -106,8 +109,8 @@ class JAXKernelEvaluator:
     adapt: Optional[List[str]] = None,
     timeout_seconds: int = 300,
     cleanup: bool = True,
-    atol: float = 1e-3,
-    rtol: float = 1e-3,
+    atol: Optional[Union[float, List[float]]] = None,
+    rtol: Optional[Union[float, List[float]]] = None,
   ) -> EvaluationResult:
     """Runs the evaluation pipeline locally on the current machine."""
     # Adapt the provided code and generate kernel task if necessary
@@ -140,8 +143,8 @@ class JAXKernelEvaluator:
       xprof_local = os.path.join(local_base_dir, "xprof_utils.py")
 
       # Build JSON and harness
-      self._build_task_json(task, task_json_local)
-      self._build_harness_code(harness_local, atol, rtol)
+      self._build_task_json(task, task_json_local, atol=atol, rtol=rtol)
+      self._build_harness_code(harness_local)
 
       # Copy reference, optimized code and xprof_utils.py
       shutil.copy(reference_code_path, ref_local)
@@ -227,8 +230,8 @@ class JAXKernelEvaluator:
     adapt: Optional[List[str]] = None,
     timeout_seconds: int = 300,  # Default timeout of 5 minutes
     cleanup: bool = True,
-    atol: float = 1e-3,
-    rtol: float = 1e-3,
+    atol: Optional[Union[float, List[float]]] = None,
+    rtol: Optional[Union[float, List[float]]] = None,
   ) -> EvaluationResult:
     """Runs the evaluation pipeline for a given reference and kernel script.
 
@@ -264,10 +267,10 @@ class JAXKernelEvaluator:
       remote_base_dir_created = False
 
       task = load_kernel_task_from_yaml(task_yaml_path)
-      self._build_task_json(task, task_json_local)
+      self._build_task_json(task, task_json_local, atol=atol, rtol=rtol)
 
       eval_result = EvaluationResult(task_id=task.task_id)
-      self._build_harness_code(harness_local, atol, rtol)
+      self._build_harness_code(harness_local)
 
       xprof_src = os.path.join(os.path.dirname(__file__), "xprof_utils.py")
       files_to_upload = {
@@ -409,33 +412,45 @@ class JAXKernelEvaluator:
       if os.path.exists(task_json_local):
         os.remove(task_json_local)
 
-  def _build_task_json(self, task: KernelTask, local_path: str):
+  def _build_task_json(
+    self,
+    task: KernelTask,
+    local_path: str,
+    atol: Optional[Union[float, List[float]]] = None,
+    rtol: Optional[Union[float, List[float]]] = None,
+  ):
     """Creates a JSON file with task input specifications.
 
     Args:
         task: KernelTask object containing input specifications.
         local_path: Local path to save the JSON file.
+        atol: Evaluator level fallback for atol.
+        rtol: Evaluator level fallback for rtol.
     """
+    effective_atol = (
+      atol if atol is not None else
+      (task.atol if task.atol is not None else DEFAULT_ATOL)
+    )
+    effective_rtol = (
+      rtol if rtol is not None else
+      (task.rtol if task.rtol is not None else DEFAULT_RTOL)
+    )
+
     task_info = {
       "input_gen_code": task.input_gen_code,
+      "atol": effective_atol,
+      "rtol": effective_rtol,
     }
     with open(local_path, "w") as f:
       json.dump(task_info, f)
 
-  def _build_harness_code(
-    self, local_path: str, atol: float = 1e-3, rtol: float = 1e-3
-  ):
+  def _build_harness_code(self, local_path: str):
     """Creates the remote evaluation harness script locally.
 
     Args:
         local_path: Local path to save the harness script.
-        atol: Absolute tolerance for correctness check.
-        rtol: Relative tolerance for correctness check.
     """
     harness_content = HARNESS_TEMPLATE.template
-    harness_content = harness_content.replace("{atol}", str(atol))
-    harness_content = harness_content.replace("{rtol}", str(rtol))
-
     with open(local_path, "w", encoding="utf-8") as f_write:
       f_write.write(harness_content)
 
@@ -595,14 +610,16 @@ if __name__ == "__main__":
   parser.add_argument(
     "--atol",
     type=float,
-    default=1e-3,
-    help="Absolute tolerance for correctness check.",
+    nargs="+",
+    default=None,
+    help="Absolute tolerance for correctness check. Can be a single float or list of floats.",
   )
   parser.add_argument(
     "--rtol",
     type=float,
-    default=1e-3,
-    help="Relative tolerance for correctness check.",
+    nargs="+",
+    default=None,
+    help="Relative tolerance for correctness check. Can be a single float or list of floats.",
   )
 
   args = parser.parse_args()
@@ -623,6 +640,14 @@ if __name__ == "__main__":
     remote_base_dir=args.remote_base_dir,
   )
 
+  atol = args.atol
+  if atol is not None and len(atol) == 1:
+    atol = atol[0]
+
+  rtol = args.rtol
+  if rtol is not None and len(rtol) == 1:
+    rtol = rtol[0]
+
   evaluator.evaluate(
     reference_code_path=args.reference_code_path,
     optimized_code_path=args.optimized_code_path,
@@ -630,6 +655,6 @@ if __name__ == "__main__":
     adapt=args.adapt,
     timeout_seconds=args.timeout_seconds,
     cleanup=args.cleanup,
-    atol=args.atol,
-    rtol=args.rtol,
+    atol=atol,
+    rtol=rtol,
   )

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/10p_Sparse_MoE/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/10p_Sparse_MoE/kernel_task.yaml
@@ -31,3 +31,6 @@ input_gen_code: |-
       static_args = [CONFIG['num_experts_per_tok']]
 
       return dynamic_args, static_args
+
+rtol: 0.1
+atol: 0.1

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/11p_Megablox_GMM/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/11p_Megablox_GMM/kernel_task.yaml
@@ -35,3 +35,6 @@ input_gen_code: |-
       static_args = [max_expert_size]
 
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/12p_RMSNorm/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/12p_RMSNorm/kernel_task.yaml
@@ -16,3 +16,6 @@ input_gen_code: |-
       x = jax.random.normal(k1, (batch, seq_len, emb_dim), dtype=dtype)
       scale = jax.random.normal(k2, (emb_dim,), dtype=dtype) * 0.1 + 1.0
       return [x, scale], [epsilon]
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/13p_Cross_Entropy/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/13p_Cross_Entropy/kernel_task.yaml
@@ -23,3 +23,6 @@ input_gen_code: |-
       dynamic_args = [hidden, weight, labels]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/14p_Ragged_Dot/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/14p_Ragged_Dot/kernel_task.yaml
@@ -23,3 +23,6 @@ input_gen_code: |-
       dynamic_args = [x, weights]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/15p_RetNet_Retention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/15p_RetNet_Retention/kernel_task.yaml
@@ -27,3 +27,6 @@ input_gen_code: |-
       dynamic_args = [query, key_val, value]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/16p_Mamba2_SSD/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/16p_Mamba2_SSD/kernel_task.yaml
@@ -27,3 +27,6 @@ input_gen_code: |-
       dynamic_args = [query, key, value, A_log]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.05

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/17p_Triangle_Multiplication/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/17p_Triangle_Multiplication/kernel_task.yaml
@@ -28,3 +28,6 @@ input_gen_code: |-
       dynamic_args = [pair_act, mask, left_proj, right_proj, left_gate, right_gate, center_scale, out_proj, out_gate]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/18k_Conv2D_ReLU_BiasAdd/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/18k_Conv2D_ReLU_BiasAdd/kernel_task.yaml
@@ -23,3 +23,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, conv_bias, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/19k_Matmul_Subtract_Multiply_ReLU/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/19k_Matmul_Subtract_Multiply_ReLU/kernel_task.yaml
@@ -21,3 +21,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = [subtract_value, multiply_value]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/1p_Flash_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/1p_Flash_Attention/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [query, key_t, value]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.05

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/20k_Gemm_Multiply_LeakyReLU/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/20k_Gemm_Multiply_LeakyReLU/kernel_task.yaml
@@ -19,3 +19,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/21k_Gemm_Divide_Sum_Scaling/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/21k_Gemm_Divide_Sum_Scaling/kernel_task.yaml
@@ -21,3 +21,6 @@ input_gen_code: |-
       static_args = [scaling_factor]
 
       return dynamic_args, static_args
+
+rtol: 0.1
+atol: 0.1

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/22k_Conv2d_InstanceNorm_Divide/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/22k_Conv2d_InstanceNorm_Divide/kernel_task.yaml
@@ -25,3 +25,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, conv_bias, in_weight, in_bias]
       static_args = [divide_by_value]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/23k_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/23k_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp/kernel_task.yaml
@@ -17,3 +17,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/24k_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/24k_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish/kernel_task.yaml
@@ -21,3 +21,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = [scale_factor, clamp_min, clamp_max]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/25k_Conv3d_GroupNorm_Mean/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/25k_Conv3d_GroupNorm_Mean/kernel_task.yaml
@@ -19,3 +19,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, conv_bias, gamma, beta]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/26k_BMM_InstanceNorm_Sum_ResidualAdd_Multiply/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/26k_BMM_InstanceNorm_Sum_ResidualAdd_Multiply/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [x, y, bmm_weight, bmm_bias, in_weight, in_bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/27k_Matmul_Mish_Mish/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/27k_Matmul_Mish_Mish/kernel_task.yaml
@@ -17,3 +17,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/28k_ConvTranspose3d_LayerNorm_GELU_Scaling/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/28k_ConvTranspose3d_LayerNorm_GELU_Scaling/kernel_task.yaml
@@ -29,3 +29,6 @@ input_gen_code: |-
       static_args = [stride_val, padding_val, kernel_size_val, eps_val, scaling_factor_val]
 
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.05

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/29k_Matmul_Swish_Sum_GroupNorm/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/29k_Matmul_Swish_Sum_GroupNorm/kernel_task.yaml
@@ -20,3 +20,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias, gn_weight, gn_bias]
       static_args = [num_groups, out_features]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/2p_GQA_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/2p_GQA_Attention/kernel_task.yaml
@@ -27,3 +27,6 @@ input_gen_code: |-
       dynamic_args = [query, key_t, value]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.05
+atol: 0.05

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/30k_Matmul_Scaling_ResidualAdd/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/30k_Matmul_Scaling_ResidualAdd/kernel_task.yaml
@@ -17,3 +17,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/31k_Gemm_BatchNorm_GELU_ReLU/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/31k_Gemm_BatchNorm_GELU_ReLU/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [x, gemm_weight, gemm_bias, bn_weight, bn_bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.05

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/32k_Gemm_Sigmoid_LogSumExp/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/32k_Gemm_Sigmoid_LogSumExp/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [x, w1, b1, w2, b2]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/33k_Conv3d_Mish_Tanh/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/33k_Conv3d_Mish_Tanh/kernel_task.yaml
@@ -21,3 +21,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/34k_Conv2d_Activation_BatchNorm/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/34k_Conv2d_Activation_BatchNorm/kernel_task.yaml
@@ -24,3 +24,6 @@ input_gen_code: |-
       dynamic_args = [x, conv_weight, conv_bias, bn_weight, bn_bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.1

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/35k_Gemm_Scaling_Hardtanh_GELU/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/35k_Gemm_Scaling_Hardtanh_GELU/kernel_task.yaml
@@ -33,3 +33,6 @@ input_gen_code: |-
       static_args = [scaling_factor, hardtanh_min, hardtanh_max]
 
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/36k_Matmul_Sigmoid_Sum/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/36k_Matmul_Sigmoid_Sum/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/37k_Matmul_Swish_Scaling/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/37k_Matmul_Swish_Scaling/kernel_task.yaml
@@ -19,3 +19,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/38k_Matmul_Dropout_Softmax/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/38k_Matmul_Dropout_Softmax/kernel_task.yaml
@@ -19,3 +19,6 @@ input_gen_code: |-
       static_args = []
 
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/39k_Conv2d_GELU_GlobalAvgPool/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/39k_Conv2d_GELU_GlobalAvgPool/kernel_task.yaml
@@ -16,3 +16,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/3p_MLA_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/3p_MLA_Attention/kernel_task.yaml
@@ -39,3 +39,6 @@ input_gen_code: |-
       dynamic_args = [x, q_down, q_up, kv_down, k_up, v_up, o_proj]
       static_args = [H, nope, rope, vd, kvl, C['rope_theta']]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.05

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/40k_Gemm_GroupNorm_Min_BiasAdd/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/40k_Gemm_GroupNorm_Min_BiasAdd/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, linear_bias, gn_weight, gn_bias, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/41k_Gemm_Add_ReLU/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/41k_Gemm_Add_ReLU/kernel_task.yaml
@@ -19,3 +19,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/42k_Gemm_Max_Subtract_GELU/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/42k_Gemm_Max_Subtract_GELU/kernel_task.yaml
@@ -20,3 +20,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/43k_Gemm_BatchNorm_Scaling_Softmax/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/43k_Gemm_BatchNorm_Scaling_Softmax/kernel_task.yaml
@@ -23,3 +23,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias, bn_scale, bn_bias, bn_mean, bn_var, scale]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/44k_Matmul_Divide_GELU/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/44k_Matmul_Divide_GELU/kernel_task.yaml
@@ -21,3 +21,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = [divisor]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/45k_Gemm_GroupNorm_Swish_Multiply_Swish/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/45k_Gemm_GroupNorm_Swish_Multiply_Swish/kernel_task.yaml
@@ -24,3 +24,6 @@ input_gen_code: |-
       static_args = [num_groups, out_features]
 
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/46k_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/46k_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp/kernel_task.yaml
@@ -21,3 +21,6 @@ input_gen_code: |-
       dynamic_args = [x, conv_weight, conv_bias, gn_weight, gn_bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/47k_Matmul_Add_Swish_Tanh_GELU_Hardtanh/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/47k_Matmul_Add_Swish_Tanh_GELU_Hardtanh/kernel_task.yaml
@@ -20,3 +20,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias, add_value]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/48k_Matmul_BatchNorm_BiasAdd_Divide_Swish/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/48k_Matmul_BatchNorm_BiasAdd_Divide_Swish/kernel_task.yaml
@@ -22,3 +22,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, linear_bias, bn_scale, bn_bias, bn_mean, bn_var, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/49k_Matmul_AvgPool_GELU_Scale_Max/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/49k_Matmul_AvgPool_GELU_Scale_Max/kernel_task.yaml
@@ -22,3 +22,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = [pool_kernel_size, scale_factor]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/4p_Sparse_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/4p_Sparse_Attention/kernel_task.yaml
@@ -28,3 +28,6 @@ input_gen_code: |-
       dynamic_args = [q, k, v]
       static_args = [S, H_q, H_kv, D]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/50k_Matmul_GELU_Softmax/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/50k_Matmul_GELU_Softmax/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [x, weight, bias]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/5p_Flex_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/5p_Flex_Attention/kernel_task.yaml
@@ -28,3 +28,6 @@ input_gen_code: |-
       dynamic_args = [q, k, v, rel_pos_bias]
       static_args = [D, S]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/6p_Paged_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/6p_Paged_Attention/kernel_task.yaml
@@ -42,3 +42,6 @@ input_gen_code: |-
       static_args = [num_seqs, num_q_heads, num_kv_heads, head_dim, max_seq_len_derived]
 
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/7p_Ragged_Paged_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/7p_Ragged_Paged_Attention/kernel_task.yaml
@@ -43,3 +43,6 @@ input_gen_code: |-
       dynamic_args = [q, kv_pages, kv_lens, page_indices, cu_q_lens, num_seqs]
       static_args = [head_dim, max_num_seqs, max_num_batched_tokens]
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/8p_GEMM/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/8p_GEMM/kernel_task.yaml
@@ -18,3 +18,6 @@ input_gen_code: |-
       dynamic_args = [A, B]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.01
+atol: 0.01

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/9p_SwiGLU_MLP/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/9p_SwiGLU_MLP/kernel_task.yaml
@@ -27,3 +27,6 @@ input_gen_code: |-
       dynamic_args = [x, gate, up, down]
       static_args = []
       return dynamic_args, static_args
+
+rtol: 0.1
+atol: 0.1


### PR DESCRIPTION
This PR enhances the JAX kernel evaluation framework by introducing support for customizable and **per-input absolute (`atol`) and relative (`rtol`) tolerances**. Previously, evaluation tolerances were hardcoded or limited to single scalar float values (defaulting to `1e-3`) via string replacement in the harness template.

With this change, tolerances can be specified:
1. **Per-task in YAML definitions** (`kernel_task.yaml`).
2. **Via CLI arguments** (`--atol`, `--rtol`) as single scalars or lists of floats (this will override values from the yaml file). 
3. **Programmatically** through `JAXKernelEvaluator` and `benchmark.py`.

---

#### **Key Changes**

* **Core Harness & Per-Input Tolerance Resolution ([harness_code.py](file:///usr/local/google/home/shangkunwang/kernel_agent/accelerator-agents/MaxKernel/evaluation/harness_code.py))**
  * Replaced static `{atol}`/`{rtol}` template string substitution with JSON-driven configuration loading (`task_info["atol"]` / `task_info["rtol"]`).

* **Evaluator & Benchmark Pipeline ([jax_kernel_evaluator.py](file:///usr/local/google/home/shangkunwang/kernel_agent/accelerator-agents/MaxKernel/evaluation/jax_kernel_evaluator.py), [benchmark.py](file:///usr/local/google/home/shangkunwang/kernel_agent/accelerator-agents/MaxKernel/evaluation/benchmark.py))**
  * Updated `atol` and `rtol` type annotations across `evaluate()`, `_evaluate_local()`, and `_evaluate_remote()` from `float` to `Optional[Union[float, List[float]]]`.

* **Task Data Model & Code Adapter ([kernel_task.py](file:///usr/local/google/home/shangkunwang/kernel_agent/accelerator-agents/MaxKernel/evaluation/custom_types/kernel_task.py), [evaluation_utils.py](file:///usr/local/google/home/shangkunwang/kernel_agent/accelerator-agents/MaxKernel/evaluation/evaluation_utils.py), [code_adapter.py](file:///usr/local/google/home/shangkunwang/kernel_agent/accelerator-agents/MaxKernel/evaluation/code_adapter/code_adapter.py))**
  * Extended the `KernelTask` dataclass to include optional `atol` and `rtol` fields (`Optional[Union[float, List[float]]] = None`).
  * Updated `load_kernel_task_from_yaml` and `CodeAdapter.generate_kernel_task` to parse and propagate task-level tolerance configurations.

* **Benchmark Dataset Updates (`kernel_task.yaml` files)**
  * Added explicit `atol` and `rtol` thresholds across all 50 evaluation task YAMLs in `MaxKernel/evaluation/jaxbench_adapted_dataset/` and `MaxKernel/evaluation/examples/dsv4/`, tailored to each task's numerical stability requirements 