### PR TITLE
fix: update the human optimized code in JaxBench and the reference code so they match each other

### DIFF
--- a/JAXBench/benchmark/1p_Flash_Attention/optimized.py
+++ b/JAXBench/benchmark/1p_Flash_Attention/optimized.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Flash Attention TPU kernel."""
-from __future__ import annotations
 
 import dataclasses
 import functools

--- a/JAXBench/benchmark/2p_GQA_Attention/optimized.py
+++ b/JAXBench/benchmark/2p_GQA_Attention/optimized.py
@@ -14,8 +14,6 @@
 
 """Implementation of Sparse Flash Attention, a.k.a. "Splash" attention."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Mapping
 import dataclasses
 import enum
@@ -2584,6 +2582,7 @@ def workload(query, key, value):
     v = value.transpose(0, 2, 1, 3)   # (B, H_kv, S, D)
 
     B, H_q, S, D = q.shape
+    q = q * (D ** -0.5)
     H_kv = v.shape[1]
     heads_per_group = H_q // H_kv
     mask = mask_lib.CausalMask(shape=(S, S))

--- a/JAXBench/benchmark/3p_MLA_Attention/baseline.py
+++ b/JAXBench/benchmark/3p_MLA_Attention/baseline.py
@@ -28,11 +28,11 @@ def _compute_rope(head_dim, seq_len, theta, dtype):
 
 
 def _apply_rope(x, cos, sin):
-    x1, x2 = x[..., ::2], x[..., 1::2]
+    d = x.shape[-1]
+    x1, x2 = x[..., :d // 2], x[..., d // 2:]
     cos = cos[None, :, None, :]
     sin = sin[None, :, None, :]
-    rotated = jnp.stack([x1 * cos - x2 * sin, x1 * sin + x2 * cos], axis=-1)
-    return rotated.reshape(x.shape)
+    return jnp.concatenate([x1 * cos - x2 * sin, x2 * cos + x1 * sin], axis=-1)
 
 
 def create_inputs(dtype=jnp.bfloat16):

--- a/JAXBench/benchmark/3p_MLA_Attention/optimized.py
+++ b/JAXBench/benchmark/3p_MLA_Attention/optimized.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Flash Attention TPU kernel."""
-from __future__ import annotations
 
 import dataclasses
 import functools

--- a/JAXBench/benchmark/4p_Sparse_Attention/baseline.py
+++ b/JAXBench/benchmark/4p_Sparse_Attention/baseline.py
@@ -23,13 +23,14 @@ def create_inputs(dtype=jnp.bfloat16):
     """Returns (q, k, v) tensors in [num_heads, seq_len, head_dim] layout."""
     key = jax.random.key(42)
     k1, k2, k3 = jax.random.split(key, 3)
+    B = CONFIG['batch']
     S = CONFIG['seq_len']
     H_q = CONFIG['num_query_heads']
     H_kv = CONFIG['num_kv_heads']
     D = CONFIG['head_dim']
-    q = jax.random.normal(k1, (H_q, S, D), dtype=dtype) * (D ** -0.5)
-    k = jax.random.normal(k2, (H_kv, S, D), dtype=dtype) * 0.02
-    v = jax.random.normal(k3, (H_kv, S, D), dtype=dtype) * 0.02
+    q = jax.random.normal(k1, (B, H_q, S, D), dtype=dtype) * (D ** -0.5)
+    k = jax.random.normal(k2, (B, H_kv, S, D), dtype=dtype) * 0.02
+    v = jax.random.normal(k3, (B, H_kv, S, D), dtype=dtype) * 0.02
     return q, k, v
 
 
@@ -40,22 +41,17 @@ def workload(q, k, v):
     H_kv = CONFIG['num_kv_heads']
     num_q_per_kv = H_q // H_kv
 
-    # Repeat KV heads for GQA
-    k = jnp.repeat(k, num_q_per_kv, axis=0)  # (H_q, S, D)
-    v = jnp.repeat(v, num_q_per_kv, axis=0)  # (H_q, S, D)
+    @jax.vmap
+    def _attend(q_b, k_b, v_b):
+        k_rep = jnp.repeat(k_b, num_q_per_kv, axis=0)
+        v_rep = jnp.repeat(v_b, num_q_per_kv, axis=0)
+        attn = jnp.einsum('hqd,hkd->hqk', q_b, k_rep)
+        causal = jnp.tril(jnp.ones((S, S), dtype=jnp.bool_))
+        attn = jnp.where(causal[None, :, :], attn, -1e30)
+        attn = jax.nn.softmax(attn, axis=-1)
+        return jnp.einsum('hqk,hkd->hqd', attn, v_rep)
 
-    # Attention scores: (H_q, S, D) x (H_q, S, D) -> (H_q, S, S)
-    attn = jnp.einsum('hqd,hkd->hqk', q, k)
-
-    # Causal mask
-    causal = jnp.tril(jnp.ones((S, S), dtype=jnp.bool_))
-    attn = jnp.where(causal[None, :, :], attn, -1e30)
-
-    attn = jax.nn.softmax(attn, axis=-1)
-
-    # Output: (H_q, S, S) x (H_q, S, D) -> (H_q, S, D)
-    out = jnp.einsum('hqk,hkd->hqd', attn, v)
-    return out
+    return _attend(q, k, v)
 
 
 def benchmark(num_warmup=5, num_iters=100):

--- a/JAXBench/benchmark/4p_Sparse_Attention/optimized.py
+++ b/JAXBench/benchmark/4p_Sparse_Attention/optimized.py
@@ -14,8 +14,6 @@
 
 """Implementation of Sparse Flash Attention, a.k.a. "Splash" attention."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Mapping
 import dataclasses
 import enum
@@ -2575,9 +2573,9 @@ def create_inputs(dtype=jnp.bfloat16):
     H_q = CONFIG['num_query_heads']
     H_kv = CONFIG['num_kv_heads']
     D = CONFIG['head_dim']
-    q = jax.random.normal(k1, (B, H_q, S, D), dtype=dtype)
-    k = jax.random.normal(k2, (B, H_kv, S, D), dtype=dtype)
-    v = jax.random.normal(k3, (B, H_kv, S, D), dtype=dtype)
+    q = jax.random.normal(k1, (B, H_q, S, D), dtype=dtype) * (D ** -0.5)
+    k = jax.random.normal(k2, (B, H_kv, S, D), dtype=dtype) * 0.02
+    v = jax.random.normal(k3, (B, H_kv, S, D), dtype=dtype) * 0.02
     return q, k, v
 
 

--- a/JAXBench/benchmark/6p_Paged_Attention/optimized.py
+++ b/JAXBench/benchmark/6p_Paged_Attention/optimized.py
@@ -553,10 +553,10 @@ def paged_attention(
   if k_scales_pages is not None and v_scales_pages is not None:
     in_specs = [
         q_block_spec,
-        pl.BlockSpec(memory_space=pltpu.ANY),
-        pl.BlockSpec(memory_space=pltpu.ANY),
-        pl.BlockSpec(memory_space=pltpu.ANY),
-        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=pl.ANY),
+        pl.BlockSpec(memory_space=pl.ANY),
+        pl.BlockSpec(memory_space=pl.ANY),
+        pl.BlockSpec(memory_space=pl.ANY),
     ]
     scratch_shapes = (
         pltpu.VMEM(
@@ -601,9 +601,9 @@ def paged_attention(
   else:
     in_specs = [
         q_block_spec,
-        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=pl.ANY),
         None,  # type: ignore[list-item]
-        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=pl.ANY),
         None,  # type: ignore[list-item]
     ]
     scratch_shapes = (
@@ -704,7 +704,7 @@ def get_flops():
 
 def create_inputs(dtype=jnp.bfloat16):
     key = jax.random.key(42)
-    k1, k2, k3 = jax.random.split(key, 3)
+    keys = jax.random.split(key, 5)
     B = CONFIG['batch']
     H_q = CONFIG['num_q_heads']
     H_kv = CONFIG['num_kv_heads']
@@ -712,9 +712,14 @@ def create_inputs(dtype=jnp.bfloat16):
     page_size = CONFIG['page_size']
     pages_per_seq = CONFIG['pages_per_seq']
     total_num_pages = B * pages_per_seq
-    q = jax.random.normal(k1, (B, H_q, D), dtype=dtype)
-    k_pages = jax.random.normal(k2, (H_kv, total_num_pages, page_size, D), dtype=dtype)
-    v_pages = jax.random.normal(k3, (H_kv, total_num_pages, page_size, D), dtype=dtype)
+    
+    q = jax.random.normal(keys[0], (B, H_q, D), dtype=dtype)
+    k_pages = jax.random.normal(keys[1], (total_num_pages, page_size, H_kv, D), dtype=dtype) * 0.02
+    v_pages = jax.random.normal(keys[2], (total_num_pages, page_size, H_kv, D), dtype=dtype) * 0.02
+    
+    k_pages = k_pages.transpose(2, 0, 1, 3)
+    v_pages = v_pages.transpose(2, 0, 1, 3)
+    
     seq_len = pages_per_seq * page_size
     lengths = jnp.full((B,), seq_len, dtype=jnp.int32)
     page_indices = jnp.arange(total_num_pages, dtype=jnp.int32).reshape(B, pages_per_seq)

--- a/JAXBench/benchmark/7p_Ragged_Paged_Attention/optimized.py
+++ b/JAXBench/benchmark/7p_Ragged_Paged_Attention/optimized.py
@@ -19,6 +19,7 @@ specifically designed for TPU and compatible with a wide range of model
 specifications. It supports mixed prefill and decoding, enhancing throughput
 during inference.
 """
+
 import functools
 import jax
 from jax import lax
@@ -910,7 +911,6 @@ def ragged_paged_attention(
 
 
 import math
-
 
 CONFIG = {
     'name': 'pallas_ragged_paged_attention_llama70b',

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/3p_MLA_Attention/reference.py
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/3p_MLA_Attention/reference.py
@@ -47,11 +47,11 @@ def _compute_rope(head_dim, seq_len, theta, dtype):
     return jnp.cos(angles).astype(dtype), jnp.sin(angles).astype(dtype)
 
 def _apply_rope(x, cos, sin):
-    x1, x2 = x[..., ::2], x[..., 1::2]
+    d = x.shape[-1]
+    x1, x2 = x[..., :d // 2], x[..., d // 2:]
     cos = cos[None, :, None, :]
     sin = sin[None, :, None, :]
-    rotated = jnp.stack([x1 * cos - x2 * sin, x1 * sin + x2 * cos], axis=-1)
-    return rotated.reshape(x.shape)
+    return jnp.concatenate([x1 * cos - x2 * sin, x2 * cos + x1 * sin], axis=-1)
 
 def computation(x, q_down_proj, q_up_proj, kv_down_proj, k_up_proj, v_up_proj, o_proj,
                 num_heads, qk_nope_head_dim, qk_rope_head_dim, v_head_dim, kv_lora_rank, rope_theta):

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/4p_Sparse_Attention/kernel_task.yaml
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/4p_Sparse_Attention/kernel_task.yaml
@@ -17,13 +17,14 @@ input_gen_code: |-
       }
       key = jax.random.key(42)
       k1, k2, k3 = jax.random.split(key, 3)
-      S = CONFIG['seq_len']
-      H_q = CONFIG['num_query_heads']
-      H_kv = CONFIG['num_kv_heads']
-      D = CONFIG['head_dim']
-      q = jax.random.normal(k1, (H_q, S, D), dtype=dtype) * (D ** -0.5)
-      k = jax.random.normal(k2, (H_kv, S, D), dtype=dtype) * 0.02
-      v = jax.random.normal(k3, (H_kv, S, D), dtype=dtype) * 0.02
+      B = CONFIG["batch"]
+      S = CONFIG["seq_len"]
+      H_q = CONFIG["num_query_heads"]
+      H_kv = CONFIG["num_kv_heads"]
+      D = CONFIG["head_dim"]
+      q = jax.random.normal(k1, (B, H_q, S, D), dtype=dtype) * (D ** -0.5)
+      k = jax.random.normal(k2, (B, H_kv, S, D), dtype=dtype) * 0.02
+      v = jax.random.normal(k3, (B, H_kv, S, D), dtype=dtype) * 0.02
 
       dynamic_args = [q, k, v]
       static_args = [S, H_q, H_kv, D]

--- a/MaxKernel/evaluation/jaxbench_adapted_dataset/4p_Sparse_Attention/reference.py
+++ b/MaxKernel/evaluation/jaxbench_adapted_dataset/4p_Sparse_Attention/reference.py
@@ -16,13 +16,14 @@ def get_inputs(dtype=jnp.bfloat16):
     }
     key = jax.random.key(42)
     k1, k2, k3 = jax.random.split(key, 3)
+    B = CONFIG['batch']
     S = CONFIG['seq_len']
     H_q = CONFIG['num_query_heads']
     H_kv = CONFIG['num_kv_heads']
     D = CONFIG['head_dim']
-    q = jax.random.normal(k1, (H_q, S, D), dtype=dtype) * (D ** -0.5)
-    k = jax.random.normal(k2, (H_kv, S, D), dtype=dtype) * 0.02
-    v = jax.random.normal(k3, (H_kv, S, D), dtype=dtype) * 0.02
+    q = jax.random.normal(k1, (B, H_q, S, D), dtype=dtype) * (D ** -0.5)
+    k = jax.random.normal(k2, (B, H_kv, S, D), dtype=dtype) * 0.02
+    v = jax.random.normal(k3, (B, H_kv, S, D), dtype=dtype) * 0.02
 
     dynamic_args = [q, k, v]
     static_args = [S, H_q, H_kv, D]
@@ -32,15 +33,14 @@ def get_inputs(dtype=jnp.bfloat16):
 def computation(q, k, v, S, H_q, H_kv, D):
     num_q_per_kv = H_q // H_kv
 
-    k = jnp.repeat(k, num_q_per_kv, axis=0)
-    v = jnp.repeat(v, num_q_per_kv, axis=0)
+    @jax.vmap
+    def _attend(q_b, k_b, v_b):
+        k_rep = jnp.repeat(k_b, num_q_per_kv, axis=0)
+        v_rep = jnp.repeat(v_b, num_q_per_kv, axis=0)
+        attn = jnp.einsum('hqd,hkd->hqk', q_b, k_rep)
+        causal = jnp.tril(jnp.ones((S, S), dtype=jnp.bool_))
+        attn = jnp.where(causal[None, :, :], attn, -1e30)
+        attn = jax.nn.softmax(attn, axis=-1)
+        return jnp.einsum('hqk,hkd->hqd', attn, v_rep)
 
-    attn = jnp.einsum('hqd,hkd->hqk', q, k)
-
-    causal = jnp.tril(jnp.ones((S, S), dtype=jnp.bool_))
-    attn = jnp.where(causal[None, :, :], attn, -1e30)
-
-    attn = jax.nn.softmax(attn, axis=-1)
-
-    out = jnp.einsum('hqk,hkd->hqd', attn, v)
-    return out
+    return _attend(q, k, v)


### PR DESCRIPTION
For the 8 priority kernels, the human optimized code has  outdated syntax and has discripency discrepency with the reference code .
1. Update pltpu.ANY to plt.ANY
2. Update mismatched input generation
3. Update rope mechanism in MLA
4. remove from `__future__` import annotations