### PR TITLE
fix: correct corrupted shebang in prepare_hitl_agent.sh

### DIFF
--- a/MaxKernel/prepare_hitl_agent.sh
+++ b/MaxKernel/prepare_hitl_agent.sh
@@ -1,4 +1,4 @@
-source#!/bin/bash
+#!/bin/bash
 
 set -e  # Exit on any error
 


### PR DESCRIPTION
## Summary

Line 1 of `MaxKernel/prepare_hitl_agent.sh` has a corrupted shebang — `source#!/bin/bash` instead of `#!/bin/bash`. This was introduced in commit `54e6df5` and has been present since.

## Error

```sh
$ ./prepare_hitl_agent.sh
./prepare_hitl_agent.sh: line 1: source#!/bin/bash: No such file or directory
```

The script still runs (bash falls back after the invalid shebang fails), but the error prints on **every invocation**, which is confusing for first-time users.

## Fix

```diff
-source#!/bin/bash
+#!/bin/bash
```

The sibling script `prepare_auto_agent.sh` has the correct `#!/bin/bash` on line 1, confirming this is a typo.

## Testing

Verified the script runs cleanly with no spurious error after the fix.