### PR TITLE
fix: declare mcp as required dependency in setup.py

### DIFF
--- a/MaxKernel/setup.py
+++ b/MaxKernel/setup.py
@@ -8,5 +8,7 @@ setup(
   author_email="your.email@example.com",
   packages=find_packages(),
   python_requires=">=3.7",
-  install_requires=[],
+  install_requires=[
+    "mcp>=1.24,<2",
+  ],
 )


### PR DESCRIPTION
## Summary

The HITL agent fails to import with `ModuleNotFoundError: No module named 'mcp'` because the `mcp` package is never installed during setup. It is imported unconditionally by the agent code and transitively by `google.adk`, but it was never declared as a dependency.

## Error

```
File ".../MaxKernel/hitl_agent/tools/filesystem_tools.py", line 5, in <module>
    from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
File ".../.venv/lib/python3.12/site-packages/google/adk/tools/mcp_tool/mcp_session_manager.py", line 59, in <module>
    from mcp import ClientSession
ModuleNotFoundError: No module named 'mcp'
```

## Root cause

`mcp` is an **optional extra** of `google-adk` (`mcp>=1.24,<2 ; extra == "mcp"`), but the agent imports it unconditionally. It was not declared in:
- `setup.py` → `install_requires` (was `[]`)
- No `requirements.txt` files exist

The `prepare_hitl_agent.sh` script runs `pip install -e .` (line 187), which uses `setup.py` — so `mcp` was never installed.

## Fix

Add `mcp>=1.24,<2` to `install_requires` in `setup.py`:

```diff
-  install_requires=[],
+  install_requires=[
+    "mcp>=1.24,<2",
+  ],
```

> **Note:** `mcp` 2.0.0 has breaking API changes and is **not compatible** with `google-adk`. The `<2` constraint matches what `google-adk` itself declares.

## Testing

Verified that after `pip install -e .`, `from mcp import ClientSession` and `from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams` both succeed, and the agent loads without import errors.