### PR TITLE
refactor: centralize server configuration and port resolution logic into a shared module

### DIFF
--- a/MaxKernel/auto_agent/server_utils/cpu_server.py
+++ b/MaxKernel/auto_agent/server_utils/cpu_server.py
@@ -2,17 +2,15 @@ import asyncio
 import json
 import logging
 import os
-import socket
 import sys
 import tempfile
 from typing import Optional
 
 import uvicorn
-import yaml
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from auto_agent.constants import CPU_SERVER_PORT
+from auto_agent.server_utils.server_config import get_local_cpu_port
 from auto_agent.tools.analyze_profile import analyze_trace
 
 logging.basicConfig(
@@ -504,43 +502,6 @@ async def get_backend_version() -> str:
       A string indicating CPU backend.
   """
   return GetBackendVersionResponse(backend_version="CPU")
-
-
-def _get_local_ip():
-  try:
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))
-    local_ip = s.getsockname()[0]
-    s.close()
-    return local_ip
-  except Exception:
-    return "127.0.0.1"
-
-
-def get_local_cpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
-  """Checks eval_config.yaml and returns the port if a local CPU server is needed."""
-  try:
-    with open(cfg_path, "r") as file:
-      config = yaml.safe_load(file)
-  except FileNotFoundError:
-    logging.error(f"Config file {cfg_path} not found.")
-    return None
-
-  backends = config.get("backends", [])
-  local_ip = _get_local_ip()
-
-  # Find all backends that are local CPUs
-  local_cpu_backends = [
-    b
-    for b in backends
-    if b.get("type") == "cpu"
-    and b.get("ip") in ["127.0.0.1", "localhost", local_ip]
-  ]
-
-  if not local_cpu_backends:
-    return None
-
-  return local_cpu_backends[0].get("port", CPU_SERVER_PORT)
 
 
 if __name__ == "__main__":

--- a/MaxKernel/auto_agent/server_utils/server_config.py
+++ b/MaxKernel/auto_agent/server_utils/server_config.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import socket
-import sys
 from typing import Any, Optional
 
 import yaml
@@ -18,11 +17,9 @@ from auto_agent.constants import (
 def get_local_ip() -> str:
   """Returns the local IP address of the machine."""
   try:
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))
-    local_ip = s.getsockname()[0]
-    s.close()
-    return local_ip
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+      s.connect(("8.8.8.8", 80))
+      return s.getsockname()[0]
   except Exception:
     return "127.0.0.1"
 
@@ -51,14 +48,27 @@ def get_local_tpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
     logging.error(f"Config file {resolved_path} error: {e}")
     return None
 
+  if not isinstance(config, dict):
+    raise ValueError(
+      f"Invalid configuration format in {resolved_path}: "
+      "Expected a YAML dictionary at the root level."
+    )
+
   backends = config.get("backends", [])
+  if not isinstance(backends, list):
+    raise ValueError(
+      f"Invalid configuration format in {resolved_path}: "
+      "'backends' must be a list."
+    )
+
   local_ip = get_local_ip()
 
   # Find all backends that are local TPUs
   local_tpu_backends = [
     b
     for b in backends
-    if b.get("type") == "tpu"
+    if isinstance(b, dict)
+    and b.get("type") == "tpu"
     and b.get("ip") in ["127.0.0.1", "localhost", local_ip]
     and "tpu_vm" not in b
   ]
@@ -82,14 +92,27 @@ def get_local_cpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
     logging.error(f"Config file {resolved_path} error: {e}")
     return None
 
+  if not isinstance(config, dict):
+    raise ValueError(
+      f"Invalid configuration format in {resolved_path}: "
+      "Expected a YAML dictionary at the root level."
+    )
+
   backends = config.get("backends", [])
+  if not isinstance(backends, list):
+    raise ValueError(
+      f"Invalid configuration format in {resolved_path}: "
+      "'backends' must be a list."
+    )
+
   local_ip = get_local_ip()
 
   # Find all backends that are local CPUs
   local_cpu_backends = [
     b
     for b in backends
-    if b.get("type") == "cpu"
+    if isinstance(b, dict)
+    and b.get("type") == "cpu"
     and b.get("ip") in ["127.0.0.1", "localhost", local_ip]
   ]
 
@@ -110,14 +133,21 @@ def get_bastion_config(
   try:
     with open(resolved_path, "r") as file:
       cfg = yaml.safe_load(file) or {}
+
+    if not isinstance(cfg, dict):
+      raise ValueError(
+        f"Invalid configuration format in {resolved_path}: "
+        "Expected a YAML dictionary at the root level."
+      )
+
     b = cfg.get("bastion_vm", {})
-    if b:
+    if isinstance(b, dict) and b:
       return {
-        "name": b.get("name", ""),
-        "zone": b.get("zone", ""),
-        "project": b.get("project", ""),
-        "local_port": b.get("local_port", b.get("port", default_eval_port)),
-        "remote_port": b.get("remote_port", b.get("port", default_eval_port)),
+        "name": b.get("name") or "",
+        "zone": b.get("zone") or "",
+        "project": b.get("project") or "",
+        "local_port": b.get("local_port") or b.get("port") or default_eval_port,
+        "remote_port": b.get("remote_port") or b.get("port") or default_eval_port,
       }
   except Exception as e:
     logging.error(f"Config file {resolved_path} error: {e}")

--- a/MaxKernel/auto_agent/server_utils/server_config.py
+++ b/MaxKernel/auto_agent/server_utils/server_config.py
@@ -1,0 +1,141 @@
+"""Shared lightweight configuration and port resolution utilities for server_utils."""
+
+import logging
+import os
+import socket
+import sys
+from typing import Any, Optional
+
+import yaml
+
+from auto_agent.constants import (
+  CPU_SERVER_PORT,
+  EVAL_SERVER_PORT,
+  TPU_SERVER_PORT,
+)
+
+
+def get_local_ip() -> str:
+  """Returns the local IP address of the machine."""
+  try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    local_ip = s.getsockname()[0]
+    s.close()
+    return local_ip
+  except Exception:
+    return "127.0.0.1"
+
+
+def _resolve_config_path(cfg_path: str) -> Optional[str]:
+  """Resolves configuration path in cwd or relative to this script's directory."""
+  if os.path.exists(cfg_path):
+    return cfg_path
+  script_dir = os.path.dirname(os.path.abspath(__file__))
+  alt_path = os.path.join(script_dir, cfg_path)
+  if os.path.exists(alt_path):
+    return alt_path
+  return None
+
+
+def get_local_tpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
+  """Checks eval_config.yaml and returns the port if a local TPU server is needed."""
+  resolved_path = _resolve_config_path(cfg_path)
+  if not resolved_path:
+    return None
+
+  try:
+    with open(resolved_path, "r") as file:
+      config = yaml.safe_load(file) or {}
+  except Exception as e:
+    logging.error(f"Config file {resolved_path} error: {e}")
+    return None
+
+  backends = config.get("backends", [])
+  local_ip = get_local_ip()
+
+  # Find all backends that are local TPUs
+  local_tpu_backends = [
+    b
+    for b in backends
+    if b.get("type") == "tpu"
+    and b.get("ip") in ["127.0.0.1", "localhost", local_ip]
+    and "tpu_vm" not in b
+  ]
+
+  if not local_tpu_backends:
+    return None
+
+  return local_tpu_backends[0].get("port")
+
+
+def get_local_cpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
+  """Checks eval_config.yaml and returns the port if a local CPU server is needed."""
+  resolved_path = _resolve_config_path(cfg_path)
+  if not resolved_path:
+    return None
+
+  try:
+    with open(resolved_path, "r") as file:
+      config = yaml.safe_load(file) or {}
+  except Exception as e:
+    logging.error(f"Config file {resolved_path} error: {e}")
+    return None
+
+  backends = config.get("backends", [])
+  local_ip = get_local_ip()
+
+  # Find all backends that are local CPUs
+  local_cpu_backends = [
+    b
+    for b in backends
+    if b.get("type") == "cpu"
+    and b.get("ip") in ["127.0.0.1", "localhost", local_ip]
+  ]
+
+  if not local_cpu_backends:
+    return None
+
+  return local_cpu_backends[0].get("port")
+
+
+def get_bastion_config(
+  cfg_path: str = "gke_config.yaml", default_eval_port: int = EVAL_SERVER_PORT
+) -> dict[str, Any]:
+  """Checks gke_config.yaml and returns bastion configuration dict if configured."""
+  resolved_path = _resolve_config_path(cfg_path)
+  if not resolved_path:
+    return {}
+
+  try:
+    with open(resolved_path, "r") as file:
+      cfg = yaml.safe_load(file) or {}
+    b = cfg.get("bastion_vm", {})
+    if b:
+      return {
+        "name": b.get("name", ""),
+        "zone": b.get("zone", ""),
+        "project": b.get("project", ""),
+        "local_port": b.get("local_port", b.get("port", default_eval_port)),
+        "remote_port": b.get("remote_port", b.get("port", default_eval_port)),
+      }
+  except Exception as e:
+    logging.error(f"Config file {resolved_path} error: {e}")
+  return {}
+
+
+if __name__ == "__main__":
+  tpu_p = get_local_tpu_port()
+  cpu_p = get_local_cpu_port()
+  b = get_bastion_config()
+
+  print(f"EVAL_PORT={EVAL_SERVER_PORT}")
+  print(f"TPU_PORT={tpu_p if tpu_p is not None else TPU_SERVER_PORT}")
+  print(f"CPU_PORT={cpu_p if cpu_p is not None else CPU_SERVER_PORT}")
+  print(f"LOCAL_TPU_PORT={tpu_p if tpu_p is not None else ''}")
+  print(f"LOCAL_CPU_PORT={cpu_p if cpu_p is not None else ''}")
+  print(f"BASTION_NAME='{b.get('name', '')}'")
+  print(f"BASTION_ZONE='{b.get('zone', '')}'")
+  print(f"BASTION_PROJECT='{b.get('project', '')}'")
+  print(f"BASTION_LOCAL_PORT={b.get('local_port', EVAL_SERVER_PORT)}")
+  print(f"BASTION_REMOTE_PORT={b.get('remote_port', EVAL_SERVER_PORT)}")

--- a/MaxKernel/auto_agent/server_utils/server_config.py
+++ b/MaxKernel/auto_agent/server_utils/server_config.py
@@ -76,7 +76,8 @@ def get_local_tpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
   if not local_tpu_backends:
     return None
 
-  return local_tpu_backends[0].get("port")
+  port = local_tpu_backends[0].get("port")
+  return port if port is not None else TPU_SERVER_PORT
 
 
 def get_local_cpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
@@ -119,7 +120,8 @@ def get_local_cpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
   if not local_cpu_backends:
     return None
 
-  return local_cpu_backends[0].get("port")
+  port = local_cpu_backends[0].get("port")
+  return port if port is not None else CPU_SERVER_PORT
 
 
 def get_bastion_config(
@@ -147,7 +149,9 @@ def get_bastion_config(
         "zone": b.get("zone") or "",
         "project": b.get("project") or "",
         "local_port": b.get("local_port") or b.get("port") or default_eval_port,
-        "remote_port": b.get("remote_port") or b.get("port") or default_eval_port,
+        "remote_port": b.get("remote_port")
+        or b.get("port")
+        or default_eval_port,
       }
   except Exception as e:
     logging.error(f"Config file {resolved_path} error: {e}")
@@ -160,8 +164,6 @@ if __name__ == "__main__":
   b = get_bastion_config()
 
   print(f"EVAL_PORT={EVAL_SERVER_PORT}")
-  print(f"TPU_PORT={tpu_p if tpu_p is not None else TPU_SERVER_PORT}")
-  print(f"CPU_PORT={cpu_p if cpu_p is not None else CPU_SERVER_PORT}")
   print(f"LOCAL_TPU_PORT={tpu_p if tpu_p is not None else ''}")
   print(f"LOCAL_CPU_PORT={cpu_p if cpu_p is not None else ''}")
   print(f"BASTION_NAME='{b.get('name', '')}'")

--- a/MaxKernel/auto_agent/server_utils/setup.sh
+++ b/MaxKernel/auto_agent/server_utils/setup.sh
@@ -19,7 +19,7 @@ wait_for_server_health() {
     local max_retries="${4:-15}"
     
     echo "Waiting for $name on port $port to become healthy..."
-    for i in $(seq 1 "$max_retries"); do
+    for ((i=1; i<=max_retries; i++)); do
         if curl -s --max-time 2 "http://localhost:${port}/health" >/dev/null 2>&1; then
             echo "$name started successfully and is healthy on port $port!"
             return 0

--- a/MaxKernel/auto_agent/server_utils/setup.sh
+++ b/MaxKernel/auto_agent/server_utils/setup.sh
@@ -6,59 +6,62 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # Change to the script directory so Python files are always found
 cd "$SCRIPT_DIR" || exit 1
 
-# Helper to check if a bastion_vm is configured in gke_config.yaml
-get_bastion_config() {
-    if [ -f "gke_config.yaml" ]; then
-        python3 -c '
-import yaml
-try:
-    with open("gke_config.yaml") as f:
-        cfg = yaml.safe_load(f)
-    b = cfg.get("bastion_vm", {})
-    if b:
-        name = b.get("name", "")
-        zone = b.get("zone", "")
-        project = b.get("project", "")
-        local_port = b.get("local_port", b.get("port", 1245))
-        remote_port = b.get("remote_port", b.get("port", 1245))
-        print(f"{name}|{zone}|{project}|{local_port}|{remote_port}")
-except:
-    pass
-'
-    fi
+# Load all configurations and ports dynamically from server_config.py
+load_config() {
+    eval "$(python3 "$SCRIPT_DIR/server_config.py" 2>/dev/null)"
 }
 
-# Lazy loader for bastion configuration to avoid running python on every script call
-load_bastion_config() {
-    if [ -n "$BASTION_NAME" ]; then
-        return # Already loaded
-    fi
+# Health check helper function
+wait_for_server_health() {
+    local name="$1"
+    local port="$2"
+    local log_file="$3"
+    local max_retries="${4:-15}"
     
-    local config_info=$(get_bastion_config)
-    if [ -n "$config_info" ]; then
-        IFS='|' read -r BASTION_NAME BASTION_ZONE BASTION_PROJECT BASTION_LOCAL_PORT BASTION_REMOTE_PORT <<< "$config_info"
+    echo "Waiting for $name on port $port to become healthy..."
+    for i in $(seq 1 "$max_retries"); do
+        if curl -s --max-time 2 "http://localhost:${port}/health" >/dev/null 2>&1; then
+            echo "$name started successfully and is healthy on port $port!"
+            return 0
+        fi
+        sleep 1
+    done
+    
+    echo "========================================================="
+    echo " ERROR: $name failed to become healthy on port $port."
+    if [ -n "$log_file" ] && [ -f "$log_file" ]; then
+        echo " Last 10 lines of $log_file:"
+        tail -n 10 "$log_file"
     fi
-    BASTION_LOCAL_PORT=${BASTION_LOCAL_PORT:-1245}
-    BASTION_REMOTE_PORT=${BASTION_REMOTE_PORT:-1245}
+    echo "========================================================="
+    return 1
 }
 
 if [ "$1" = "--start-tpu" ]; then
-    # Start TPU server on port 5463
+    load_config
+    if [ -z "$LOCAL_TPU_PORT" ]; then
+        echo "Note: No local TPU backend configured in eval_config.yaml (remote TPU VM or CPU only)."
+        exit 0
+    fi
     nohup python3 tpu_server.py > output_tpu_server.txt 2>&1 &
+    wait_for_server_health "TPU server" "$TPU_PORT" "output_tpu_server.txt" || exit 1
 
-    echo "TPU server started successfully on port 5463"
 elif [ "$1" = "--start-cpu" ]; then
-    # Start CPU server on port 5464
+    load_config
+    if [ -z "$LOCAL_CPU_PORT" ]; then
+        echo "Note: No local CPU backend configured in eval_config.yaml."
+        exit 0
+    fi
     nohup python3 cpu_server.py > output_cpu_server.txt 2>&1 &
+    wait_for_server_health "CPU server" "$CPU_PORT" "output_cpu_server.txt" || exit 1
 
-    echo "CPU server started successfully on port 5464"
 elif [ "$1" = "--start-eval" ]; then
-    # Start eval server on port 1245
+    load_config
     nohup python3 eval_server.py > output_eval_server.txt 2>&1 &
+    wait_for_server_health "Eval server" "$EVAL_PORT" "output_eval_server.txt" || exit 1
 
-    echo "Eval server started successfully on port 1245"
 elif [ "$1" = "--start-gke" ]; then
-    load_bastion_config
+    load_config
     
     if [ -n "$BASTION_NAME" ]; then
         # Check if tunnel/eval server is already running on the local port
@@ -83,42 +86,33 @@ elif [ "$1" = "--start-gke" ]; then
         
         # Start the tunnel in the background
         nohup "${CMD[@]}" > output_bastion_tunnel.txt 2>&1 &
-        
-        # Test the tunnel connection
-        echo "Waiting for SSH tunnel to establish..."
-        TUNNEL_SUCCESS=false
-        for i in {1..15}; do
-            if curl -s --max-time 2 http://localhost:${BASTION_LOCAL_PORT}/health >/dev/null 2>&1; then
-                TUNNEL_SUCCESS=true
-                break
-            fi
-            sleep 1
-        done
-        
-        if [ "$TUNNEL_SUCCESS" = true ]; then
-            echo "SSH tunnel established and remote Evaluation server is reachable!"
-        else
-            echo "========================================================="
-            echo " WARNING: SSH tunnel established but Evaluation server is not reachable on localhost:${BASTION_LOCAL_PORT}."
-            echo " Please verify that the eval_server.py is running on the Bastion VM."
-            echo "========================================================="
-            exit 1
-        fi
+        wait_for_server_health "GKE Evaluation tunnel" "$BASTION_LOCAL_PORT" "output_bastion_tunnel.txt" || exit 1
     else
         echo "Error: No bastion_vm configuration found in gke_config.yaml."
         echo "Please add a 'bastion_vm' section with 'name' to gke_config.yaml."
         exit 1
     fi
 elif [ "$1" = "--start-local" ] || [ "$1" = "--start-gce" ]; then
+    load_config
     # Start all local execution/evaluation servers (needed for local or GCE cases)
     echo "Starting local background servers (CPU, TPU, Eval)..."
-    nohup python3 tpu_server.py > output_tpu_server.txt 2>&1 &
-    nohup python3 cpu_server.py > output_cpu_server.txt 2>&1 &
+    if [ -n "$LOCAL_TPU_PORT" ]; then
+        nohup python3 tpu_server.py > output_tpu_server.txt 2>&1 &
+    fi
+    if [ -n "$LOCAL_CPU_PORT" ]; then
+        nohup python3 cpu_server.py > output_cpu_server.txt 2>&1 &
+    fi
     nohup python3 eval_server.py > output_eval_server.txt 2>&1 &
 
-    echo "Local background servers started successfully."
+    if [ -n "$LOCAL_TPU_PORT" ]; then
+        wait_for_server_health "TPU server" "$TPU_PORT" "output_tpu_server.txt" || exit 1
+    fi
+    if [ -n "$LOCAL_CPU_PORT" ]; then
+        wait_for_server_health "CPU server" "$CPU_PORT" "output_cpu_server.txt" || exit 1
+    fi
+    wait_for_server_health "Eval server" "$EVAL_PORT" "output_eval_server.txt" || exit 1
 elif [ "$1" = "--end-gke" ]; then
-    load_bastion_config
+    load_config
     echo "Stopping GKE SSH tunnel..."
     if [ -n "$BASTION_LOCAL_PORT" ] && [ -n "$BASTION_REMOTE_PORT" ]; then
         if pkill -f "${BASTION_LOCAL_PORT}:localhost:${BASTION_REMOTE_PORT}"; then
@@ -130,9 +124,9 @@ elif [ "$1" = "--end-gke" ]; then
 elif [ "$1" = "--end-local" ] || [ "$1" = "--end-gce" ]; then
     echo "Stopping local background servers..."
     servers_stopped=false
-    pkill -f "tpu_server.py" && servers_stopped=true
-    pkill -f "cpu_server.py" && servers_stopped=true
-    pkill -f "eval_server.py" && servers_stopped=true
+    pkill -f "tpu_server.py" && servers_stopped=true || true
+    pkill -f "cpu_server.py" && servers_stopped=true || true
+    pkill -f "eval_server.py" && servers_stopped=true || true
     
     if [ "$servers_stopped" = true ]; then
         echo "Local background servers stopped successfully."
@@ -140,18 +134,18 @@ elif [ "$1" = "--end-local" ] || [ "$1" = "--end-gce" ]; then
         echo "No active local background servers were running."
     fi
 elif [ "$1" = "--end" ]; then
-    load_bastion_config
+    load_config
     echo "Stopping all background servers and tunnels..."
     
     tunnel_stopped=false
     if [ -n "$BASTION_LOCAL_PORT" ] && [ -n "$BASTION_REMOTE_PORT" ]; then
-        pkill -f "${BASTION_LOCAL_PORT}:localhost:${BASTION_REMOTE_PORT}" && tunnel_stopped=true
+        pkill -f "${BASTION_LOCAL_PORT}:localhost:${BASTION_REMOTE_PORT}" && tunnel_stopped=true || true
     fi
     
     servers_stopped=false
-    pkill -f "tpu_server.py" && servers_stopped=true
-    pkill -f "cpu_server.py" && servers_stopped=true
-    pkill -f "eval_server.py" && servers_stopped=true
+    pkill -f "tpu_server.py" && servers_stopped=true || true
+    pkill -f "cpu_server.py" && servers_stopped=true || true
+    pkill -f "eval_server.py" && servers_stopped=true || true
 
     if [ "$tunnel_stopped" = true ] || [ "$servers_stopped" = true ]; then
         echo "Successfully stopped:"

--- a/MaxKernel/auto_agent/server_utils/setup.sh
+++ b/MaxKernel/auto_agent/server_utils/setup.sh
@@ -44,7 +44,7 @@ if [ "$1" = "--start-tpu" ]; then
         exit 0
     fi
     nohup python3 tpu_server.py > output_tpu_server.txt 2>&1 &
-    wait_for_server_health "TPU server" "$TPU_PORT" "output_tpu_server.txt" || exit 1
+    wait_for_server_health "TPU server" "$LOCAL_TPU_PORT" "output_tpu_server.txt" || exit 1
 
 elif [ "$1" = "--start-cpu" ]; then
     load_config
@@ -53,7 +53,7 @@ elif [ "$1" = "--start-cpu" ]; then
         exit 0
     fi
     nohup python3 cpu_server.py > output_cpu_server.txt 2>&1 &
-    wait_for_server_health "CPU server" "$CPU_PORT" "output_cpu_server.txt" || exit 1
+    wait_for_server_health "CPU server" "$LOCAL_CPU_PORT" "output_cpu_server.txt" || exit 1
 
 elif [ "$1" = "--start-eval" ]; then
     load_config
@@ -105,10 +105,10 @@ elif [ "$1" = "--start-local" ] || [ "$1" = "--start-gce" ]; then
     nohup python3 eval_server.py > output_eval_server.txt 2>&1 &
 
     if [ -n "$LOCAL_TPU_PORT" ]; then
-        wait_for_server_health "TPU server" "$TPU_PORT" "output_tpu_server.txt" || exit 1
+        wait_for_server_health "TPU server" "$LOCAL_TPU_PORT" "output_tpu_server.txt" || exit 1
     fi
     if [ -n "$LOCAL_CPU_PORT" ]; then
-        wait_for_server_health "CPU server" "$CPU_PORT" "output_cpu_server.txt" || exit 1
+        wait_for_server_health "CPU server" "$LOCAL_CPU_PORT" "output_cpu_server.txt" || exit 1
     fi
     wait_for_server_health "Eval server" "$EVAL_PORT" "output_eval_server.txt" || exit 1
 elif [ "$1" = "--end-gke" ]; then

--- a/MaxKernel/auto_agent/server_utils/tpu_server.py
+++ b/MaxKernel/auto_agent/server_utils/tpu_server.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import shutil
-import socket
 import subprocess
 import sys
 import tempfile
@@ -14,11 +13,10 @@ import time
 from typing import Optional
 
 import uvicorn
-import yaml
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from auto_agent.constants import TPU_SERVER_PORT
+from auto_agent.server_utils.server_config import get_local_tpu_port
 from auto_agent.tools.analyze_profile import analyze_trace
 
 logging.basicConfig(
@@ -506,44 +504,6 @@ def get_tpu_version() -> dict:
     pass
 
   return {"tpu_version": "TPU version not found"}
-
-
-def _get_local_ip():
-  try:
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))
-    local_ip = s.getsockname()[0]
-    s.close()
-    return local_ip
-  except Exception:
-    return "127.0.0.1"
-
-
-def get_local_tpu_port(cfg_path: str = "eval_config.yaml") -> Optional[int]:
-  """Checks eval_config.yaml and returns the port if a local TPU server is needed."""
-  try:
-    with open(cfg_path, "r") as file:
-      config = yaml.safe_load(file)
-  except FileNotFoundError:
-    logging.error(f"Config file {cfg_path} not found.")
-    return None
-
-  backends = config.get("backends", [])
-  local_ip = _get_local_ip()
-
-  # Find all backends that are local TPUs
-  local_tpu_backends = [
-    b
-    for b in backends
-    if b.get("type") == "tpu"
-    and b.get("ip") in ["127.0.0.1", "localhost", local_ip]
-    and "tpu_vm" not in b
-  ]
-
-  if not local_tpu_backends:
-    return None
-
-  return local_tpu_backends[0].get("port", TPU_SERVER_PORT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors the server initialization and configuration loading processes in the auto agent by consolidating duplicated code into a new, single source of truth module: `server_config.py`. 

Previously, `tpu_server.py`, `cpu_server.py`, and `setup.sh` each had their own mechanisms for parsing configuration files (`eval_config.yaml` / `gke_config.yaml`) and determining which ports to use or backends to initialize. By centralizing this logic, we ensure more reliable port assignments, avoid code duplication, and introduce a cleaner, more robust startup mechanism.

## Key Changes

- **Introduced `server_config.py`**: A new shared module that acts as the centralized authority for configuration parsing and port resolution for local TPU, CPU, Eval, and Bastion servers.
- **Refactored Server Scripts**: Cleaned up `cpu_server.py` and `tpu_server.py` by removing duplicate configuration-loading logic (e.g., `_get_local_ip` and YAML parsing) and instead importing the utilities directly from `server_config.py`.
- **Enhanced `setup.sh` Robustness**:
  - Replaced hardcoded ports and distributed config loading with a unified `load_config()` method that dynamically evaluates configurations from `server_config.py`.
  - Added a `wait_for_server_health()` helper function to proactively poll the `/health` endpoints of newly spawned servers (CPU, TPU, Eval, and GKE SSH tunnel) to guarantee they are ready before proceeding.
  - Improved conditional startup and shutdown logic: local CPU and TPU servers are now intelligently skipped if they aren't explicitly required by the backend configuration. Stopping logic was also updated to gracefully handle missing servers without failing.