### PR TITLE
feat: Add token metrics telemetry and tracking aggregation

### DIFF
--- a/MaxKernel/auto_agent/subagents/pipeline_agent.py
+++ b/MaxKernel/auto_agent/subagents/pipeline_agent.py
@@ -232,6 +232,18 @@ class AutonomousPipelineAgent(BaseAgent):
 
     finally:
       end_time = time.time()
+      if "token_metrics" in ctx.session.state:
+        tm = ctx.session.state["token_metrics"]
+        try:
+          with open(
+            os.path.join(
+              ctx.session.state.get("workdir", ""), "token_metrics.json"
+            ),
+            "w",
+          ) as f:
+            json.dump(tm, f, indent=2)
+        except Exception:
+          pass
       if "timing_metrics" in ctx.session.state:
         m = ctx.session.state["timing_metrics"]
         m["overall_pipeline_time"] = end_time - ctx.session.state.get(

--- a/MaxKernel/auto_agent/timing_callbacks.py
+++ b/MaxKernel/auto_agent/timing_callbacks.py
@@ -92,8 +92,8 @@ def _extract_tokens(llm_response):
       completion_tokens = getattr(usage_metadata, "candidates_token_count", 0)
       thought_tokens = getattr(
         usage_metadata,
-        "reasoning_token_count",
-        getattr(usage_metadata, "thought_token_count", 0),
+        "thoughts_token_count",
+        getattr(usage_metadata, "thoughtsTokenCount", 0),
       )
     elif usage is not None:
       prompt_tokens = getattr(
@@ -103,9 +103,8 @@ def _extract_tokens(llm_response):
         usage, "completion_tokens", getattr(usage, "candidates_token_count", 0)
       )
       thought_tokens = getattr(
-        usage, "reasoning_tokens", getattr(usage, "thought_tokens", 0)
+        usage, "thoughts_token_count", getattr(usage, "thoughtsTokenCount", 0)
       )
-
       details = getattr(usage, "completion_tokens_details", None)
       if details is not None:
         thought_tokens = max(
@@ -115,11 +114,21 @@ def _extract_tokens(llm_response):
       ud = raw["usage"]
       prompt_tokens = ud.get("prompt_tokens", 0)
       completion_tokens = ud.get("completion_tokens", 0)
-      thought_tokens = ud.get("reasoning_tokens", ud.get("thought_tokens", 0))
-
+      thought_tokens = ud.get(
+        "thoughts_token_count", ud.get("thoughtsTokenCount", 0)
+      )
       details = ud.get("completion_tokens_details", {})
       if isinstance(details, dict):
         thought_tokens = max(thought_tokens, details.get("reasoning_tokens", 0))
+
+    if thought_tokens == 0:
+      import re
+
+      match = re.search(
+        r'("?thoughts?_?token_?count"?\s*[:=]\s*(\d+))', str(raw), re.IGNORECASE
+      )
+      if match:
+        thought_tokens = int(match.group(2))
 
   except Exception as e:
     print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)

--- a/MaxKernel/auto_agent/timing_callbacks.py
+++ b/MaxKernel/auto_agent/timing_callbacks.py
@@ -79,60 +79,45 @@ async def after_agent_callback(callback_context: CallbackContext) -> None:
 
 
 def _extract_tokens(llm_response):
-  prompt_tokens = 0
-  completion_tokens = 0
-  thought_tokens = 0
+  prompt_tokens, completion_tokens, thought_tokens = 0, 0, 0
   try:
     raw = getattr(llm_response, "raw_response", llm_response)
-    usage_metadata = getattr(raw, "usage_metadata", None)
-    usage = getattr(llm_response, "usage", None)
 
-    if usage_metadata is not None:
-      prompt_tokens = getattr(usage_metadata, "prompt_token_count", 0)
-      completion_tokens = getattr(usage_metadata, "candidates_token_count", 0)
-      thought_tokens = getattr(
-        usage_metadata,
-        "thoughts_token_count",
-        getattr(usage_metadata, "thoughtsTokenCount", 0),
+    # 1. Isolate the usage block dynamically (Google = usage_metadata, OpenAI = usage)
+    usage = getattr(raw, "usage_metadata", None) or getattr(raw, "usage", None)
+    if not usage and isinstance(raw, dict):
+      usage = raw.get("usage")
+
+    if usage:
+      # Helper to extract the first matching key whether it's a Dict or an Object
+      def safe_get(obj, *keys):
+        for k in keys:
+          val = obj.get(k) if isinstance(obj, dict) else getattr(obj, k, None)
+          if val is not None:
+            return val
+        return 0
+
+      # 2. Extract using known schemas
+      prompt_tokens = safe_get(usage, "prompt_token_count", "prompt_tokens")
+      completion_tokens = safe_get(
+        usage, "candidates_token_count", "completion_tokens"
       )
-    elif usage is not None:
-      prompt_tokens = getattr(
-        usage, "prompt_tokens", getattr(usage, "prompt_token_count", 0)
+      thought_tokens = safe_get(
+        usage, "thoughts_token_count", "thoughtsTokenCount", "reasoning_tokens"
       )
-      completion_tokens = getattr(
-        usage, "completion_tokens", getattr(usage, "candidates_token_count", 0)
-      )
-      thought_tokens = getattr(
-        usage, "thoughts_token_count", getattr(usage, "thoughtsTokenCount", 0)
-      )
-      details = getattr(usage, "completion_tokens_details", None)
-      if details is not None:
+
+      # 3. Handle OpenAI-specific nested reasoning budgets
+      details = safe_get(usage, "completion_tokens_details")
+      if details:
         thought_tokens = max(
-          thought_tokens, getattr(details, "reasoning_tokens", 0)
+          thought_tokens, safe_get(details, "reasoning_tokens") or 0
         )
-    elif isinstance(raw, dict) and isinstance(raw.get("usage"), dict):
-      ud = raw["usage"]
-      prompt_tokens = ud.get("prompt_tokens", 0)
-      completion_tokens = ud.get("completion_tokens", 0)
-      thought_tokens = ud.get(
-        "thoughts_token_count", ud.get("thoughtsTokenCount", 0)
-      )
-      details = ud.get("completion_tokens_details", {})
-      if isinstance(details, dict):
-        thought_tokens = max(thought_tokens, details.get("reasoning_tokens", 0))
-
-    if thought_tokens == 0:
-      import re
-
-      match = re.search(
-        r'("?thoughts?_?token_?count"?\s*[:=]\s*(\d+))', str(raw), re.IGNORECASE
-      )
-      if match:
-        thought_tokens = int(match.group(2))
 
   except Exception as e:
     print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)
-  return prompt_tokens, completion_tokens, thought_tokens
+
+  # Final sanitization enforcing 0 over None
+  return prompt_tokens or 0, completion_tokens or 0, thought_tokens or 0
 
 
 async def before_model_callback(

--- a/MaxKernel/auto_agent/timing_callbacks.py
+++ b/MaxKernel/auto_agent/timing_callbacks.py
@@ -85,24 +85,21 @@ def _extract_tokens(llm_response):
   prompt_tokens = 0
   completion_tokens = 0
   try:
-    raw = getattr(llm_response, "raw_response", llm_response)
-    if hasattr(raw, "usage_metadata"):
-      usage = raw.usage_metadata
-      prompt_tokens = getattr(usage, "prompt_token_count", 0)
-      completion_tokens = getattr(usage, "candidates_token_count", 0)
-    elif hasattr(llm_response, "usage"):
-      usage = llm_response.usage
-      prompt_tokens = getattr(
-        usage, "prompt_tokens", getattr(usage, "prompt_token_count", 0)
-      )
-      completion_tokens = getattr(
-        usage, "completion_tokens", getattr(usage, "candidates_token_count", 0)
-      )
-    elif isinstance(raw, dict) and "usage" in raw:
-      prompt_tokens = raw["usage"].get("prompt_tokens", 0)
-      completion_tokens = raw["usage"].get("completion_tokens", 0)
+      raw = getattr(llm_response, "raw_response", llm_response)
+      usage_metadata = getattr(raw, "usage_metadata", None)
+      usage = getattr(llm_response, "usage", None)
+
+      if usage_metadata is not None:
+          prompt_tokens = getattr(usage_metadata, "prompt_token_count", 0)
+          completion_tokens = getattr(usage_metadata, "candidates_token_count", 0)
+      elif usage is not None:
+          prompt_tokens = getattr(usage, "prompt_tokens", getattr(usage, "prompt_token_count", 0))
+          completion_tokens = getattr(usage, "completion_tokens", getattr(usage, "candidates_token_count", 0))
+      elif isinstance(raw, dict) and isinstance(raw.get("usage"), dict):
+          prompt_tokens = raw["usage"].get("prompt_tokens", 0)
+          completion_tokens = raw["usage"].get("completion_tokens", 0)
   except Exception as e:
-    print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)
+      print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)
   return prompt_tokens, completion_tokens
 
 

--- a/MaxKernel/auto_agent/timing_callbacks.py
+++ b/MaxKernel/auto_agent/timing_callbacks.py
@@ -85,21 +85,25 @@ def _extract_tokens(llm_response):
   prompt_tokens = 0
   completion_tokens = 0
   try:
-      raw = getattr(llm_response, "raw_response", llm_response)
-      usage_metadata = getattr(raw, "usage_metadata", None)
-      usage = getattr(llm_response, "usage", None)
+    raw = getattr(llm_response, "raw_response", llm_response)
+    usage_metadata = getattr(raw, "usage_metadata", None)
+    usage = getattr(llm_response, "usage", None)
 
-      if usage_metadata is not None:
-          prompt_tokens = getattr(usage_metadata, "prompt_token_count", 0)
-          completion_tokens = getattr(usage_metadata, "candidates_token_count", 0)
-      elif usage is not None:
-          prompt_tokens = getattr(usage, "prompt_tokens", getattr(usage, "prompt_token_count", 0))
-          completion_tokens = getattr(usage, "completion_tokens", getattr(usage, "candidates_token_count", 0))
-      elif isinstance(raw, dict) and isinstance(raw.get("usage"), dict):
-          prompt_tokens = raw["usage"].get("prompt_tokens", 0)
-          completion_tokens = raw["usage"].get("completion_tokens", 0)
+    if usage_metadata is not None:
+      prompt_tokens = getattr(usage_metadata, "prompt_token_count", 0)
+      completion_tokens = getattr(usage_metadata, "candidates_token_count", 0)
+    elif usage is not None:
+      prompt_tokens = getattr(
+        usage, "prompt_tokens", getattr(usage, "prompt_token_count", 0)
+      )
+      completion_tokens = getattr(
+        usage, "completion_tokens", getattr(usage, "candidates_token_count", 0)
+      )
+    elif isinstance(raw, dict) and isinstance(raw.get("usage"), dict):
+      prompt_tokens = raw["usage"].get("prompt_tokens", 0)
+      completion_tokens = raw["usage"].get("completion_tokens", 0)
   except Exception as e:
-      print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)
+    print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)
   return prompt_tokens, completion_tokens
 
 

--- a/MaxKernel/auto_agent/timing_callbacks.py
+++ b/MaxKernel/auto_agent/timing_callbacks.py
@@ -81,6 +81,31 @@ async def after_agent_callback(callback_context: CallbackContext) -> None:
     )
 
 
+def _extract_tokens(llm_response):
+  prompt_tokens = 0
+  completion_tokens = 0
+  try:
+    raw = getattr(llm_response, "raw_response", llm_response)
+    if hasattr(raw, "usage_metadata"):
+      usage = raw.usage_metadata
+      prompt_tokens = getattr(usage, "prompt_token_count", 0)
+      completion_tokens = getattr(usage, "candidates_token_count", 0)
+    elif hasattr(llm_response, "usage"):
+      usage = llm_response.usage
+      prompt_tokens = getattr(
+        usage, "prompt_tokens", getattr(usage, "prompt_token_count", 0)
+      )
+      completion_tokens = getattr(
+        usage, "completion_tokens", getattr(usage, "candidates_token_count", 0)
+      )
+    elif isinstance(raw, dict) and "usage" in raw:
+      prompt_tokens = raw["usage"].get("prompt_tokens", 0)
+      completion_tokens = raw["usage"].get("completion_tokens", 0)
+  except Exception as e:
+    print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)
+  return prompt_tokens, completion_tokens
+
+
 async def before_model_callback(
   callback_context: CallbackContext, llm_request: LlmRequest
 ) -> None:
@@ -101,6 +126,46 @@ async def after_model_callback(
     duration = end_time - start_time
     agent_name = _get_agent_name(callback_context)
     metrics, iter_metrics = _ensure_iteration_metrics(state)
+
+    # --- INJECTED TOKEN TRACKING ---
+    try:
+      if "token_metrics" not in state:
+        state["token_metrics"] = {"iterations": {}}
+      t_metrics = state["token_metrics"]
+      it_str = str(state.get("iteration", 0))
+      if it_str not in t_metrics["iterations"]:
+        t_metrics["iterations"][it_str] = {"agents": {}, "llm_calls": []}
+      t_iter = t_metrics["iterations"][it_str]
+
+      pt, ct = _extract_tokens(llm_response)
+      tt = pt + ct
+
+      if agent_name not in t_iter["agents"]:
+        t_iter["agents"][agent_name] = {
+          "prompt_tokens": 0,
+          "completion_tokens": 0,
+          "total_tokens": 0,
+          "calls": 0,
+        }
+
+      t_iter["agents"][agent_name]["prompt_tokens"] += pt
+      t_iter["agents"][agent_name]["completion_tokens"] += ct
+      t_iter["agents"][agent_name]["total_tokens"] += tt
+      t_iter["agents"][agent_name]["calls"] += 1
+
+      t_iter["llm_calls"].append(
+        {
+          "agent": agent_name,
+          "prompt_tokens": pt,
+          "completion_tokens": ct,
+          "total_tokens": tt,
+          "timestamp": time.time(),
+        }
+      )
+    except Exception as e:
+      print(f"FAILED TOKEN TRACKING LOGIC: {e}", flush=True)
+    # -------------------------------
+
     iter_metrics["llm_calls"].append(
       {
         "agent": agent_name,

--- a/MaxKernel/auto_agent/timing_callbacks.py
+++ b/MaxKernel/auto_agent/timing_callbacks.py
@@ -20,8 +20,8 @@ def _ensure_iteration_metrics(state: dict):
   if iteration_str not in metrics["iterations"]:
     metrics["iterations"][iteration_str] = {
       "iteration_total_time": 0,
-      "agents": {},  # Restored to native dict for pipeline loop
-      "agent_events": [],  # Explicit array for chronological tracking
+      "agents": {},
+      "agent_events": [],
       "llm_calls": [],
       "tools": [],
       "framework_overhead": 0,
@@ -35,7 +35,6 @@ def _get_agent_name(ctx: Any) -> str:
     name = getattr(ctx.agent, "name", None)
 
   if not name:
-    # Fallback to console debug if perfectly opaque
     print(f"DEBUG_CTX_DIR: {dir(ctx)}", flush=True)
     try:
       print(f"DEBUG_CTX_VARS: {vars(ctx)}", flush=True)
@@ -61,13 +60,11 @@ async def after_agent_callback(callback_context: CallbackContext) -> None:
     duration = end_time - start_time
     metrics, iter_metrics = _ensure_iteration_metrics(state)
 
-    # 1. Maintain aggregated duration dictionary for compatibility with pipeline_agent.py
     if not isinstance(iter_metrics.get("agents"), dict):
       iter_metrics["agents"] = {}
     current_dur = iter_metrics["agents"].get(agent_name, 0.0)
     iter_metrics["agents"][agent_name] = current_dur + duration
 
-    # 2. Append granular events array for frontend visualization tooling
     if "agent_events" not in iter_metrics:
       iter_metrics["agent_events"] = []
 
@@ -84,6 +81,7 @@ async def after_agent_callback(callback_context: CallbackContext) -> None:
 def _extract_tokens(llm_response):
   prompt_tokens = 0
   completion_tokens = 0
+  thought_tokens = 0
   try:
     raw = getattr(llm_response, "raw_response", llm_response)
     usage_metadata = getattr(raw, "usage_metadata", None)
@@ -92,6 +90,11 @@ def _extract_tokens(llm_response):
     if usage_metadata is not None:
       prompt_tokens = getattr(usage_metadata, "prompt_token_count", 0)
       completion_tokens = getattr(usage_metadata, "candidates_token_count", 0)
+      thought_tokens = getattr(
+        usage_metadata,
+        "reasoning_token_count",
+        getattr(usage_metadata, "thought_token_count", 0),
+      )
     elif usage is not None:
       prompt_tokens = getattr(
         usage, "prompt_tokens", getattr(usage, "prompt_token_count", 0)
@@ -99,12 +102,28 @@ def _extract_tokens(llm_response):
       completion_tokens = getattr(
         usage, "completion_tokens", getattr(usage, "candidates_token_count", 0)
       )
+      thought_tokens = getattr(
+        usage, "reasoning_tokens", getattr(usage, "thought_tokens", 0)
+      )
+
+      details = getattr(usage, "completion_tokens_details", None)
+      if details is not None:
+        thought_tokens = max(
+          thought_tokens, getattr(details, "reasoning_tokens", 0)
+        )
     elif isinstance(raw, dict) and isinstance(raw.get("usage"), dict):
-      prompt_tokens = raw["usage"].get("prompt_tokens", 0)
-      completion_tokens = raw["usage"].get("completion_tokens", 0)
+      ud = raw["usage"]
+      prompt_tokens = ud.get("prompt_tokens", 0)
+      completion_tokens = ud.get("completion_tokens", 0)
+      thought_tokens = ud.get("reasoning_tokens", ud.get("thought_tokens", 0))
+
+      details = ud.get("completion_tokens_details", {})
+      if isinstance(details, dict):
+        thought_tokens = max(thought_tokens, details.get("reasoning_tokens", 0))
+
   except Exception as e:
     print(f"FAILED TOKEN EXTRACTION: {e}", flush=True)
-  return prompt_tokens, completion_tokens
+  return prompt_tokens, completion_tokens, thought_tokens
 
 
 async def before_model_callback(
@@ -138,19 +157,21 @@ async def after_model_callback(
         t_metrics["iterations"][it_str] = {"agents": {}, "llm_calls": []}
       t_iter = t_metrics["iterations"][it_str]
 
-      pt, ct = _extract_tokens(llm_response)
+      pt, ct, tht = _extract_tokens(llm_response)
       tt = pt + ct
 
       if agent_name not in t_iter["agents"]:
         t_iter["agents"][agent_name] = {
           "prompt_tokens": 0,
           "completion_tokens": 0,
+          "thought_tokens": 0,
           "total_tokens": 0,
           "calls": 0,
         }
 
       t_iter["agents"][agent_name]["prompt_tokens"] += pt
       t_iter["agents"][agent_name]["completion_tokens"] += ct
+      t_iter["agents"][agent_name]["thought_tokens"] += tht
       t_iter["agents"][agent_name]["total_tokens"] += tt
       t_iter["agents"][agent_name]["calls"] += 1
 
@@ -159,6 +180,7 @@ async def after_model_callback(
           "agent": agent_name,
           "prompt_tokens": pt,
           "completion_tokens": ct,
+          "thought_tokens": tht,
           "total_tokens": tt,
           "timestamp": time.time(),
         }

--- a/MaxKernel/auto_search/run_search.py
+++ b/MaxKernel/auto_search/run_search.py
@@ -187,7 +187,7 @@ async def run_search(
           token_summary_text = analyze_token_path(dest_dir)
           if token_summary_text:
             token_out_file = os.path.join(dest_dir, "token.md")
-            with open(token_out_file, "w") as f:
+            with open(token_out_file, "w", encoding="utf-8") as f:
               f.write(token_summary_text)
             print(
               f"\n\n====== TOKEN METRICS ======\n{token_summary_text}\n===========================\n"

--- a/MaxKernel/auto_search/run_search.py
+++ b/MaxKernel/auto_search/run_search.py
@@ -177,6 +177,24 @@ async def run_search(
         with open(out_file, "w") as f:
           f.write("```text\n" + summary_text + "\n```\n")
         logger.info(f"Saved metric summary to: {out_file}")
+
+        logger.info("Generating token summary...")
+        try:
+          from auto_search.utils.analyze_tokens import (
+            analyze_path as analyze_token_path,
+          )
+
+          token_summary_text = analyze_token_path(dest_dir)
+          if token_summary_text:
+            token_out_file = os.path.join(dest_dir, "token.md")
+            with open(token_out_file, "w") as f:
+              f.write(token_summary_text)
+            print(
+              f"\n\n====== TOKEN METRICS ======\n{token_summary_text}\n===========================\n"
+            )
+        except Exception as e:
+          logger.error(f"Failed to generate token summary: {e}")
+
       except Exception as analyze_err:
         logger.error(f"Failed to generate timing summary: {analyze_err}")
 

--- a/MaxKernel/auto_search/utils/analyze_tokens.py
+++ b/MaxKernel/auto_search/utils/analyze_tokens.py
@@ -1,0 +1,250 @@
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def generate_padded_table(headers, rows):
+  # Calculate max widths
+  widths = [len(h) for h in headers]
+  for row in rows:
+    for i, col in enumerate(row):
+      widths[i] = max(widths[i], len(str(col)))
+
+  # Format header
+  header_str = (
+    "| " + " | ".join(f"{h:<{w}}" for h, w in zip(headers, widths)) + " |"
+  )
+  # Format separator
+  sep_str = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
+
+  # Format rows
+  row_strs = []
+  for row in rows:
+    row_str = (
+      "| "
+      + " | ".join(f"{str(col):<{w}}" for col, w in zip(row, widths))
+      + " |"
+    )
+    row_strs.append(row_str)
+
+  return [header_str, sep_str] + row_strs
+
+
+def analyze_path(target_path: str) -> str:
+  path = Path(target_path)
+  if not path.exists():
+    return f"Target path {target_path} does not exist."
+
+  if path.is_file():
+    if path.name == "token_metrics.json":
+      files_to_process = [path]
+    else:
+      return "Please provide a token_metrics.json file or a directory containing them."
+  else:
+    files_to_process = list(path.glob("**/token_metrics.json"))
+
+  if not files_to_process:
+    return ""
+
+  all_markdown = []
+
+  # Global Aggregators
+  global_agents = {}
+  global_total_calls = 0
+  total_nodes = 0
+
+  for file_path in files_to_process:
+    with open(file_path, "r", encoding="utf-8") as f:
+      try:
+        data = json.load(f)
+        node_md, node_agents, node_calls = generate_node_markdown(
+          file_path, data
+        )
+        all_markdown.append(node_md)
+
+        # Accumulate macros
+        total_nodes += 1
+        global_total_calls += node_calls
+        for ag_name, ag_data in node_agents.items():
+          if ag_name not in global_agents:
+            global_agents[ag_name] = {
+              "calls": 0,
+              "prompt_tokens": 0,
+              "completion_tokens": 0,
+              "total_tokens": 0,
+            }
+          global_agents[ag_name]["calls"] += ag_data.get("calls", 0)
+          global_agents[ag_name]["prompt_tokens"] += ag_data.get(
+            "prompt_tokens", 0
+          )
+          global_agents[ag_name]["completion_tokens"] += ag_data.get(
+            "completion_tokens", 0
+          )
+          global_agents[ag_name]["total_tokens"] += ag_data.get(
+            "total_tokens", 0
+          )
+
+      except Exception as e:
+        logger.error(f"Failed to process {file_path}: {e}")
+
+  # Build Macro Summary
+  if total_nodes > 0:
+    macro_md = [
+      "============================================================",
+      "      MACRO TOKEN SUMMARY (ACROSS ALL DISCOVERED NODES)     ",
+      "============================================================",
+      f"Total Nodes/Attempts Analyzed : {total_nodes}",
+      "",
+    ]
+
+    headers = [
+      "Agent",
+      "LLM Calls",
+      "Prompt Tokens",
+      "Completion Tokens",
+      "Total Tokens",
+    ]
+    rows = []
+    sorted_global = sorted(
+      global_agents.items(),
+      key=lambda x: x[1].get("total_tokens", 0),
+      reverse=True,
+    )
+
+    grand_prompt = 0
+    grand_comp = 0
+    grand_total = 0
+
+    for agent_name, agent_data in sorted_global:
+      p = agent_data["prompt_tokens"]
+      c = agent_data["completion_tokens"]
+      t = agent_data["total_tokens"]
+      calls = agent_data["calls"]
+      grand_prompt += p
+      grand_comp += c
+      grand_total += t
+      rows.append([agent_name, str(calls), f"{p:,}", f"{c:,}", f"{t:,}"])
+
+    macro_md.append("### Global Agent Aggregate Tokens")
+    macro_md.extend(generate_padded_table(headers, rows))
+    macro_md.append("")
+    macro_md.append(
+      f"*(Grand Total: {global_total_calls} LLM calls | {grand_prompt:,} prompt | {grand_comp:,} completion | {grand_total:,} total)*"
+    )
+    macro_md.append(
+      "============================================================"
+    )
+
+    all_markdown.append("\n".join(macro_md))
+
+  return "\n\n---\n\n".join(all_markdown)
+
+
+def generate_node_markdown(
+  file_path: Path, metrics: Dict[str, Any]
+) -> tuple[str, dict, int]:
+  md = [f"# Token Metrics: {file_path.parent.name}"]
+
+  iterations = metrics.get("iterations", {})
+  if not iterations:
+    md.append("No iterations tracked.")
+    return "\n".join(md), {}, 0
+
+  node_agents = {}
+  node_total_calls = 0
+
+  for iter_key, iter_data in sorted(
+    iterations.items(), key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0]
+  ):
+    md.append(f"## Iteration {iter_key}")
+
+    agents = iter_data.get("agents", {})
+    if agents:
+      md.append("### Agent Aggregate Tokens")
+      headers = [
+        "Agent",
+        "LLM Calls",
+        "Prompt Tokens",
+        "Completion Tokens",
+        "Total Tokens",
+      ]
+      rows = []
+
+      # Sort agents by total tokens descending
+      sorted_agents = sorted(
+        agents.items(), key=lambda x: x[1].get("total_tokens", 0), reverse=True
+      )
+      for agent_name, agent_data in sorted_agents:
+        prompt = agent_data.get("prompt_tokens", 0)
+        completion = agent_data.get("completion_tokens", 0)
+        total = agent_data.get("total_tokens", 0)
+        calls = agent_data.get("calls", 0)
+        rows.append(
+          [
+            agent_name,
+            str(calls),
+            f"{prompt:,}",
+            f"{completion:,}",
+            f"{total:,}",
+          ]
+        )
+
+        # Accumulate for node return
+        if agent_name not in node_agents:
+          node_agents[agent_name] = {
+            "calls": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+          }
+        node_agents[agent_name]["calls"] += calls
+        node_agents[agent_name]["prompt_tokens"] += prompt
+        node_agents[agent_name]["completion_tokens"] += completion
+        node_agents[agent_name]["total_tokens"] += total
+
+      md.extend(generate_padded_table(headers, rows))
+
+    md.append("")
+    llm_calls = iter_data.get("llm_calls", [])
+    if llm_calls:
+      calls_len = len(llm_calls)
+      node_total_calls += calls_len
+      md.append(f"*(Total {calls_len} LLM calls in this iteration)*")
+
+    md.append("")
+
+  return "\n".join(md), node_agents, node_total_calls
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Analyze ADK token metrics")
+  parser.add_argument(
+    "target",
+    help="Path to token_metrics.json OR a root directory",
+  )
+  parser.add_argument(
+    "--write",
+    action="store_true",
+    help="Write token.md in the target directory",
+  )
+  args = parser.parse_args()
+
+  md_content = analyze_path(args.target)
+
+  if args.write:
+    target_path = Path(args.target)
+    out_dir = target_path.parent if target_path.is_file() else target_path
+    out_file = out_dir / "token.md"
+    with open(out_file, "w", encoding="utf-8") as f:
+      f.write(md_content)
+    print(f"Wrote {out_file}")
+  else:
+    print(md_content)
+
+
+if __name__ == "__main__":
+  main()

--- a/MaxKernel/auto_search/utils/analyze_tokens.py
+++ b/MaxKernel/auto_search/utils/analyze_tokens.py
@@ -158,7 +158,8 @@ def generate_node_markdown(
   node_total_calls = 0
 
   for iter_key, iter_data in sorted(
-    iterations.items(), key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0]))
+    iterations.items(),
+    key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0])),
   ):
     md.append(f"## Iteration {iter_key}")
 

--- a/MaxKernel/auto_search/utils/analyze_tokens.py
+++ b/MaxKernel/auto_search/utils/analyze_tokens.py
@@ -8,20 +8,16 @@ logger = logging.getLogger(__name__)
 
 
 def generate_padded_table(headers, rows):
-  # Calculate max widths
   widths = [len(h) for h in headers]
   for row in rows:
     for i, col in enumerate(row):
       widths[i] = max(widths[i], len(str(col)))
 
-  # Format header
   header_str = (
     "| " + " | ".join(f"{h:<{w}}" for h, w in zip(headers, widths)) + " |"
   )
-  # Format separator
   sep_str = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
 
-  # Format rows
   row_strs = []
   for row in rows:
     row_str = (
@@ -52,7 +48,6 @@ def analyze_path(target_path: str) -> str:
 
   all_markdown = []
 
-  # Global Aggregators
   global_agents = {}
   global_total_calls = 0
   total_nodes = 0
@@ -66,7 +61,6 @@ def analyze_path(target_path: str) -> str:
         )
         all_markdown.append(node_md)
 
-        # Accumulate macros
         total_nodes += 1
         global_total_calls += node_calls
         for ag_name, ag_data in node_agents.items():
@@ -75,6 +69,7 @@ def analyze_path(target_path: str) -> str:
               "calls": 0,
               "prompt_tokens": 0,
               "completion_tokens": 0,
+              "thought_tokens": 0,
               "total_tokens": 0,
             }
           global_agents[ag_name]["calls"] += ag_data.get("calls", 0)
@@ -84,6 +79,9 @@ def analyze_path(target_path: str) -> str:
           global_agents[ag_name]["completion_tokens"] += ag_data.get(
             "completion_tokens", 0
           )
+          global_agents[ag_name]["thought_tokens"] += ag_data.get(
+            "thought_tokens", 0
+          )
           global_agents[ag_name]["total_tokens"] += ag_data.get(
             "total_tokens", 0
           )
@@ -91,7 +89,6 @@ def analyze_path(target_path: str) -> str:
       except Exception as e:
         logger.error(f"Failed to process {file_path}: {e}")
 
-  # Build Macro Summary
   if total_nodes > 0:
     macro_md = [
       "============================================================",
@@ -106,6 +103,7 @@ def analyze_path(target_path: str) -> str:
       "LLM Calls",
       "Prompt Tokens",
       "Completion Tokens",
+      "Thought Tokens",
       "Total Tokens",
     ]
     rows = []
@@ -117,23 +115,28 @@ def analyze_path(target_path: str) -> str:
 
     grand_prompt = 0
     grand_comp = 0
+    grand_thought = 0
     grand_total = 0
 
     for agent_name, agent_data in sorted_global:
       p = agent_data["prompt_tokens"]
       c = agent_data["completion_tokens"]
+      tht = agent_data["thought_tokens"]
       t = agent_data["total_tokens"]
       calls = agent_data["calls"]
       grand_prompt += p
       grand_comp += c
+      grand_thought += tht
       grand_total += t
-      rows.append([agent_name, str(calls), f"{p:,}", f"{c:,}", f"{t:,}"])
+      rows.append(
+        [agent_name, str(calls), f"{p:,}", f"{c:,}", f"{tht:,}", f"{t:,}"]
+      )
 
     macro_md.append("### Global Agent Aggregate Tokens")
     macro_md.extend(generate_padded_table(headers, rows))
     macro_md.append("")
     macro_md.append(
-      f"*(Grand Total: {global_total_calls} LLM calls | {grand_prompt:,} prompt | {grand_comp:,} completion | {grand_total:,} total)*"
+      f"*(Grand Total: {global_total_calls} LLM calls | {grand_prompt:,} prompt | {grand_comp:,} completion | {grand_thought:,} thought | {grand_total:,} total)*"
     )
     macro_md.append(
       "============================================================"
@@ -171,17 +174,18 @@ def generate_node_markdown(
         "LLM Calls",
         "Prompt Tokens",
         "Completion Tokens",
+        "Thought Tokens",
         "Total Tokens",
       ]
       rows = []
 
-      # Sort agents by total tokens descending
       sorted_agents = sorted(
         agents.items(), key=lambda x: x[1].get("total_tokens", 0), reverse=True
       )
       for agent_name, agent_data in sorted_agents:
         prompt = agent_data.get("prompt_tokens", 0)
         completion = agent_data.get("completion_tokens", 0)
+        thought = agent_data.get("thought_tokens", 0)
         total = agent_data.get("total_tokens", 0)
         calls = agent_data.get("calls", 0)
         rows.append(
@@ -190,21 +194,23 @@ def generate_node_markdown(
             str(calls),
             f"{prompt:,}",
             f"{completion:,}",
+            f"{thought:,}",
             f"{total:,}",
           ]
         )
 
-        # Accumulate for node return
         if agent_name not in node_agents:
           node_agents[agent_name] = {
             "calls": 0,
             "prompt_tokens": 0,
             "completion_tokens": 0,
+            "thought_tokens": 0,
             "total_tokens": 0,
           }
         node_agents[agent_name]["calls"] += calls
         node_agents[agent_name]["prompt_tokens"] += prompt
         node_agents[agent_name]["completion_tokens"] += completion
+        node_agents[agent_name]["thought_tokens"] += thought
         node_agents[agent_name]["total_tokens"] += total
 
       md.extend(generate_padded_table(headers, rows))
@@ -224,8 +230,7 @@ def generate_node_markdown(
 def main():
   parser = argparse.ArgumentParser(description="Analyze ADK token metrics")
   parser.add_argument(
-    "target",
-    help="Path to token_metrics.json OR a root directory",
+    "target", help="Path to token_metrics.json OR a root directory"
   )
   parser.add_argument(
     "--write",
@@ -238,6 +243,9 @@ def main():
 
   if args.write:
     target_path = Path(args.target)
+    if not target_path.exists():
+      print(f"Error: Target path {args.target} does not exist.")
+      return
     out_dir = target_path.parent if target_path.is_file() else target_path
     out_file = out_dir / "token.md"
     with open(out_file, "w", encoding="utf-8") as f:

--- a/MaxKernel/auto_search/utils/analyze_tokens.py
+++ b/MaxKernel/auto_search/utils/analyze_tokens.py
@@ -158,7 +158,7 @@ def generate_node_markdown(
   node_total_calls = 0
 
   for iter_key, iter_data in sorted(
-    iterations.items(), key=lambda x: int(x[0]) if str(x[0]).isdigit() else x[0]
+    iterations.items(), key=lambda x: (0, int(x[0])) if str(x[0]).isdigit() else (1, str(x[0]))
   ):
     md.append(f"## Iteration {iter_key}")
 


### PR DESCRIPTION
## Description
This PR introduces token tracking into the ADK callback pipeline. It provides visibility into LLM context window size and generation scale, showing where agents are accumulating context overhead and allowing us to profile model speed bottlenecks accurately.

A follow-up analysis utility was expanded to aggregate token telemetry locally and globally, emitting visual tables directly to the console and to `token.md` files.

## Summary of Changes
* **`timing_callbacks.py`**: Injected hooks sequentially after LLM responses to extract `prompt_tokens` and `completion_tokens`, tracking metrics on a per-agent basis.
* **`pipeline_agent.py`**: Ensures the runtime properly extracts the token payload from the `callback_context.session.state` and saving it as `token_metrics.json` right next to the existing timing reports.
* **`utils/analyze_tokens.py`**: Digests `token_metrics.json` footprints inside nodes. Calculates maximum widths for visual rendering and summarizes cross-node arrays into a global Macro Token Summary.
* **`run_search.py`**: Automated token aggregation calls into the end-of-run lifecycle, printing metrics out so users don't have to manually execute the util script.

## Sample Output
```text
============================================================
      MACRO TOKEN SUMMARY (ACROSS ALL DISCOVERED NODES)     
============================================================
Total Nodes/Attempts Analyzed : 1

### Global Agent Aggregate Tokens
| Agent                  | LLM Calls | Prompt Tokens | Completion Tokens | Total Tokens |
|------------------------|-----------|---------------|-------------------|--------------|
| FixTestScriptAgent     | 10        | 66,227        | 1,266             | 67,493       |
| PrepareBaseKernelAgent | 11        | 15,910        | 534               | 16,444       |
| GenerateTestFileAgent  | 3         | 7,102         | 310               | 7,412        |
| ValidationSummaryAgent | 1         | 867           | 206               | 1,073        |

*(Grand Total: 25 LLM calls | 90,106 prompt | 2,316 completion | 92,422 total)*
============================================================
```